### PR TITLE
Range check improvement

### DIFF
--- a/examples/fibonacci-square/src/module.rs
+++ b/examples/fibonacci-square/src/module.rs
@@ -70,12 +70,24 @@ impl<F: PrimeField + AbstractField + Clone + Copy + Default + 'static> Module<F>
             trace[i].x_mod = F::from_canonical_u64(x_mod);
 
             // Check if x_mod is in the range
-            self.std_lib.range_check(F::from_canonical_u64(module - x_mod), range.0.clone(), range.1.clone());
+            self.std_lib.range_check(
+                F::from_canonical_u64(module - x_mod),
+                range.0.clone(),
+                range.1.clone(),
+                F::one(),
+                Some(true),
+            );
         }
 
         // Trivial range check for the remaining rows
         for _ in inputs.len()..num_rows {
-            self.std_lib.range_check(F::from_canonical_u64(module), range.0.clone(), range.1.clone());
+            self.std_lib.range_check(
+                F::from_canonical_u64(module),
+                range.0.clone(),
+                range.1.clone(),
+                F::one(),
+                Some(true),
+            );
         }
 
         let air_instance = AirInstance::new(MODULE_AIRGROUP_ID, MODULE_AIR_IDS[0], Some(0), buffer);

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -36,6 +36,10 @@ airtemplate U8Air(const int N = 2**8) {
         error(`The number of rows N should be 2**8 to use the predefined range U8, got N=${N} instead`);
     }
 
+    // save the airgroup id and air id of the table for latter use
+    proof.std.u8.airgroup_id = AIRGROUP_ID;
+    proof.std.u8.air_id = AIR_ID;
+
     col witness mul;
 
     @u8air{reference: mul};
@@ -49,6 +53,9 @@ airtemplate U16Air(const int N = 2**16) {
         error(`The number of rows N should be 2**16 to use the predefined range U16, got N=${N} instead`);
     }
 
+    proof.std.u16.airgroup_id = AIRGROUP_ID;
+    proof.std.u16.air_id = AIR_ID;
+
     col witness mul;
 
     @u16air{reference: mul};
@@ -57,17 +64,22 @@ airtemplate U16Air(const int N = 2**16) {
     lookup_proves(OPIDS[1], [U16], mul, PIOP_NAME_RANGE_CHECK);
 }
 
