### PR TITLE
STD Improvements

### DIFF
--- a/pil2-components/lib/std/pil/std_common.pil
+++ b/pil2-components/lib/std/pil/std_common.pil
@@ -9,6 +9,10 @@ const int DEFAULT_DIRECT_BUS_TYPE = PIOP_BUS_SUM;
 // We allow any expression as inputs to this function, but if some of it is not a global element
 // the PIL will throw an error
 function direct_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, int bus_type = PIOP_BUS_DEFAULT, int name = PIOP_NAME_DEFAULT) {
+    if (AIRGROUP_ID == -1) {
+        error("A direct update has to be performed inside an airgroup");
+    }
+
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_DIRECT_NAME;
 
     if (bus_type == PIOP_BUS_DEFAULT) bus_type = DEFAULT_DIRECT_BUS_TYPE;

--- a/pil2-components/lib/std/pil/std_lookup.pil
+++ b/pil2-components/lib/std/pil/std_lookup.pil
@@ -15,6 +15,13 @@ function lookup_proves(const int opid, const expr cols[], const expr mul = 1, in
     sum_proves(name, opid, cols, mul);
 }
 
+// Lookup with freedom in whether to assume or prove based on the provided selector
+function lookup(const int opid, const expr cols[], const expr sel = 1, int name = PIOP_NAME_DEFAULT) {
+    if (name == PIOP_NAME_DEFAULT) name = DEFAULT_LOOKUP_NAME;
+
+    sum_proves(name, opid, cols, mul);
+}
+
 function lookup_assumes_dynamic(const int opid[], const expr sumid, const expr cols[], const expr sel = 1, int name = PIOP_NAME_DEFAULT) {
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_LOOKUP_NAME;
 

--- a/pil2-components/lib/std/pil/std_permutation.pil
+++ b/pil2-components/lib/std/pil/std_permutation.pil
@@ -45,7 +45,7 @@ function permutation(const int opid, const expr cols[], const expr sel = 1, int 
 
     switch (bus_type) {
         case PIOP_BUS_SUM:
-            sum_proves(name, opid, cols, sel);
+            sum(name, opid, cols, sel);
         case PIOP_BUS_PROD:
             error("Free permutation with product bus is not supported");
         default:

--- a/pil2-components/lib/std/pil/std_permutation.pil
+++ b/pil2-components/lib/std/pil/std_permutation.pil
@@ -36,3 +36,19 @@ function permutation_proves(const int opid, const expr cols[], const expr sel = 
             error(`Unknown bus type: ${bus_type}`);
     }
 }
+
+// Permutation with freedom in whether to assume or prove based on the provided selector
+function permutation(const int opid, const expr cols[], const expr sel = 1, int bus_type = PIOP_BUS_DEFAULT, int name = PIOP_NAME_DEFAULT) {
+    if (name == PIOP_NAME_DEFAULT) name = DEFAULT_PERMUTATION_NAME;
+
+    if (bus_type == PIOP_BUS_DEFAULT) bus_type = DEFAULT_PERMUTATION_BUS_TYPE;
+
+    switch (bus_type) {
+        case PIOP_BUS_SUM:
+            sum_proves(name, opid, cols, sel);
+        case PIOP_BUS_PROD:
+            error("Free permutation with product bus is not supported");
+        default:
+            error(`Unknown bus type: ${bus_type}`);
+    }
+}

--- a/pil2-components/lib/std/pil/std_permutation.pil
+++ b/pil2-components/lib/std/pil/std_permutation.pil
@@ -5,7 +5,7 @@ require "std_prod.pil";
 const int DEFAULT_PERMUTATION_NAME = PIOP_NAME_PERMUTATION;
 
 // Note: This constant allows you to choose whether the permutation is proven via the sum or product bus
-int DEFAULT_PERMUTATION_BUS_TYPE = PIOP_BUS_PROD;
+int DEFAULT_PERMUTATION_BUS_TYPE = PIOP_BUS_SUM;
 
 function permutation_assumes(const int opid, const expr cols[], const expr sel = 1, int bus_type = PIOP_BUS_DEFAULT, int name = PIOP_NAME_DEFAULT) {
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_PERMUTATION_NAME;

--- a/pil2-components/lib/std/pil/std_prod.pil
+++ b/pil2-components/lib/std/pil/std_prod.pil
@@ -72,7 +72,7 @@ private function initial_checks_prod(int proves, int opid, expr cols[], int is_d
     }
 
     // The same opid is shared among multiple instances of the same air, so we must keep track of the number of
-    // proves and assumes to verify at the end that all of them match (except for the is_direct case)
+    // proves and assumes to verify at the end that all of them match
     const string name_str = proves ? "proves" : "assumes";
     proof.std.gprod.`id${opid}`.`${name_str}`++;
 }

--- a/pil2-components/lib/std/pil/std_prod.pil
+++ b/pil2-components/lib/std/pil/std_prod.pil
@@ -10,7 +10,7 @@ function prod_proves(const int name, const int opid, const expr cols[], const ex
     update_piop_prod(name, 1, opid, sel, cols, is_direct);
 }
 
-private function init_containers_prod(int name, int opid) {
+private function init_proof_containers_prod(int name, int opid) {
     container proof.std.gprod {
         // Used for final checks
         int opids_count = 0;
@@ -31,6 +31,16 @@ private function init_containers_prod(int name, int opid) {
         expr direct_gprod_proves[100];
     }
 
+    // Container used for final checks
+    container proof.std.gprod.`id${opid}` {
+        int name = name;
+        int cols;
+        int proves = 0;
+        int assumes = 0;
+    }
+}
+
+private function init_containers_prod(int name, int opid) {
     container airgroup.std.gprod {
         airgroupval aggregate(prod) gprod_result;
     }
@@ -43,14 +53,6 @@ private function init_containers_prod(int name, int opid) {
         int gprod_proves_count = 0;
         expr gprod_proves_sel[100];
         expr gprod_proves[100];
-    }
-
-    // Container used for final checks
-    container proof.std.gprod.`id${opid}` {
-        int name = name;
-        int cols;
-        int proves = 0;
-        int assumes = 0;
     }
 }
 
@@ -72,12 +74,7 @@ private function initial_checks_prod(int proves, int opid, expr cols[], int is_d
     // The same opid is shared among multiple instances of the same air, so we must keep track of the number of
     // proves and assumes to verify at the end that all of them match (except for the is_direct case)
     const string name_str = proves ? "proves" : "assumes";
-    const string other_name_str = proves ? "assumes" : "proves";
-    if (!is_direct) {
-        proof.std.gprod.`id${opid}`.`${name_str}`++;
-    } else {
-        proof.std.gprod.`id${opid}`.`${name_str}` = proof.std.gprod.`id${opid}`.`${other_name_str}`;
-    }
+    proof.std.gprod.`id${opid}`.`${name_str}`++;
 }
 
 /**
@@ -98,11 +95,11 @@ private function update_piop_prod(int name, int proves, int opid, expr sel, expr
         error(`The number of columns of ${side} #${opid} must be at least 1`);
     }
 
-    init_containers_prod(name, opid);
-
-    initial_checks_prod(proves, opid, cols, is_direct);
+    init_proof_containers_prod(name, opid);
 
     if (!is_direct) {
+        init_containers_prod(name, opid);
+
         // Create debug hints for the witness computation
         const int ncols = length(cols);
         string name_cols[ncols];
@@ -111,6 +108,8 @@ private function update_piop_prod(int name, int proves, int opid, expr sel, expr
         }
         @gprod_member_data{name_piop: get_piop_name(name), names: name_cols, opid: opid, proves: proves, selector: sel, references: cols};
     }
+
+    initial_checks_prod(proves, opid, cols, is_direct);
 
     init_challenges();
 

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -5,6 +5,8 @@ require "std_lookup.pil";
 // Moreover, having a fewer ranges makes the preprocessing faster and the prvoing less memory consuming
 
 const int MAX_RANGE_LEN = (PRIME - 1) / 2;
+const int BYTE = 2**8-1;
+const int TWOBYTES = 2**16-1;
 
 const int OPIDS[2] = [100, 101];
 int last_assigned_opid = OPIDS[length(OPIDS) - 1];
@@ -14,25 +16,17 @@ private function next_available_opid(): int {
     return last_assigned_opid;
 }
 
-private function get_opid(int min, int max, int predefined): int {
-    if (predefined) {
-        if (min >= 0) {
-            return (max <= BYTE) ? OPIDS[0] :
-                   (max <= TWOBYTES) ? OPIDS[1] :
-                   next_available_opid();
+private function get_opid(const int min, const int max, const int predefined): int {
+    if (predefined && min >= 0) {
+        if (max <= BYTE) {
+            return OPIDS[0];
+        } else if (max <= TWOBYTES) {
+            return OPIDS[1];
         }
-    }
-    else if (min == 0) {
-        return (max == BYTE) ? OPIDS[0] :
-               (max == TWOBYTES) ? OPIDS[1] :
-               next_available_opid();
     }
 
     return next_available_opid();
 }
-
-const int BYTE = 2**8-1;
-const int TWOBYTES = 2**16-1;
 
 airtemplate U8Air(const int N = 2**8) {
     if (N != 2**8) {
@@ -122,15 +116,15 @@ function range_check(expr colu, int min, int max, expr sel = 1, int predefined =
         if (min == 0 && (max == BYTE || max == TWOBYTES)) {
             const int is_u8 = max == BYTE ? 1 : 0;
 
-            proof.std.rc.u8_used = proof.std.rc.u8_used || is_u8;
-            proof.std.rc.u16_used = proof.std.rc.u16_used || 1-is_u8;
+            airgroup.std.rc.u8_used = airgroup.std.rc.u8_used || is_u8;
+            airgroup.std.rc.u16_used = airgroup.std.rc.u16_used || 1-is_u8;
             lookup_assumes(opid, [colu], sel, PIOP_NAME_RANGE_CHECK);
         } else {
             // Here, we need to reuse to some of the default ranges depending
             // on the values of min and max
             if (max <= BYTE) {
                 // reuse U8
-                proof.std.rc.u8_used = 1;
+                airgroup.std.rc.u8_used = 1;
 
                 // first prove that colu - min is in U8
                 lookup_assumes(opid, [colu - min], sel, PIOP_NAME_RANGE_CHECK);
@@ -139,7 +133,7 @@ function range_check(expr colu, int min, int max, expr sel = 1, int predefined =
                 lookup_assumes(opid, [max - colu], sel, PIOP_NAME_RANGE_CHECK);
             } else if (max <= TWOBYTES) {
                 // reuse U16
-                proof.std.rc.u16_used = 1;
+                airgroup.std.rc.u16_used = 1;
 
                 // first prove that colu - min is in U16
                 lookup_assumes(opid, [colu - min], sel, PIOP_NAME_RANGE_CHECK);
@@ -199,7 +193,7 @@ function multi_range_check(expr colu, int min1, int max1, int min2, int max2, ex
     lookup_assumes_dynamic([opid1,opid2], range_sel*(opid1-opid2) + opid2, [colu], sel, PIOP_NAME_RANGE_CHECK);
 
     // Define the prove
-    define_proves(0);
+    define_proves(absorb: 0);
 
     // Note: This solution improves the naive solution:
     //   · range_check(colu, min1, max1, 0, sel*range_sel).
@@ -261,7 +255,7 @@ function range_check_dynamic(const expr colu, const expr range_sel, const expr s
     lookup_assumes_dynamic(opids, range_sel, [colu], sel, PIOP_NAME_RANGE_CHECK);
 
     // Define the prove
-    define_proves(0);
+    define_proves(absorb: 0);
 }
 
 // Private functions
@@ -297,18 +291,31 @@ private function range_validator(const int min, const int max) {
 
 private function opid_process(const int min, const int max, const int predefined): int {
     container proof.std.rc alias rcproof {
-        int max_pre_airgroup_id = 0;
-        int max_airgroup_id = 0;
-        int opids_count = 0;
-        int u8_used = 0;
-        int u16_used = 0;
+        // Number of times U8, U16 and specified ranges air are used
+        int num_u8_airgroup = 0;
+        int num_u16_airgroup = 0;
+        int num_spec_airgroup = 0;
+
+        // Last airgroup id that uses U8, U16 and specified ranges air
+        int max_u8_airgroup_id = 0;
+        int max_u16_airgroup_id = 0;
+        int max_spec_airgroup_id = 0;
+
+        // N to be used in the specified ranges air
         int specified_N = 0;
 
         // FIX: dynamic arrays not ready
+        int opids_count = 0;
         int opids[100];
         int predefineds[100];
         int mins[100];
         int maxs[100];
+    }
+
+    container airgroup.std.rc {
+        // To mark if the U8 and U16 airs are used within the airgroup
+        int u8_used = 0;
+        int u16_used = 0;
     }
 
     // If the range has already been introduced, we reuse the same opid
@@ -318,10 +325,15 @@ private function opid_process(const int min, const int max, const int predefined
         }
     }
 
-    // Otherwise, we get a new opid
+    // Otherwise, we get the corresponding opid
     const int opid = get_opid(min, max, predefined);
 
-    // Save range data for later use
+    // Exit if the range does not belong to the specified ranges air
+    if (opid <= OPIDS[1]) {
+        return opid;
+    }
+
+    // Save range data for later use in the specified ranges air
     rcproof.predefineds[rcproof.opids_count] = predefined;
     rcproof.mins[rcproof.opids_count] = min;
     rcproof.maxs[rcproof.opids_count] = max;
@@ -337,18 +349,29 @@ private function opid_process(const int min, const int max, const int predefined
 }
 
 private function define_proves(const int absorb) {
+    use proof.std.rc;
+
     if (absorb) {
-        // Update the max airgroup id
-        if (proof.std.rc.max_pre_airgroup_id < AIRGROUP_ID) {
-            proof.std.rc.max_pre_airgroup_id = AIRGROUP_ID;
+        // If the U8 was used, update the max airgroup id
+        if (airgroup.std.rc.u8_used) {
+            if (max_u8_airgroup_id < AIRGROUP_ID) {
+                max_u8_airgroup_id = AIRGROUP_ID;
+            }
+        }
+
+        // If the U16 was used, update the max airgroup id
+        if (airgroup.std.rc.u16_used) {
+            if (proof.std.rc.max_u16_airgroup_id < AIRGROUP_ID) {
+                proof.std.rc.max_u16_airgroup_id = AIRGROUP_ID;
+            }
         }
 
         on final airgroup declarePreRangeAir();
         on final proof createPreMetadata();
     } else {
-        // Update the max airgroup id
-        if (proof.std.rc.max_airgroup_id < AIRGROUP_ID) {
-            proof.std.rc.max_airgroup_id = AIRGROUP_ID;
+        // If the specified range is used, update the max airgroup id
+        if (max_spec_airgroup_id < AIRGROUP_ID) {
+            max_spec_airgroup_id = AIRGROUP_ID;
         }
 
         on final airgroup declareRangeAir();
@@ -359,33 +382,53 @@ private function define_proves(const int absorb) {
 private function declarePreRangeAir() {
     use proof.std.rc;
 
+    // If the U8 was used in the airgroup, update the number of U8 airgroups
+    if (airgroup.std.rc.u8_used) {
+        num_u8_airgroup++;
+    }
+
+    // If the U16 was used in the airgroup, update the number of U16 airgroups
+    if (airgroup.std.rc.u16_used) {
+        num_u16_airgroup++;
+    }
+
     // The U8 and U16 airs are only needed once, so we wait for the last airgroup that uses them
-    if (AIRGROUP_ID != max_pre_airgroup_id) {
+    if (AIRGROUP_ID != max_u8_airgroup_id && AIRGROUP_ID != max_u16_airgroup_id) {
         return;
     }
 
-    if (u8_used) {
+    if (AIRGROUP_ID == max_u8_airgroup_id && num_u8_airgroup > 0) {
         // container used to store the airgroup id and air id of the table
         container proof.std.u8 {
             int airgroup_id = 0;
             int air_id = 0;
         }
 
-        // TODO: The following airtemplate should be instantiated outside of the airgroup
-        airgroup U8Air {
+        if (num_u8_airgroup == 1){
+            // If the U8Air is needed only once, we instantiate it in the (single) callable airgroup
             U8Air();
+        } else {
+            // If the U8Air is needed more than once, we instantiate it in its own airgroup
+            airgroup U8Air {
+                U8Air();
+            }
         }
     }
 
-    if (u16_used) {
+    if (AIRGROUP_ID == max_u16_airgroup_id && num_u16_airgroup > 0) {
         container proof.std.u16 {
             int airgroup_id = 0;
             int air_id = 0;
         }
 
-        // TODO: The following airtemplate should be instantiated outside of the airgroup
-        airgroup U16Air {
+        if (num_u16_airgroup == 1){
+            // If the U16Air is needed only once, we instantiate it in the (single) callable airgroup
             U16Air();
+        } else {
+            // If the U16Air is needed more than once, we instantiate it in its own airgroup
+            airgroup U16Air {
+                U16Air();
+            }
         }
     }
 }
@@ -398,24 +441,33 @@ private function declareRangeAir() {
 
     use proof.std.rc;
 
+    // Update the number of specified ranges airgroups
+    num_spec_airgroup++;
+
     // The specified ranges air is only needed once, so we wait for the last airgroup that uses them
-    if (AIRGROUP_ID != max_airgroup_id) {
+    if (AIRGROUP_ID != max_spec_airgroup_id) {
         return;
     }
 
     const int next_pow2 = 2**(log2(specified_N));
 
-    airgroup SpecifiedRanges {
+    if (num_spec_airgroup == 1) {
+        // If the SpecifiedRanges is needed only once, we instantiate it in the (single) callable airgroup
         SpecifiedRanges(next_pow2, opids, opids_count, predefineds, mins, maxs);
+    } else {
+        // If the SpecifiedRanges is needed more than once, we instantiate it in its own airgroup
+        airgroup SpecifiedRanges {
+            SpecifiedRanges(next_pow2, opids, opids_count, predefineds, mins, maxs);
+        }
     }
 }
 
 private function createPreMetadata() {
-    if (proof.std.rc.u8_used) {
+    if (proof.std.rc.num_u8_airgroup > 0) {
         @u8air{airgroup_id: proof.std.u8.airgroup_id, air_id: proof.std.u8.air_id};
     }
 
-    if (proof.std.rc.u16_used) {
+    if (proof.std.rc.num_u16_airgroup > 0) {
         @u16air{airgroup_id: proof.std.u16.airgroup_id, air_id: proof.std.u16.air_id};
     }
 }

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -160,7 +160,12 @@ function range_check(expr colu, int min, int max, expr sel = 1, int predefined =
  * TODO: Add description
  */
 function range_check_group(const expr cols[], const int min, const int max, const expr sels[], const int predefined = 1) {
-    for (int i = 0; i < length(cols); i = i + 1) {
+    const int len = length(cols);
+    if (len != length(sels)) {
+        error(`The length of cols (${len}) and sels (${length(sels)}) should be the same`);
+    }
+
+    for (int i = 0; i < length(cols); i++) {
         range_check(cols[i], min, max, sels[i], predefined);
     }
 }
@@ -276,7 +281,7 @@ private function range_validator(const int min, const int max) {
         const int diff = max - min + 1;
 
         string diff_str = `(colu - ${min})`;
-        for (int i = 1; i < diff; i = i + 1) {
+        for (int i = 1; i < diff; i++) {
             diff_str = diff_str + `·(colu - ${min + i})`;
         }
 

--- a/pil2-components/lib/std/pil/std_sum.pil
+++ b/pil2-components/lib/std/pil/std_sum.pil
@@ -10,6 +10,10 @@ function sum_proves(const int name, const int opid, const expr cols[], const exp
     update_piop_sum(name, 1, [opid], opid, mul, cols, is_direct);
 }
 
+function sum(const int name, const int opid, const expr cols[], const expr mul = 1, const int is_direct = 0) {
+    update_piop_sum(name, 2, [opid], opid, mul, cols, is_direct);
+}
+
 function sum_assumes_dynamic(const int name, const int opid[], const expr sumid, const expr cols[], const expr sel = 1) {
     update_piop_sum(name, 0, opid, sumid, sel, cols);
 }
@@ -73,9 +77,15 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int is_
         }
 
         // The same opid is shared among multiple instances of the same air, so we must keep track of the number of
-        // proves and assumes to verify at the end that all of them match (except for the is_direct case)
-        const string name_str = proves ? "proves" : "assumes";
-        proof.std.gsum.`id${opid[i]}`.`${name_str}`++;
+        // proves and assumes to verify at the end that all of them match
+        if (proves == 2) {
+            // proves = 2 marks that the user is responsible for the use of proves and assumes
+            proof.std.gsum.`id${opid[i]}`.proves++;
+            proof.std.gsum.`id${opid[i]}`.assumes++;
+        } else {
+            const string name_str = proves ? "proves" : "assumes";
+            proof.std.gsum.`id${opid[i]}`.`${name_str}`++;
+        }
     }
 }
 

--- a/pil2-components/lib/std/pil/std_sum.pil
+++ b/pil2-components/lib/std/pil/std_sum.pil
@@ -14,7 +14,7 @@ function sum_assumes_dynamic(const int name, const int opid[], const expr sumid,
     update_piop_sum(name, 0, opid, sumid, sel, cols);
 }
 
-private function init_containers_sum(int name, int opid[]) {
+private function init_proof_containers_sum(int name, int opid[]) {
     container proof.std.gsum {
         // Used for final checks
         int opids_count = 0;
@@ -31,17 +31,6 @@ private function init_containers_sum(int name, int opid[]) {
         expr direct_gsum_e[100];
     }
 
-    container airgroup.std.gsum {
-        airgroupval aggregate(sum) gsum_result;
-    }
-
-    container air.std.gsum {
-        int gsum_nargs = 0;
-        expr gsum_s[100];
-        expr gsum_e[100];
-        int gsum_t[100]; // Used for optimization
-    }
-
     // Container used for final checks
     for (int i = 0; i < length(opid); i++) {
         container proof.std.gsum.`id${opid[i]}` {
@@ -53,11 +42,24 @@ private function init_containers_sum(int name, int opid[]) {
     }
 }
 
+private function init_containers_sum(int name, int opid[]) {
+    container airgroup.std.gsum {
+        airgroupval aggregate(sum) gsum_result;
+    }
+
+    container air.std.gsum {
+        int gsum_nargs = 0;
+        expr gsum_s[100];
+        expr gsum_e[100];
+        int gsum_t[100]; // Used for optimization
+    }
+}
+
 private function initial_checks_sum(int proves, int opid[], expr cols[], int is_direct) {
     const int cols_count = length(cols);
 
     for (int i = 0; i < length(opid); i++) {
-        // Assumes and proves of the same opid must have the same number of columns
+        // Assumes and proves of the same opid must have the same number of columns (except for the is_direct case)
         if (proof.std.gsum.`id${opid[i]}`.cols == 0) {
             // first time called
             proof.std.gsum.`id${opid[i]}`.cols = cols_count;
@@ -71,7 +73,7 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int is_
         }
 
         // The same opid is shared among multiple instances of the same air, so we must keep track of the number of
-        // proves and assumes to verify at the end that all of them match
+        // proves and assumes to verify at the end that all of them match (except for the is_direct case)
         const string name_str = proves ? "proves" : "assumes";
         proof.std.gsum.`id${opid[i]}`.`${name_str}`++;
     }
@@ -95,11 +97,11 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
         error(`The number of columns in ${side} of ${name} #${opid} must be at least 1`);
     }
 
-    init_containers_sum(name, opid);
-
-    initial_checks_sum(proves, opid, cols, is_direct);
+    init_proof_containers_sum(name, opid);
 
     if (!is_direct) {
+        init_containers_sum(name, opid);
+
         // Create debug hints for the witness computation
         const int ncols = length(cols);
         string name_cols[ncols];
@@ -108,6 +110,8 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
         }
         @gsum_member_data{name_piop: get_piop_name(name), names: name_cols, sumid: sumid, proves: proves, selector: sel, references: cols};
     }
+
+    initial_checks_sum(proves, opid, cols, is_direct);
 
     init_challenges();
 

--- a/pil2-components/lib/std/pil/std_tools.pil
+++ b/pil2-components/lib/std/pil/std_tools.pil
@@ -1,3 +1,14 @@
+require "std_constants.pil";
+
+function set_bus_type(const int bus_type) {
+    if (bus_type != PIOP_BUS_SUM && bus_type != PIOP_BUS_PROD) {
+        error(`Unknown bus type: ${bus_type}`);
+    }
+
+    // Set the bus type for the std components
+    DEFAULT_PERMUTATION_BUS_TYPE = bus_type;
+}
+
 function init_challenges() {
     if (!defined(std_alpha)) {
         challenge stage(2) std_alpha;

--- a/pil2-components/test/README.md
+++ b/pil2-components/test/README.md
@@ -69,7 +69,7 @@ mkdir -p ./pil2-components/test/std/lookup/build/ \
 && cargo run --bin proofman-cli prove \
      --witness-lib ./target/debug/liblookup.so \
      --proving-key ./pil2-components/test/std/lookup/build/provingKey \
-     --output-dir ./pil2-components/test/std/lookup/build -d \
+     --output-dir ./pil2-components/test/std/lookup/build/proofs -d \
 && node ../pil2-proofman-js/src/main_verify -k ./pil2-components/test/std/lookup/build/provingKey -p ./pil2-components/test/std/lookup/build/proofs
 
 ------------------------------------

--- a/pil2-components/test/std/range_check/range_check_dynamic.pil
+++ b/pil2-components/test/std/range_check/range_check_dynamic.pil
@@ -7,12 +7,12 @@ airtemplate RangeCheckDynamic1(const int N = 2**8) {
 
     int id_range_7 = range_check_id(0, 2**7-1);
     int id_range_8 = range_check_id(0, 2**8-1);
-    assert(id_range_8 == OPIDS[0]);
+    assert(id_range_8 != OPIDS[0]);
     int id_range_8_2 = range_check_id(0, 2**8-1);
     assert(id_range_8_2 == id_range_8);
     int id_range_17 = range_check_id(0, 2**17-1);
     int id_range_16 = range_check_id(0, 2**16-1);
-    assert(id_range_16 == OPIDS[1]);
+    assert(id_range_16 != OPIDS[1]);
     int id_range_7_2 = range_check_id(0, 2**7-1);
     assert(id_range_7_2 == id_range_7);
 
@@ -28,6 +28,7 @@ airtemplate RangeCheckDynamic2(const int N = 2**6) {
     int id_range_2 = range_check_id(-8719, -7269);
     int id_range_3 = range_check_id(-10, 10);
     int id_range_4 = range_check_id(0, 2**8-1);
+    assert(id_range_4 != OPIDS[0]);
     int id_range_5 = range_check_id(0, 2**7-1);
 
     range_check_dynamic(colu, id_range_1 * sel_1 + id_range_2 * sel_2 + id_range_3 * sel_3 + id_range_4 * sel_4 + id_range_5 * sel_5);

--- a/pil2-components/test/std/range_check/rs/src/pil_helpers/pilout.rs
+++ b/pil2-components/test/std/range_check/rs/src/pil_helpers/pilout.rs
@@ -26,9 +26,7 @@ pub const RANGE_CHECK_MIX_AIRGROUP_ID: usize = 8;
 
 pub const U_8_AIR_AIRGROUP_ID: usize = 9;
 
-pub const U_16_AIR_AIRGROUP_ID: usize = 10;
-
-pub const SPECIFIED_RANGES_AIRGROUP_ID: usize = 11;
+pub const SPECIFIED_RANGES_AIRGROUP_ID: usize = 10;
 
 //AIR CONSTANTS
 
@@ -39,6 +37,8 @@ pub const RANGE_CHECK_2_AIR_IDS: &[usize] = &[0];
 pub const RANGE_CHECK_1_AIR_IDS: &[usize] = &[0];
 
 pub const RANGE_CHECK_4_AIR_IDS: &[usize] = &[0];
+
+pub const U_16_AIR_AIR_IDS: &[usize] = &[1];
 
 pub const MULTI_RANGE_CHECK_1_AIR_IDS: &[usize] = &[0];
 
@@ -51,8 +51,6 @@ pub const RANGE_CHECK_DYNAMIC_2_AIR_IDS: &[usize] = &[0];
 pub const RANGE_CHECK_MIX_AIR_IDS: &[usize] = &[0];
 
 pub const U_8_AIR_AIR_IDS: &[usize] = &[0];
-
-pub const U_16_AIR_AIR_IDS: &[usize] = &[0];
 
 pub const SPECIFIED_RANGES_AIR_IDS: &[usize] = &[0];
 
@@ -77,6 +75,7 @@ impl Pilout {
         let air_group = pilout.add_air_group(Some("RangeCheck4"));
 
         air_group.add_air(Some("RangeCheck4"), 64);
+        air_group.add_air(Some("U16Air"), 65536);
 
         let air_group = pilout.add_air_group(Some("MultiRangeCheck1"));
 
@@ -101,10 +100,6 @@ impl Pilout {
         let air_group = pilout.add_air_group(Some("U8Air"));
 
         air_group.add_air(Some("U8Air"), 256);
-
-        let air_group = pilout.add_air_group(Some("U16Air"));
-
-        air_group.add_air(Some("U16Air"), 65536);
 
         let air_group = pilout.add_air_group(Some("SpecifiedRanges"));
 

--- a/pil2-components/test/std/range_check/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/std/range_check/rs/src/pil_helpers/traces.rs
@@ -19,6 +19,10 @@ trace!(RangeCheck40Row, RangeCheck40Trace<F> {
  a1: F, a2: F, a3: F, a4: F, a5: F, a6: F, a7: F, a8: F, sel1: F, sel2: F,
 });
 
+trace!(U16Air1Row, U16Air1Trace<F> {
+ mul: F,
+});
+
 trace!(MultiRangeCheck10Row, MultiRangeCheck10Trace<F> {
  a: [F; 3], sel: [F; 3], range_sel: [F; 3],
 });
@@ -43,10 +47,6 @@ trace!(U8Air0Row, U8Air0Trace<F> {
  mul: F,
 });
 
-trace!(U16Air0Row, U16Air0Trace<F> {
- mul: F,
-});
-
 trace!(SpecifiedRanges0Row, SpecifiedRanges0Trace<F> {
- mul: [F; 24],
+ mul: [F; 20],
 });

--- a/pil2-components/test/std/special/diff_buses.pil
+++ b/pil2-components/test/std/special/diff_buses.pil
@@ -1,0 +1,37 @@
+require "std_tools.pil";
+require "std_constants.pil";
+require "std_permutation.pil";
+require "std_lookup.pil";
+
+// One can use the following function to set the bus type for the entire std
+// set_bus_type(PIOP_BUS_SUM);
+
+airtemplate Air1(const int N = 2**4) {
+    col witness a,b;
+
+    permutation_assumes(1, [a], bus_type: PIOP_BUS_PROD);
+    permutation_proves(1, [b], bus_type: PIOP_BUS_PROD);
+}
+
+airtemplate Air2(const int N = 2**5) {
+    col witness a,b;
+
+    lookup_assumes(2, [a]);
+    lookup_proves(2, [b]);
+}
+
+airtemplate Air3(const int N = 2**4) {
+    col witness a,b,c,d;
+
+    permutation_assumes(3, [a]);
+    permutation_proves(3, [b]);
+
+    lookup_assumes(4, [c]);
+    lookup_proves(4, [d]);
+}
+
+airgroup Buses {
+    Air1();
+    Air2();
+    Air3();
+}

--- a/pil2-components/test/std/special/direct_update.pil
+++ b/pil2-components/test/std/special/direct_update.pil
@@ -2,46 +2,42 @@ require "std_permutation.pil";
 require "std_lookup.pil";
 require "std_common.pil";
 
+const int OP_BUS_ID1 = 100;
+const int OPID1 = 333;
 public input1[10];
 
 airtemplate DirectUpdatePermutation(const int N = 2**4) {
-
-    const int OP_BUS_ID = 100;
-    const int OPID = 333;
-
     col witness a[2],b[2],c[2];
     col witness flag;
     col witness perform_operation;
-    permutation_proves(OP_BUS_ID, [OPID, ...a, ...b, ...c, flag], sel: perform_operation);
-
-    for (int i = 0; i < length(input1)/2; i++) {
-        direct_update(OP_BUS_ID, [OPID, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], proves: 0, bus_type: PIOP_BUS_PROD);
-    }
+    permutation_proves(OP_BUS_ID1, [OPID1, ...a, ...b, ...c, flag], sel: perform_operation, bus_type: PIOP_BUS_PROD);
 }
-
-public input2[20];
-
-airtemplate DirectUpdateLookup(const int N = 2**5) {
-
-    const int OP_BUS_ID = 200;
-    const int OPID = 444;
-
-    for (int i = 0; i < length(input2)/2; i++) {
-        direct_update(OP_BUS_ID, [OPID, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0])
-    }
-
-    col witness a[2],b[2],c[2];
-    col witness flag;
-    col witness perform_operation;
-    lookup_assumes(OP_BUS_ID, [OPID, ...a, ...b, ...c, flag], sel: perform_operation);
-}
-
-// TODO: Do an example with multiple elements in the direct_update
 
 airgroup Permutation {
     DirectUpdatePermutation();
+
+    for (int i = 0; i < length(input1)/2; i++) {
+        direct_update(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], proves: 0, bus_type: PIOP_BUS_PROD);
+    }
+}
+
+const int OP_BUS_ID2 = 200;
+const int OPID2 = 444;
+public input2[20];
+
+airtemplate DirectUpdateLookup(const int N = 2**5) {
+    col witness a[2],b[2],c[2];
+    col witness flag;
+    col witness perform_operation;
+    lookup_assumes(OP_BUS_ID2, [OPID2, ...a, ...b, ...c, flag], sel: perform_operation);
 }
 
 airgroup Lookup {
+    for (int i = 0; i < length(input2)/2; i++) {
+        direct_update(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0])
+    }
+
     DirectUpdateLookup();
 }
+
+// TODO: Do an example with multiple elements in the direct_update

--- a/pil2-components/test/std/special/range_check_airgroup.pil
+++ b/pil2-components/test/std/special/range_check_airgroup.pil
@@ -1,0 +1,107 @@
+require "std_range_check.pil";
+
+airtemplate RangeCheck1(const int N = 2**3) {
+
+    col witness a1,a2,a3;
+
+    range_check(a1, 0, 2**8-1, predefined: 1);  // U8
+    range_check(a2, 0, 2**16-1, predefined: 1); // U16
+
+    range_check(a1, 0, 2**8-1, predefined: 0);  // Specified
+    range_check(a2, 0, 2**16-1, predefined: 0); // Specified
+
+    range_check(a3, 40, 100, predefined: 0);    // Specified
+};
+
+airtemplate RangeCheck2(const int N = 2**4) {
+
+    col witness b1,b2,b3;
+
+    range_check(b1, 1, 2**8-2, predefined: 1);   // U8
+    range_check(b2, 1, 2**16-2, predefined: 1);  // U16
+    range_check(b3, 40, 100, predefined: 0);     // Specified
+};
+
+// airgroup RangeCheck1 {
+//     RangeCheck1();
+//     // RangeCheck2();
+// }
+
+// airgroup RangeCheck2 {
+//     RangeCheck2();
+// }
+
+airtemplate MultiRangeCheck1(const int N = 2**3) {
+
+    col witness a[3];
+    col witness sel[3];
+    col witness range_sel[3];
+
+    multi_range_check(a[0], 0, 2**7-1, 0, 2**8-1, range_sel[0], sel[0]);       // Both Specified
+    multi_range_check(a[1], 0, 2**7-1, 0, 2**6-1, range_sel[1], sel[1]);       // Both Specified
+    multi_range_check(a[2], 2**5, 2**8-1, 2**8, 2**9-1, range_sel[2], sel[2]); // Both Specified
+};
+
+airtemplate MultiRangeCheck2(const int N = 2**4) {
+
+    col witness a[2];
+    col witness sel[2];
+    col witness range_sel[2];
+
+    multi_range_check(a[0], 2**5, 2**8-1, 2**8, 2**9-1, range_sel[0], sel[0]); // Both Specified
+    multi_range_check(a[1], 0, 2**7-1, 0, 2**4-1, range_sel[1], sel[1]);       // Both Specified
+};
+
+// airgroup MultiRangeCheck1 {
+//     MultiRangeCheck1();
+//     // MultiRangeCheck2();
+// }
+
+// airgroup MultiRangeCheck2 {
+//     MultiRangeCheck2();
+// }
+
+airtemplate RangeCheckDynamic1(const int N = 2**8) {
+
+    col witness colu;
+    col witness sel_7, sel_8, sel_16, sel_17;
+
+    // All of them Specified
+    int id_range_7 = range_check_id(0, 2**7-1);
+    int id_range_8 = range_check_id(0, 2**8-1);
+    assert(id_range_8 != OPIDS[0]);
+    int id_range_8_2 = range_check_id(0, 2**8-1);
+    assert(id_range_8_2 == id_range_8);
+    int id_range_17 = range_check_id(0, 2**17-1);
+    int id_range_16 = range_check_id(0, 2**16-1);
+    assert(id_range_16 != OPIDS[1]);
+    int id_range_7_2 = range_check_id(0, 2**7-1);
+    assert(id_range_7_2 == id_range_7);
+
+    range_check_dynamic(colu, id_range_7 * sel_7 + id_range_8 * sel_8 + id_range_16 * sel_16 + id_range_17 * sel_17);
+};
+
+airtemplate RangeCheckDynamic2(const int N = 2**6) {
+
+    col witness colu;
+    col witness sel_1, sel_2, sel_3, sel_4, sel_5;
+
+    // All of them Specified
+    int id_range_1 = range_check_id(5225, 29023);
+    int id_range_2 = range_check_id(-8719, -7269);
+    int id_range_3 = range_check_id(-10, 10);
+    int id_range_4 = range_check_id(0, 2**8-1);
+    assert(id_range_4 != OPIDS[0]);
+    int id_range_5 = range_check_id(0, 2**7-1);
+
+    range_check_dynamic(colu, id_range_1 * sel_1 + id_range_2 * sel_2 + id_range_3 * sel_3 + id_range_4 * sel_4 + id_range_5 * sel_5);
+};
+
+// airgroup RangeCheckDynamic1 {
+//     RangeCheckDynamic1();
+//     // RangeCheckDynamic2();
+// }
+
+// airgroup RangeCheckDynamic2 {
+//     RangeCheckDynamic2();
+// }


### PR DESCRIPTION
Multiple updates to std:
- [x] Sum bus has been set as default for all PIOPs.
- [x] `Lookup` and `Permutation` functions have been added to allow the user freedom on the selector.
- [x] Bugs fixed in the `direct_bus` function. Notice that this function cannot be called outside an airgroup.
- [x] Range check created airgroups for `U8`, `U16` and `SpecifiedRanges` have been removed and included in a calling airgroup in the case they are always called from the same airgroup.