### PR TITLE
Fix error caused by freeling throw into the bus

### DIFF
--- a/pil2-components/lib/std/pil/std_lookup.pil
+++ b/pil2-components/lib/std/pil/std_lookup.pil
@@ -19,7 +19,7 @@ function lookup_proves(const int opid, const expr cols[], const expr mul = 1, in
 function lookup(const int opid, const expr cols[], const expr sel = 1, int name = PIOP_NAME_DEFAULT) {
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_LOOKUP_NAME;
 
-    sum_proves(name, opid, cols, mul);
+    sum(name, opid, cols, sel);
 }
 
 function lookup_assumes_dynamic(const int opid[], const expr sumid, const expr cols[], const expr sel = 1, int name = PIOP_NAME_DEFAULT) {

--- a/pil2-components/lib/std/pil/std_sum.pil
+++ b/pil2-components/lib/std/pil/std_sum.pil
@@ -118,7 +118,8 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
         for (int i = 0; i < ncols; i++) {
             name_cols[i] = string(cols[i]);
         }
-        @gsum_member_data{name_piop: get_piop_name(name), names: name_cols, sumid: sumid, proves: proves, selector: sel, references: cols};
+        // proves = 2 marks that the user is responsible for the use of proves and assumes
+        @gsum_member_data{name_piop: get_piop_name(name), names: name_cols, sumid: sumid, proves: proves != 2 ? proves : sel, selector: sel, references: cols};
     }
 
     initial_checks_sum(proves, opid, cols, is_direct);

--- a/pil2-components/test/simple/simple.pil
+++ b/pil2-components/test/simple/simple.pil
@@ -11,7 +11,7 @@ airtemplate SimpleLeft(const int N = 2**2) {
 
     permutation_assumes(2, [e, f]);
 
-    lookup_assumes(3, [g, h]);
+    lookup(3, [g, h], sel: -1);
 };
 
 airtemplate SimpleRight(const int N = 2**2) {
@@ -19,7 +19,7 @@ airtemplate SimpleRight(const int N = 2**2) {
     col witness a,b,c,d;
     col witness mul;
 
-    permutation_proves(2, [a, b]);
+    permutation(2, [a, b], sel: 1);
 
     lookup_proves(3, [c, d], mul);
 };


### PR DESCRIPTION
- [x] Fix the hints so that when the throw is "free", the `proves` flag is set by the `sel` expression.
- [x] Modify the `std_sum.rs` to reflect this. 