-airtemplate SpecifiedRanges(const int N, const int opids[], const int opids_count, const int mins[], const int maxs[]) {
+airtemplate SpecifiedRanges(const int N, const int opids[], const int opids_count, const int predefineds[], const int mins[], const int maxs[]) {
+    proof.std.specified.airgroup_id = AIRGROUP_ID;
+    proof.std.specified.air_id = AIR_ID;
+
     @specified_ranges{num_rows: N};
 
     col witness mul[opids_count];
 
     for (int j = 0; j < opids_count; j++) {
         int opid = opids[j];
+        int predefined = predefineds[j];
         int min = mins[j];
         int max = maxs[j];
 
-        @specified_ranges{reference: mul[j], min: min, max: max, min_neg: min < 0, max_neg: max < 0};
+        // @range_def{predefined: predefined, min: min, max: max, min_neg: min < 0, max_neg: max < 0};
+        @specified_ranges{reference: mul[j], predefined: predefined, min: min, max: max, min_neg: min < 0, max_neg: max < 0};
 
         if (N < max - min + 1) {
             error(`The range [min,max]=[${min},${max}] is too big, the maximum range length is ${N}`);
@@ -103,12 +115,14 @@ function multi_range_check(expr sel = 1, expr range_sel = 1, expr colu, int min1
     @range_def{predefined: 0, min: min1, max: max1, min_neg: min1 < 0 , max_neg: max1 < 0};
     @range_def{predefined: 0, min: min2, max: max2, min_neg: min2 < 0 , max_neg: max2 < 0};
 
-    const int opid1 = opid_process(min1, max1);
-    const int opid2 = opid_process(min2, max2);
+    const int opid1 = opid_process(0, min1, max1);
+    const int opid2 = opid_process(0, min2, max2);
 
     lookup_assumes_dynamic([opid1,opid2], range_sel*(opid1-opid2) + opid2, [colu], sel, PIOP_NAME_RANGE_CHECK);
 
     on final airgroup declareRangeAir();
+
+    on final proof createSpecifiedMetadata();
 
     // Note: This solution improves the naive solution:
     //   · range_check(0, sel*range_sel, colu, min1, max1).
@@ -223,12 +237,26 @@ function range_check(int predefined = 1, expr sel = 1, expr colu, int min, int m
 
         on final airgroup declarePreRangeAir();
     } else {
-        const int opid = opid_process(min, max);
+        const int opid = opid_process(predefined, min, max);
 
         lookup_assumes(opid, [colu], sel, PIOP_NAME_RANGE_CHECK);
 
         on final airgroup declareRangeAir();
     }
+
+    on final proof createMetadata();
+}
+
+function createMetadata() {
+    @u8air{airgroup_id: proof.std.u8.airgroup_id, air_id: proof.std.u8.air_id};
+    @u16air{airgroup_id: proof.std.u16.airgroup_id, air_id: proof.std.u16.air_id};
+
+    // This final proof is needed to avoid create specified metadata multiple times
+    on final proof createSpecifiedMetadata();
+}
+
+function createSpecifiedMetadata() {
+    @specified_ranges{airgroup_id: proof.std.specified.airgroup_id, air_id: proof.std.specified.air_id};
 }
 
 private function range_validator(const int min, const int max) {
@@ -254,7 +282,7 @@ private function range_validator(const int min, const int max) {
     }
 }
 
-private function opid_process(const int min, const int max): int {
+private function opid_process(const int predefined, const int min, const int max): int {
     container proof.std.rc alias rcprove {
         int max_airgroup_id = 0;
         int opids_count = 0;
@@ -262,6 +290,7 @@ private function opid_process(const int min, const int max): int {
 
         // FIX: dynamic arrays not ready
         int opids[100];
+        int predefineds[100];
         int mins[100];
         int maxs[100];
     }
@@ -280,6 +309,7 @@ private function opid_process(const int min, const int max): int {
 
     // Otherwise, we get a new opid
     opid = get_opid(min, max);
+    rcprove.predefineds[rcprove.opids_count] = predefined;
     rcprove.mins[rcprove.opids_count] = min;
     rcprove.maxs[rcprove.opids_count] = max;
     rcprove.opids[rcprove.opids_count] = opid;
@@ -297,12 +327,23 @@ private function declarePreRangeAir() {
     }
 
     if (u8_used) {
+        // container used to store the airgroup id and air id of the table
+        container proof.std.u8 {
+            int airgroup_id = 0;
+            int air_id = 0;
+        }
+
         airgroup U8Air {
             U8Air();
         }
     }
 
     if (u16_used) {
+        container proof.std.u16 {
+            int airgroup_id = 0;
+            int air_id = 0;
+        }
+
         airgroup U16Air {
             U16Air();
         }
@@ -310,6 +351,11 @@ private function declarePreRangeAir() {
 }
 
 private function declareRangeAir() {
+    container proof.std.specified {
+        int airgroup_id = 0;
+        int air_id = 0;
+    }
+
     use proof.std.rc;
 
     if (AIRGROUP_ID != max_airgroup_id) {
@@ -318,11 +364,7 @@ private function declareRangeAir() {
 
     const int next_pow2 = 2**(log2(max_diff));
 
-    _SpecifiedRanges(next_pow2,opids,opids_count,mins,maxs);
-}
-
-function _SpecifiedRanges(int a,int b[],int c,int d[],int e[]) {
     airgroup SpecifiedRanges {
-        SpecifiedRanges(a,b,c,d,e);
+        SpecifiedRanges(next_pow2, opids, opids_count, predefineds, mins, maxs);
     }
 }

--- a/pil2-components/lib/std/rs/src/range_check/range.rs
+++ b/pil2-components/lib/std/rs/src/range_check/range.rs
@@ -1,12 +1,12 @@
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 use num_bigint::{BigInt, ToBigInt};
 use p3_field::PrimeField;
 
-#[derive(Clone, Copy, Hash, Eq, PartialEq)]
-pub struct Range<F: PrimeField>(pub F, pub F, pub bool, pub bool); // (min, max, min_neg, max_neg)
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
+pub struct Range<F: PrimeField>(pub F, pub F, pub bool, pub bool, pub bool); // (min, max, min_neg, max_neg, predefined)
 
-impl<F: PrimeField> Debug for Range<F> {
+impl<F: PrimeField> Display for Range<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let order = F::order().to_bigint().unwrap();
         let min = self.0.as_canonical_biguint().to_bigint().unwrap();
@@ -19,8 +19,8 @@ impl<F: PrimeField> Debug for Range<F> {
     }
 }
 
-impl<F: PrimeField> PartialEq<(BigInt, BigInt)> for Range<F> {
-    fn eq(&self, other: &(BigInt, BigInt)) -> bool {
+impl<F: PrimeField> PartialEq<(bool, BigInt, BigInt)> for Range<F> {
+    fn eq(&self, other: &(bool, BigInt, BigInt)) -> bool {
         let order = F::order().to_bigint().unwrap();
 
         let min = self.0.as_canonical_biguint().to_bigint().unwrap();
@@ -29,7 +29,7 @@ impl<F: PrimeField> PartialEq<(BigInt, BigInt)> for Range<F> {
         let min_result = if self.2 { min.clone() - &order } else { min.clone() };
         let max_result = if self.3 { max.clone() - &order } else { max.clone() };
 
-        min_result == other.0 && max_result == other.1
+        self.4 == other.0 && min_result == other.1 && max_result == other.2
     }
 }
 

--- a/pil2-components/lib/std/rs/src/range_check/u16air.rs
+++ b/pil2-components/lib/std/rs/src/range_check/u16air.rs
@@ -24,8 +24,8 @@ pub struct U16Air<F: Copy + Display> {
     airgroup_id: usize,
     air_id: usize,
     // Inputs
-    inputs: Mutex<Vec<F>>, // value -> multiplicity
-    mul: Mutex<HintFieldValue<F>>,
+    inputs: Mutex<Vec<(F, F)>>, // value -> multiplicity
+    mul_column: Mutex<HintFieldValue<F>>,
 }
 
 impl<F: PrimeField> U16Air<F> {
@@ -38,7 +38,7 @@ impl<F: PrimeField> U16Air<F> {
             airgroup_id,
             air_id,
             inputs: Mutex::new(Vec::new()),
-            mul: Mutex::new(HintFieldValue::Field(F::zero())),
+            mul_column: Mutex::new(HintFieldValue::Field(F::zero())),
         });
 
         wcm.register_component(u16air.clone(), Some(airgroup_id), Some(&[air_id]));
@@ -46,9 +46,9 @@ impl<F: PrimeField> U16Air<F> {
         u16air
     }
 
-    pub fn update_inputs(&self, value: F) {
+    pub fn update_inputs(&self, value: F, multiplicity: F) {
         let mut inputs = self.inputs.lock().unwrap();
-        inputs.push(value);
+        inputs.push((value, multiplicity));
 
         while inputs.len() >= PROVE_CHUNK_SIZE {
             let num_drained = std::cmp::min(PROVE_CHUNK_SIZE, inputs.len());
@@ -72,21 +72,21 @@ impl<F: PrimeField> U16Air<F> {
         let mut air_instance_rw = air_instance_repo.air_instances.write().unwrap();
         let air_instance = &mut air_instance_rw[air_instance_id];
 
-        let mul = &*self.mul.lock().unwrap();
-        set_hint_field(self.wcm.get_sctx(), air_instance, self.hint.load(Ordering::Acquire), "reference", mul);
+        let mul_column = &*self.mul_column.lock().unwrap();
+        set_hint_field(self.wcm.get_sctx(), air_instance, self.hint.load(Ordering::Acquire), "reference", mul_column);
 
         log::trace!("{}: ··· Drained inputs for AIR '{}'", Self::MY_NAME, "U16Air");
     }
 
-    fn update_multiplicity(&self, drained_inputs: Vec<F>) {
+    fn update_multiplicity(&self, drained_inputs: Vec<(F, F)>) {
         // TODO! Do it in parallel
-        for input in &drained_inputs {
+        for (input, mul) in &drained_inputs {
             let value = input.as_canonical_biguint().to_usize().expect("Cannot convert to usize");
             // Note: to avoid non-expected panics, we perform a reduction to the value
             //       In debug mode, this is, in fact, checked before
             let index = value % NUM_ROWS;
-            let mut mul = self.mul.lock().unwrap();
-            mul.add(index, F::one());
+            let mut mul_column = self.mul_column.lock().unwrap();
+            mul_column.add(index, *mul);
         }
     }
 }
@@ -120,7 +120,27 @@ impl<F: PrimeField> WitnessComponent<F> for U16Air<F> {
         // Add a new air instance. Since U16Air is a table, only this air instance is needed
         let mut air_instance = AirInstance::new(self.airgroup_id, self.air_id, None, buffer);
 
-        *self.mul.lock().unwrap() = get_hint_field::<F>(
+        // let airgroup_id = get_hint_field::<F>(
+        //     &sctx,
+        //     &pctx.public_inputs,
+        //     &pctx.challenges,
+        //     &mut air_instance,
+        //     self.hint.load(Ordering::Acquire) as usize,
+        //     "airgroup_id",
+        //     HintFieldOptions::dest(),
+        // );
+
+        // let air_id = get_hint_field::<F>(
+        //     &sctx,
+        //     &pctx.public_inputs,
+        //     &pctx.challenges,
+        //     &mut air_instance,
+        //     self.hint.load(Ordering::Acquire) as usize,
+        //     "air_id",
+        //     HintFieldOptions::dest(),
+        // );
+
+        *self.mul_column.lock().unwrap() = get_hint_field::<F>(
             self.wcm.get_sctx(),
             &pctx.public_inputs,
             &pctx.challenges,

--- a/pil2-components/lib/std/rs/src/std.rs
+++ b/pil2-components/lib/std/rs/src/std.rs
@@ -47,7 +47,7 @@ impl<F: PrimeField> Std<F> {
     }
 
     /// Processes the inputs for the range check.
-    pub fn range_check(&self, val: F, min: BigInt, max: BigInt) {
-        self.range_check.assign_values(val, min, max);
+    pub fn range_check(&self, val: F, min: BigInt, max: BigInt, multiplicity: F, predefined: Option<bool>) {
+        self.range_check.assign_values(val, min, max, multiplicity, predefined);
     }
 }

--- a/pil2-components/test/std/range_check/rs/src/multi_range_check1.rs
+++ b/pil2-components/test/std/range_check/rs/src/multi_range_check1.rs
@@ -107,11 +107,23 @@ where
                     if range_selector1 {
                         trace[i].a[0] = F::from_canonical_u16(rng.gen_range(0..=(1 << 7) - 1));
 
-                        self.std_lib.range_check(trace[i].a[0], range1.0.clone(), range1.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[0],
+                            range1.0.clone(),
+                            range1.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     } else {
                         trace[i].a[0] = F::from_canonical_u16(rng.gen_range(0..=(1 << 8) - 1));
 
-                        self.std_lib.range_check(trace[i].a[0], range2.0.clone(), range2.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[0],
+                            range2.0.clone(),
+                            range2.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     }
                 }
 
@@ -119,11 +131,23 @@ where
                     if range_selector2 {
                         trace[i].a[1] = F::from_canonical_u16(rng.gen_range(0..=(1 << 7) - 1));
 
-                        self.std_lib.range_check(trace[i].a[1], range1.0.clone(), range1.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[1],
+                            range1.0.clone(),
+                            range1.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     } else {
                         trace[i].a[1] = F::from_canonical_u16(rng.gen_range(0..=(1 << 6) - 1));
 
-                        self.std_lib.range_check(trace[i].a[1], range3.0.clone(), range3.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[1],
+                            range3.0.clone(),
+                            range3.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     }
                 }
 
@@ -131,11 +155,23 @@ where
                     if range_selector3 {
                         trace[i].a[2] = F::from_canonical_u16(rng.gen_range((1 << 5)..=(1 << 8) - 1));
 
-                        self.std_lib.range_check(trace[i].a[2], range4.0.clone(), range4.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[2],
+                            range4.0.clone(),
+                            range4.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     } else {
                         trace[i].a[2] = F::from_canonical_u16(rng.gen_range((1 << 8)..=(1 << 9) - 1));
 
-                        self.std_lib.range_check(trace[i].a[2], range5.0.clone(), range5.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[2],
+                            range5.0.clone(),
+                            range5.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     }
                 }
             }

--- a/pil2-components/test/std/range_check/rs/src/multi_range_check2.rs
+++ b/pil2-components/test/std/range_check/rs/src/multi_range_check2.rs
@@ -101,11 +101,23 @@ where
                     if range_selector1 {
                         trace[i].a[0] = F::from_canonical_u16(rng.gen_range((1 << 5)..=(1 << 8) - 1));
 
-                        self.std_lib.range_check(trace[i].a[0], range1.0.clone(), range1.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[0],
+                            range1.0.clone(),
+                            range1.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     } else {
                         trace[i].a[0] = F::from_canonical_u16(rng.gen_range((1 << 8)..=(1 << 9) - 1));
 
-                        self.std_lib.range_check(trace[i].a[0], range2.0.clone(), range2.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[0],
+                            range2.0.clone(),
+                            range2.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     }
                 }
 
@@ -113,11 +125,23 @@ where
                     if range_selector2 {
                         trace[i].a[1] = F::from_canonical_u16(rng.gen_range(0..=(1 << 7) - 1));
 
-                        self.std_lib.range_check(trace[i].a[1], range3.0.clone(), range3.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[1],
+                            range3.0.clone(),
+                            range3.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     } else {
                         trace[i].a[1] = F::from_canonical_u16(rng.gen_range(0..=(1 << 4) - 1));
 
-                        self.std_lib.range_check(trace[i].a[1], range4.0.clone(), range4.1.clone());
+                        self.std_lib.range_check(
+                            trace[i].a[1],
+                            range4.0.clone(),
+                            range4.1.clone(),
+                            F::one(),
+                            Some(false),
+                        );
                     }
                 }
             }

--- a/pil2-components/test/std/range_check/rs/src/range_check1.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check1.rs
@@ -94,22 +94,22 @@ where
                     trace[i].a1 = F::from_canonical_u16(rng.gen_range(0..=(1 << 8) - 1));
                     trace[i].a3 = F::from_canonical_u32(rng.gen_range(60..=(1 << 16) - 1));
 
-                    self.std_lib.range_check(trace[i].a1, range1.0.clone(), range1.1.clone());
-                    self.std_lib.range_check(trace[i].a3, range3.0.clone(), range3.1.clone());
+                    self.std_lib.range_check(trace[i].a1, range1.0.clone(), range1.1.clone(), F::one(), Some(false));
+                    self.std_lib.range_check(trace[i].a3, range3.0.clone(), range3.1.clone(), F::one(), Some(false));
                 }
 
                 if selected2 {
                     trace[i].a2 = F::from_canonical_u8(rng.gen_range(0..=(1 << 4) - 1));
                     trace[i].a4 = F::from_canonical_u16(rng.gen_range(8228..=17400));
 
-                    self.std_lib.range_check(trace[i].a2, range2.0.clone(), range2.1.clone());
-                    self.std_lib.range_check(trace[i].a4, range4.0.clone(), range4.1.clone());
+                    self.std_lib.range_check(trace[i].a2, range2.0.clone(), range2.1.clone(), F::one(), Some(false));
+                    self.std_lib.range_check(trace[i].a4, range4.0.clone(), range4.1.clone(), F::one(), Some(false));
                 }
 
                 if selected3 {
                     trace[i].a5 = F::from_canonical_u16(rng.gen_range(0..=(1 << 8) - 1));
 
-                    self.std_lib.range_check(trace[i].a5, range1.0.clone(), range1.1.clone());
+                    self.std_lib.range_check(trace[i].a5, range1.0.clone(), range1.1.clone(), F::one(), Some(false));
                 }
             }
 

--- a/pil2-components/test/std/range_check/rs/src/range_check2.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check2.rs
@@ -84,9 +84,9 @@ where
                 trace[i].b2 = F::from_canonical_u16(rng.gen_range(0..=(1 << 9) - 1));
                 trace[i].b3 = F::from_canonical_u16(rng.gen_range(0..=(1 << 10) - 1));
 
-                self.std_lib.range_check(trace[i].b1, range1.0.clone(), range1.1.clone());
-                self.std_lib.range_check(trace[i].b2, range2.0.clone(), range2.1.clone());
-                self.std_lib.range_check(trace[i].b3, range3.0.clone(), range3.1.clone());
+                self.std_lib.range_check(trace[i].b1, range1.0.clone(), range1.1.clone(), F::one(), Some(false));
+                self.std_lib.range_check(trace[i].b2, range2.0.clone(), range2.1.clone(), F::one(), Some(false));
+                self.std_lib.range_check(trace[i].b3, range3.0.clone(), range3.1.clone(), F::one(), Some(false));
             }
 
             let air_instances_vec = &mut pctx.air_instance_repo.air_instances.write().unwrap();

--- a/pil2-components/test/std/range_check/rs/src/range_check3.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check3.rs
@@ -82,8 +82,8 @@ where
                 trace[i].c1 = F::from_canonical_u16(rng.gen_range(0..=(1 << 4) - 1));
                 trace[i].c2 = F::from_canonical_u16(rng.gen_range(0..=(1 << 8) - 1));
 
-                self.std_lib.range_check(trace[i].c1, range1.0.clone(), range1.1.clone());
-                self.std_lib.range_check(trace[i].c2, range2.0.clone(), range2.1.clone());
+                self.std_lib.range_check(trace[i].c1, range1.0.clone(), range1.1.clone(), F::one(), Some(false));
+                self.std_lib.range_check(trace[i].c2, range2.0.clone(), range2.1.clone(), F::one(), Some(false));
             }
 
             let air_instances_vec = &mut pctx.air_instance_repo.air_instances.write().unwrap();

--- a/pil2-components/test/std/range_check/rs/src/range_check4.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check4.rs
@@ -87,11 +87,11 @@ where
             let range9 = (BigInt::from(-(1 << 8) + 1), BigInt::from(-127));
 
             for i in 0..num_rows {
-                let selected1 = true; //rng.gen_bool(0.5);
+                let selected1 = rng.gen_bool(0.5);
                 trace[i].sel1 = F::from_bool(selected1);
 
                 // selected1 and selected2 have to be disjoint for the range check to pass
-                let selected2 = false; //if selected1 { false } else { rng.gen_bool(0.5) };
+                let selected2 = if selected1 { false } else { rng.gen_bool(0.5) };
                 trace[i].sel2 = F::from_bool(selected2);
 
                 if selected1 {
@@ -103,20 +103,20 @@ where
                     }
                     trace[i].a6 = F::from_canonical_u64(a6_val as u64);
 
-                    self.std_lib.range_check(trace[i].a1, range1.0.clone(), range1.1.clone());
-                    self.std_lib.range_check(trace[i].a5, range6.0.clone(), range6.1.clone());
-                    self.std_lib.range_check(trace[i].a6, range7.0.clone(), range7.1.clone());
+                    self.std_lib.range_check(trace[i].a1, range1.0.clone(), range1.1.clone(), F::one(), Some(true));
+                    self.std_lib.range_check(trace[i].a5, range6.0.clone(), range6.1.clone(), F::one(), Some(true));
+                    self.std_lib.range_check(trace[i].a6, range7.0.clone(), range7.1.clone(), F::one(), Some(true));
                 }
                 if selected2 {
-                    trace[i].a1 = F::from_canonical_u8(rng.gen_range(0..=(1 << 8) - 1));
+                    trace[i].a1 = F::from_canonical_u16(rng.gen_range(0..=(1 << 8) - 1));
                     trace[i].a2 = F::from_canonical_u8(rng.gen_range(50..=(1 << 7) - 1));
                     trace[i].a3 = F::from_canonical_u16(rng.gen_range(127..=(1 << 8)));
                     trace[i].a4 = F::from_canonical_u32(rng.gen_range(1..=(1 << 16) + 1));
 
-                    self.std_lib.range_check(trace[i].a1, range2.0.clone(), range2.1.clone());
-                    self.std_lib.range_check(trace[i].a2, range3.0.clone(), range3.1.clone());
-                    self.std_lib.range_check(trace[i].a3, range4.0.clone(), range4.1.clone());
-                    self.std_lib.range_check(trace[i].a4, range5.0.clone(), range5.1.clone());
+                    self.std_lib.range_check(trace[i].a1, range2.0.clone(), range2.1.clone(), F::one(), Some(true));
+                    self.std_lib.range_check(trace[i].a2, range3.0.clone(), range3.1.clone(), F::one(), Some(true));
+                    self.std_lib.range_check(trace[i].a3, range4.0.clone(), range4.1.clone(), F::one(), Some(true));
+                    self.std_lib.range_check(trace[i].a4, range5.0.clone(), range5.1.clone(), F::one(), Some(true));
                 }
 
                 let mut a7_val: i128 = rng.gen_range(-(2i128.pow(7)) + 1..=-50);
@@ -124,14 +124,14 @@ where
                     a7_val += F::order().to_i128().unwrap();
                 }
                 trace[i].a7 = F::from_canonical_u64(a7_val as u64);
-                self.std_lib.range_check(trace[i].a7, range8.0.clone(), range8.1.clone());
+                self.std_lib.range_check(trace[i].a7, range8.0.clone(), range8.1.clone(), F::one(), Some(true));
 
                 let mut a8_val: i128 = rng.gen_range(-(2i128.pow(8)) + 1..=-127);
                 if a8_val < 0 {
                     a8_val += F::order().to_i128().unwrap();
                 }
                 trace[i].a8 = F::from_canonical_u64(a8_val as u64);
-                self.std_lib.range_check(trace[i].a8, range9.0.clone(), range9.1.clone());
+                self.std_lib.range_check(trace[i].a8, range9.0.clone(), range9.1.clone(), F::one(), Some(true));
             }
 
             let air_instances_vec = &mut pctx.air_instance_repo.air_instances.write().unwrap();


### PR DESCRIPTION
This PR adds the following improvements to the range check API:
- [x] The `range_check` functions on the std now has the following signature:
  ```rust
  fn range_check(&self, val: F, min: BigInt, max: BigInt, multiplicity: F, predefined: Option<bool>) {}
  ```
  where `multiplicity` indicates the number of times that `val` appears in the trace, allowing a single call to the `range_check` function once during the witness computation. The `predefined` flag has also been added to let the user differenciate predefined vs non-predefined ranges (e.g., the range $[0,2^8-1]$ will behave differently depending on the `predefined` flag).
  - [ ] We should find a way to avoid passing the `predefined` flag from the user.
  - [ ] Multi-ranges checks suffer from this limitations, since they predeterminated value of `predefined` does not coincide with the one set in the std. Should we have a different API for multi-range checks?
- [ ] Range check data `RCAirData` is not needed anymore in the witness library, it is now obtained by the std from PIL hints.