### PR TITLE
Adding the constraint directly to the air

### DIFF
--- a/examples/fibonacci-square/README.md
+++ b/examples/fibonacci-square/README.md
@@ -73,6 +73,8 @@ node ../pil2-proofman-js/src/main_setup.js \
      -t ./pil2-stark/build/bctree
 ```
 
+To run the aggregated proof, need to add -r to the previous command
+
 ### 2.3 Generate PIL Helpers
 
 Generate the corresponding PIL helpers by running the following command:
@@ -123,6 +125,7 @@ node ../pil2-proofman-js/src/main_verify -k examples/fibonacci-square/build/prov
 
 ### 2.6 Generate Final Proof
 
+This will only work if setup is generated with -r
 Finally, generate the final proof using the following command:
 
 ```bash

--- a/examples/fibonacci-square/README.md
+++ b/examples/fibonacci-square/README.md
@@ -70,6 +70,7 @@ After compiling the PIL files, generate the setup:
 node ../pil2-proofman-js/src/main_setup.js \
      -a ./examples/fibonacci-square/pil/build.pilout \
      -b ./examples/fibonacci-square/build
+     -t ./pil2-stark/build/bctree
 ```
 
 ### 2.3 Generate PIL Helpers
@@ -122,7 +123,7 @@ node ../pil2-proofman-js/src/main_verify -k examples/fibonacci-square/build/prov
 
 ### 2.6 Generate Final Proof
 
-Finally, generate the proof using the following command:
+Finally, generate the final proof using the following command:
 
 ```bash
 cargo run --bin proofman-cli prove \
@@ -136,5 +137,42 @@ cargo run --bin proofman-cli prove \
 ### 2.8 Verify final proof
 
 ```bash
-node ../pil2-stark-js/src/main_verifier.js -v examples/fibonacci-square/build/provingKey/build/final/final.verkey.json -s examples/fibonacci-square/build/provingKey/build/final/final.starkinfo.json -i examples/fibonacci-square/build/provingKey/build/final/final.verifierinfo.json -o examples/fibonacci-square/build/proofs/proofs/final_proof.json -b examples/fibonacci-square/build/proofs/publics.json
+node ../pil2-stark-js/src/main_verifier.js \
+     -v examples/fibonacci-square/build/provingKey/build/final/final.verkey.json \
+     -s examples/fibonacci-square/build/provingKey/build/final/final.starkinfo.json \
+     -i examples/fibonacci-square/build/provingKey/build/final/final.verifierinfo.json \
+     -o examples/fibonacci-square/build/proofs/proofs/final_proof.json \
+     -b examples/fibonacci-square/build/proofs/publics.json
+```
+
+### 2.9 All at once
+
+```bash
+node ../pil2-compiler/src/pil.js ./examples/fibonacci-square/pil/build.pil \
+     -I ./pil2-components/lib/std/pil \
+     -o ./examples/fibonacci-square/pil/build.pilout \
+&& node ../pil2-proofman-js/src/main_setup.js \
+     -a ./examples/fibonacci-square/pil/build.pilout \
+     -b ./examples/fibonacci-square/build \
+     -t ./pil2-stark/build/bctree \
+&& cargo run --bin proofman-cli pil-helpers \
+     --pilout ./examples/fibonacci-square/pil/build.pilout \
+     --path ./examples/fibonacci-square/src -o \
+&& cargo build \
+&& cargo run --bin proofman-cli verify-constraints \
+     --witness-lib ./target/debug/libfibonacci_square.so \
+     --proving-key examples/fibonacci-square/build/provingKey/ \
+     --public-inputs examples/fibonacci-square/src/inputs.json \
+&& cargo run --bin proofman-cli prove \
+     --witness-lib ./target/debug/libfibonacci_square.so \
+     --proving-key examples/fibonacci-square/build/provingKey/ \
+     --public-inputs examples/fibonacci-square/src/inputs.json \
+     --output-dir examples/fibonacci-square/build/proofs -d \
+&& node ../pil2-proofman-js/src/main_verify -k examples/fibonacci-square/build/provingKey/ -p examples/fibonacci-square/build/proofs \
+&& node ../pil2-stark-js/src/main_verifier.js \
+     -v examples/fibonacci-square/build/provingKey/build/final/final.verkey.json \
+     -s examples/fibonacci-square/build/provingKey/build/final/final.starkinfo.json \
+     -i examples/fibonacci-square/build/provingKey/build/final/final.verifierinfo.json \
+     -o examples/fibonacci-square/build/proofs/proofs/final_proof.json \
+     -b examples/fibonacci-square/build/proofs/publics.json
 ```

--- a/hints/src/hints.rs
+++ b/hints/src/hints.rs
@@ -1,6 +1,6 @@
 use proofman_starks_lib_c::{
-    acc_hint_field_c, acc_mul_hint_fields_c, get_hint_field_c, get_hint_ids_by_name_c, mul_hint_fields_c,
-    print_expression_c, print_row_c, set_hint_field_c, VecU64Result,
+    acc_hint_field_c, acc_mul_hint_fields_c, acc_mul_add_hint_fields_c, get_hint_field_c, get_hint_ids_by_name_c,
+    mul_hint_fields_c, print_expression_c, print_row_c, set_hint_field_c, VecU64Result,
 };
 
 use std::collections::HashMap;
@@ -706,6 +706,7 @@ pub fn mul_hint_fields<F: Field + Field>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn acc_hint_field<F: Field>(
     setup_ctx: &SetupCtx<F>,
     proof_ctx: &ProofCtx<F>,
@@ -714,6 +715,7 @@ pub fn acc_hint_field<F: Field>(
     hint_field_dest: &str,
     hint_field_airgroupvalue: &str,
     hint_field_name: &str,
+    add: bool,
 ) -> (u64, u64) {
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 
@@ -743,6 +745,7 @@ pub fn acc_hint_field<F: Field>(
         hint_field_dest,
         hint_field_airgroupvalue,
         hint_field_name,
+        add,
     );
 
     let hint_ids_result = unsafe { Box::from_raw(raw_ptr as *mut VecU64Result) };
@@ -764,6 +767,7 @@ pub fn acc_mul_hint_fields<F: Field>(
     hint_field_name2: &str,
     options1: HintFieldOptions,
     options2: HintFieldOptions,
+    add: bool,
 ) -> (u64, u64) {
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 
@@ -796,6 +800,66 @@ pub fn acc_mul_hint_fields<F: Field>(
         hint_field_name2,
         (&options1).into(),
         (&options2).into(),
+        add,
+    );
+
+    let hint_ids_result = unsafe { Box::from_raw(raw_ptr as *mut VecU64Result) };
+
+    let slice = unsafe { std::slice::from_raw_parts(hint_ids_result.values, hint_ids_result.n_values as usize) };
+
+    (slice[0], slice[1])
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn acc_mul_add_hint_fields<F: Field>(
+    setup_ctx: &SetupCtx<F>,
+    proof_ctx: &ProofCtx<F>,
+    air_instance: &mut AirInstance<F>,
+    hint_id: usize,
+    hint_field_dest: &str,
+    hint_field_airgroupvalue: &str,
+    hint_field_name1: &str,
+    hint_field_name2: &str,
+    hint_field_name3: &str,
+    options1: HintFieldOptions,
+    options2: HintFieldOptions,
+    options3: HintFieldOptions,
+    add: bool,
+) -> (u64, u64) {
+    let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
+
+    let public_inputs_ptr = (*proof_ctx.public_inputs.inputs.read().unwrap()).as_ptr() as *mut c_void;
+    let challenges_ptr = (*proof_ctx.challenges.challenges.read().unwrap()).as_ptr() as *mut c_void;
+
+    let const_pols_ptr = (*setup.const_pols.values.read().unwrap()).as_ptr() as *mut c_void;
+    let const_tree_ptr = (*setup.const_tree.values.read().unwrap()).as_ptr() as *mut c_void;
+
+    let steps_params = StepsParams {
+        buffer: air_instance.get_buffer_ptr() as *mut c_void,
+        public_inputs: public_inputs_ptr,
+        challenges: challenges_ptr,
+        airgroup_values: air_instance.airgroup_values.as_ptr() as *mut c_void,
+        airvalues: air_instance.airvalues.as_ptr() as *mut c_void,
+        evals: air_instance.evals.as_ptr() as *mut c_void,
+        xdivxsub: std::ptr::null_mut(),
+        p_const_pols: const_pols_ptr,
+        p_const_tree: const_tree_ptr,
+        custom_commits: air_instance.get_custom_commits_ptr(),
+    };
+
+    let raw_ptr = acc_mul_add_hint_fields_c(
+        (&setup.p_setup).into(),
+        (&steps_params).into(),
+        hint_id as u64,
+        hint_field_dest,
+        hint_field_airgroupvalue,
+        hint_field_name1,
+        hint_field_name2,
+        hint_field_name3,
+        (&options1).into(),
+        (&options2).into(),
+        (&options3).into(),
+        add,
     );
 
     let hint_ids_result = unsafe { Box::from_raw(raw_ptr as *mut VecU64Result) };

--- a/pil2-components/lib/std/pil/std_common.pil
+++ b/pil2-components/lib/std/pil/std_common.pil
@@ -5,13 +5,23 @@ require "std_prod.pil";
 const int DEFAULT_DIRECT_NAME = PIOP_NAME_DIRECT;
 const int DEFAULT_DIRECT_BUS_TYPE = PIOP_BUS_SUM;
 
-// Updates the global constraint directly
-// We allow any expression as inputs to this function, but if some of it is not a global element
-// the PIL will throw an error
-function direct_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, int bus_type = PIOP_BUS_DEFAULT, int name = PIOP_NAME_DEFAULT) {
+// Updates either the air or global constraint directly
+function direct_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
     if (AIRGROUP_ID == -1) {
         error("A direct update has to be performed inside an airgroup");
     }
+
+    for (int i = 0; i < length(cols); i++) {
+        if (degree(cols[i]) > 0) {
+            error(`Only field elements can be used for a direct update. The column[${i}] = ${cols[i]} is not a field element`);
+        }
+    }
+
+    if (degree(sel) > 0) {
+        error(`Only field elements can be used for a direct update. The selector = ${sel} is not a field element`);
+    }
+
+    const int direct_type = AIR_ID == -1 ? PIOP_DIRECT_TYPE_GLOBAL : PIOP_DIRECT_TYPE_AIR;
 
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_DIRECT_NAME;
 
@@ -20,15 +30,15 @@ function direct_update(const int opid, const expr cols[], const expr sel = 1, co
     switch (bus_type) {
         case PIOP_BUS_SUM:
             if (proves) {
-                sum_proves(name, opid, cols, sel, is_direct: 1);
+                sum_proves(name, opid, cols, sel, direct_type);
             } else {
-                sum_assumes(name, opid, cols, sel, is_direct: 1);
+                sum_assumes(name, opid, cols, sel, direct_type);
             }
         case PIOP_BUS_PROD:
             if (proves) {
-                prod_proves(name, opid, cols, sel, is_direct: 1);
+                prod_proves(name, opid, cols, sel, direct_type);
             } else {
-                prod_assumes(name, opid, cols, sel, is_direct: 1);
+                prod_assumes(name, opid, cols, sel, direct_type);
             }
         default:
             error(`Unknown bus type: ${bus_type} for opid: ${opid}`);

--- a/pil2-components/lib/std/pil/std_common.pil
+++ b/pil2-components/lib/std/pil/std_common.pil
@@ -44,3 +44,11 @@ function direct_update(const int opid, const expr cols[], const expr sel = 1, co
             error(`Unknown bus type: ${bus_type} for opid: ${opid}`);
     }
 }
+
+function direct_update_assumes(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_update(opid, cols, sel, 0, bus_type, name);
+}
+
+function direct_update_proves(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_update(opid, cols, sel, 1, bus_type, name);
+}

--- a/pil2-components/lib/std/pil/std_constants.pil
+++ b/pil2-components/lib/std/pil/std_constants.pil
@@ -1,6 +1,8 @@
 require "goldilocks.pil";
 
 /*
+Available PIOPs:
+
     name     | code | note
 -------------|------|----------------------------------------------------------------------------
  Default     |  0   | default name set by the library
@@ -40,6 +42,8 @@ function get_piop_name(const int name): string {
 }
 
 /*
+Available bus types:
+
     name    | code | note
 ------------|------|----------------------------------------------------------------------------
  Default    |  0   | default bus set by the library
@@ -50,6 +54,20 @@ function get_piop_name(const int name): string {
 const int PIOP_BUS_DEFAULT = 0;
 const int PIOP_BUS_SUM = 1;
 const int PIOP_BUS_PROD = 2;
+
+/*
+Available direct types:
+
+    name    | code | note
+------------|------|----------------------------------------------------------------------------
+ Default    |  0   | default constraint behavior set by the library
+ AIR        |  1   | update the air constraint directly
+ Global     |  2   | update the global constraint directly
+*/
+
+const int PIOP_DIRECT_TYPE_DEFAULT = 0;
+const int PIOP_DIRECT_TYPE_AIR = 1;
+const int PIOP_DIRECT_TYPE_GLOBAL = 2;
 
 /*
     name    | code

--- a/pil2-components/lib/std/pil/std_prod.pil
+++ b/pil2-components/lib/std/pil/std_prod.pil
@@ -1,13 +1,14 @@
+require "std_constants.pil";
 require "std_tools.pil";
 
 // Note: When name is "isolated" we don't check if the number of columns is the same for all the PIOPs
 
-function prod_assumes(const int name, const int opid, const expr cols[], const expr sel = 1, int is_direct = 0) {
-    update_piop_prod(name, 0, opid, sel, cols, is_direct);
+function prod_assumes(const int name, const int opid, const expr cols[], const expr sel = 1, const int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
+    update_piop_prod(name, 0, opid, sel, cols, direct_type);
 }
 
-function prod_proves(const int name, const int opid, const expr cols[], const expr sel = 1, int is_direct = 0) {
-    update_piop_prod(name, 1, opid, sel, cols, is_direct);
+function prod_proves(const int name, const int opid, const expr cols[], const expr sel = 1, const int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
+    update_piop_prod(name, 1, opid, sel, cols, direct_type);
 }
 
 private function init_proof_containers_prod(int name, int opid) {
@@ -53,20 +54,29 @@ private function init_containers_prod(int name, int opid) {
         int gprod_proves_count = 0;
         expr gprod_proves_sel[100];
         expr gprod_proves[100];
+
+        // Direct shortcut to the previous product
+        int direct_gprod_assumes_count = 0;
+        expr direct_gprod_assumes_sel[100];
+        expr direct_gprod_assumes[100];
+
+        int direct_gprod_proves_count = 0;
+        expr direct_gprod_proves_sel[100];
+        expr direct_gprod_proves[100];
     }
 }
 
-private function initial_checks_prod(int proves, int opid, expr cols[], int is_direct) {
+private function initial_checks_prod(int proves, int opid, expr cols[], int direct_type) {
     const int cols_count = length(cols);
 
-    // Assumes and proves of the same opid must have the same number of columns (except for the is_direct case)
+    // Assumes and proves of the same opid must have the same number of columns (except for the direct_type case)
     if (proof.std.gprod.`id${opid}`.cols == 0) {
         // first time called
         proof.std.gprod.`id${opid}`.cols = cols_count;
         // add opid on a list to verify at final
         proof.std.gprod.opids[proof.std.gprod.opids_count] = opid;
         proof.std.gprod.opids_count++;
-    } else if (!is_direct && cols_count != proof.std.gprod.`id${opid}`.cols) {
+    } else if (direct_type == PIOP_DIRECT_TYPE_DEFAULT && cols_count != proof.std.gprod.`id${opid}`.cols) {
         const int expected_cols = proof.std.gprod.`id${opid}`.cols;
         error(`The number of columns of PIOP #${opid} must be ${expected_cols} but was ${cols_count}`);
     }
@@ -88,7 +98,7 @@ private function initial_checks_prod(int proves, int opid, expr cols[], int is_d
  * @param sel selector of the PIOP
  * @param cols columns of the PIOP
  */
-private function update_piop_prod(int name, int proves, int opid, expr sel, expr cols[], int is_direct = 0) {
+private function update_piop_prod(int name, int proves, int opid, expr sel, expr cols[], int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
     const int cols_count = length(cols);
     if (cols_count < 1) {
         string side = proves ? "proves" : "assumes";
@@ -97,9 +107,11 @@ private function update_piop_prod(int name, int proves, int opid, expr sel, expr
 
     init_proof_containers_prod(name, opid);
 
-    if (!is_direct) {
+    if (direct_type == PIOP_DIRECT_TYPE_AIR || direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
         init_containers_prod(name, opid);
+    }
 
+    if (direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
         // Create debug hints for the witness computation
         const int ncols = length(cols);
         string name_cols[ncols];
@@ -109,53 +121,73 @@ private function update_piop_prod(int name, int proves, int opid, expr sel, expr
         @gprod_member_data{name_piop: get_piop_name(name), names: name_cols, opid: opid, proves: proves, selector: sel, references: cols};
     }
 
-    initial_checks_prod(proves, opid, cols, is_direct);
+    initial_checks_prod(proves, opid, cols, direct_type);
 
     init_challenges();
 
     // selected vector to simple column reduction
     expr cols_compressed = compress_cols(opid, cols);
 
-    if (is_direct) {
+    switch (direct_type) {
+        case PIOP_DIRECT_TYPE_GLOBAL:
+            gprod_update_global_constraint_data(proves, sel, cols_compressed);
+        case PIOP_DIRECT_TYPE_AIR, PIOP_DIRECT_TYPE_DEFAULT:
+            gprod_update_air_constraint_data(proves, sel, cols_compressed, direct_type);
+        default:
+            error("Invalid direct_type: ${direct_type}");
+    }
+
+    // Define and update constraints at the proof level
+    on final proof piop_gprod_proof();
+}
+
+private function gprod_update_global_constraint_data(int proves, expr sel, expr cols_compressed) {
         use proof.std.gprod;
 
         if (proves) {
-            // adding all prods of proves called in this air
             direct_gprod_proves_sel[direct_gprod_proves_count] = sel;
             direct_gprod_proves[direct_gprod_proves_count] = cols_compressed;
             direct_gprod_proves_count++;
         } else {
-            // adding all prods of assumes called in this air
+            direct_gprod_assumes_sel[direct_gprod_assumes_count] = sel;
+            direct_gprod_assumes[direct_gprod_assumes_count] = cols_compressed;
+            direct_gprod_assumes_count++;
+        }
+}
+
+private function gprod_update_air_constraint_data(int proves, expr sel, expr cols_compressed, int direct_type) {
+    use air.std.gprod;
+
+    if (direct_type == PIOP_DIRECT_TYPE_AIR) {
+        if (proves) {
+            direct_gprod_proves_sel[direct_gprod_proves_count] = sel;
+            direct_gprod_proves[direct_gprod_proves_count] = cols_compressed;
+            direct_gprod_proves_count++;
+        } else {
             direct_gprod_assumes_sel[direct_gprod_assumes_count] = sel;
             direct_gprod_assumes[direct_gprod_assumes_count] = cols_compressed;
             direct_gprod_assumes_count++;
         }
     } else {
-        use air.std.gprod;
         if (proves) {
-            // adding all prods of proves called in this air
             gprod_proves_sel[gprod_proves_count] = sel;
             gprod_proves[gprod_proves_count] = cols_compressed;
             gprod_proves_count++;
         } else {
-            // adding all prods of assumes called in this air
             gprod_assumes_sel[gprod_assumes_count] = sel;
             gprod_assumes[gprod_assumes_count] = cols_compressed;
             gprod_assumes_count++;
         }
 
-        // define constraints at the air level
-        on final air piop_gprod_air();
-
-        // update values at the airgroup level
-        on final airgroup piop_gprod_airgroup();
-
         // at the end, check consistency of all the opids
         on final proof check_opids_were_completed_prod();
     }
 
-    // update constraints at the proof level
-    on final proof piop_gprod_proof();
+    // Define and update constraints at the air level
+    on final air piop_gprod_air();
+
+    // Define and update constraints at the airgroup level
+    on final airgroup piop_gprod_airgroup();
 }
 
 /**
@@ -174,19 +206,41 @@ private function piop_gprod_air() {
 
     col fixed _L1 = [1,0...]; // TODO: Fix
 
-    expr numerator = 1;
+    expr air_num = 1;
     for (int i = 0; i < gprod_proves_count; i++) {
-        numerator *= (gprod_proves_sel[i] * (gprod_proves[i] + std_gamma - 1) + 1);
+        air_num *= (gprod_proves_sel[i] * (gprod_proves[i] + std_gamma - 1) + 1);
     }
 
-    expr denominator = 1;
+    expr air_den = 1;
     for (int i = 0; i < gprod_assumes_count; i++) {
-        denominator *= (gprod_assumes_sel[i] * (gprod_assumes[i] + std_gamma - 1) + 1);
+        air_den *= (gprod_assumes_sel[i] * (gprod_assumes[i] + std_gamma - 1) + 1);
     }
 
-    @gprod_col{reference: gprod, numerator: numerator, denominator: denominator, result: airgroup.std.gprod.gprod_result};
+    /*
+     At this point, the constraint has been transformed to:
+          gprod === ('gprod * (1 - L1) + L1) * air_num / air_den
 
-    gprod * denominator === ('gprod * (1 - _L1) + _L1) * numerator;
+     Now, we whould add the direct terms to the constraint:
+          gprod === ('gprod * (1 - L1) + L1) * air_num / air_den * ∏ⱼ (sⱼ·(eⱼ+ɣ-1)+1) / (sⱼ'·(eⱼ'+ɣ-1)+1)
+     where all sⱼ,sⱼ',eⱼ,eⱼ' are field elements, for all j.
+
+     We rewrite it as:
+          gprod * air_den * ∏ⱼ (sⱼ'·(eⱼ'+ɣ-1)+1)  === ('gprod * (1 - L1) + L1) * air_num * ∏ⱼ (sⱼ·(eⱼ+ɣ-1)+1)
+    */
+
+    expr direct_num = 1;
+    for (int i = 0; i < direct_gprod_proves_count; i++) {
+        direct_num *= (direct_gprod_proves_sel[i] * (direct_gprod_proves[i] + std_gamma - 1) + 1);
+    }
+
+    expr direct_den = 1;
+    for (int i = 0; i < direct_gprod_assumes_count; i++) {
+        direct_den *= (direct_gprod_assumes_sel[i] * (direct_gprod_assumes[i] + std_gamma - 1) + 1);
+    }
+
+    @gprod_col{reference: gprod, numerator: air_num * direct_num, denominator: air_den * direct_den, result: airgroup.std.gprod.gprod_result};
+
+    gprod * air_den * direct_den === ('gprod * (1 - _L1) + _L1) * air_num * direct_num;
     _L1' * (gprod - airgroup.std.gprod.gprod_result) === 0;
 }
 
@@ -223,17 +277,17 @@ private function piop_gprod_proof() {
 
     use proof.std.gprod;
 
-    expr numerator = 1;
+    expr global_num = 1;
     for (int i = 0; i < direct_gprod_proves_count; i++) {
-        numerator *= (direct_gprod_proves_sel[i] * (direct_gprod_proves[i] + std_gamma - 1) + 1);
+        global_num *= (direct_gprod_proves_sel[i] * (direct_gprod_proves[i] + std_gamma - 1) + 1);
     }
 
-    expr denominator = 1;
+    expr global_den = 1;
     for (int i = 0; i < direct_gprod_assumes_count; i++) {
-        denominator *= (direct_gprod_assumes_sel[i] * (direct_gprod_assumes[i] + std_gamma - 1) + 1);
+        global_den *= (direct_gprod_assumes_sel[i] * (direct_gprod_assumes[i] + std_gamma - 1) + 1);
     }
 
-    gprod * numerator === denominator;
+    gprod * global_num === global_den;
 }
 
 /**

--- a/pil2-components/lib/std/pil/std_sum.pil
+++ b/pil2-components/lib/std/pil/std_sum.pil
@@ -1,17 +1,18 @@
+require "std_constants.pil";
 require "std_tools.pil";
 
 // Note: When name is "isolated" we don't check if the number of columns is the same for all the PIOPs
 
-function sum_assumes(const int name, const int opid, const expr cols[], const expr sel = 1, const int is_direct = 0) {
-    update_piop_sum(name, 0, [opid], opid, sel, cols, is_direct);
+function sum_assumes(const int name, const int opid, const expr cols[], const expr sel = 1, const int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
+    update_piop_sum(name, 0, [opid], opid, sel, cols, direct_type);
 }
 
-function sum_proves(const int name, const int opid, const expr cols[], const expr mul = 1, const int is_direct = 0) {
-    update_piop_sum(name, 1, [opid], opid, mul, cols, is_direct);
+function sum_proves(const int name, const int opid, const expr cols[], const expr mul = 1, const int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
+    update_piop_sum(name, 1, [opid], opid, mul, cols, direct_type);
 }
 
-function sum(const int name, const int opid, const expr cols[], const expr mul = 1, const int is_direct = 0) {
-    update_piop_sum(name, 2, [opid], opid, mul, cols, is_direct);
+function sum(const int name, const int opid, const expr cols[], const expr mul = 1, const int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
+    update_piop_sum(name, 2, [opid], opid, mul, cols, direct_type);
 }
 
 function sum_assumes_dynamic(const int name, const int opid[], const expr sumid, const expr cols[], const expr sel = 1) {
@@ -30,7 +31,7 @@ private function init_proof_containers_sum(int name, int opid[]) {
         expr gsum = 0;
 
         // Direct shortcut to the previous sum
-        int direct_gsum_count = 0;
+        int direct_gsum_nargs = 0;
         expr direct_gsum_s[100];
         expr direct_gsum_e[100];
     }
@@ -56,14 +57,19 @@ private function init_containers_sum(int name, int opid[]) {
         expr gsum_s[100];
         expr gsum_e[100];
         int gsum_t[100]; // Used for optimization
+
+        // Direct shortcut to the previous sum
+        int direct_gsum_nargs = 0;
+        expr direct_gsum_s[100];
+        expr direct_gsum_e[100];
     }
 }
 
-private function initial_checks_sum(int proves, int opid[], expr cols[], int is_direct) {
+private function initial_checks_sum(int proves, int opid[], expr cols[], int direct_type) {
     const int cols_count = length(cols);
 
     for (int i = 0; i < length(opid); i++) {
-        // Assumes and proves of the same opid must have the same number of columns (except for the is_direct case)
+        // Assumes and proves of the same opid must have the same number of columns (except for the direct_type case)
         if (proof.std.gsum.`id${opid[i]}`.cols == 0) {
             // first time called
             proof.std.gsum.`id${opid[i]}`.cols = cols_count;
@@ -71,7 +77,7 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int is_
             // add opid on a list to verify at final
             proof.std.gsum.opids[proof.std.gsum.opids_count] = opid[i];
             proof.std.gsum.opids_count++;
-        } else if (!is_direct && cols_count != proof.std.gsum.`id${opid[i]}`.cols) {
+        } else if (direct_type == PIOP_DIRECT_TYPE_DEFAULT && cols_count != proof.std.gsum.`id${opid[i]}`.cols) {
             const int expected_cols = proof.std.gsum.`id${opid[i]}`.cols;
             error(`The number of columns of PIOP #${opid[i]} must be ${expected_cols} but was ${cols_count}`);
         }
@@ -100,7 +106,7 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int is_
  * @param sel selector of the PIOP
  * @param cols columns of the PIOP
  */
-private function update_piop_sum(int name, int proves, int opid[], expr sumid, expr sel, expr cols[], int is_direct = 0) {
+private function update_piop_sum(int name, int proves, int opid[], expr sumid, expr sel, expr cols[], int direct_type = PIOP_DIRECT_TYPE_DEFAULT) {
     const int cols_count = length(cols);
     if (cols_count < 1) {
         string side = proves ? "proves" : "assumes";
@@ -109,9 +115,11 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
 
     init_proof_containers_sum(name, opid);
 
-    if (!is_direct) {
+    if (direct_type == PIOP_DIRECT_TYPE_AIR || direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
         init_containers_sum(name, opid);
+    }
 
+    if (direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
         // Create debug hints for the witness computation
         const int ncols = length(cols);
         string name_cols[ncols];
@@ -122,42 +130,60 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
         @gsum_member_data{name_piop: get_piop_name(name), names: name_cols, sumid: sumid, proves: proves == 2 ? sel : proves, selector: sel, references: cols};
     }
 
-    initial_checks_sum(proves, opid, cols, is_direct);
+    initial_checks_sum(proves, opid, cols, direct_type);
 
     init_challenges();
 
     // selected vector to simple column reduction
     expr cols_compressed = compress_cols(sumid, cols);
 
-    if (is_direct) {
-        use proof.std.gsum;
+    switch (direct_type) {
+        case PIOP_DIRECT_TYPE_GLOBAL:
+            gsum_update_global_constraint_data(proves, sel, cols_compressed);
+        case PIOP_DIRECT_TYPE_AIR, PIOP_DIRECT_TYPE_DEFAULT:
+            gsum_update_air_constraint_data(proves, sel, cols_compressed, direct_type);
+        default:
+            error("Invalid direct_type: ${direct_type}");
+    }
 
-        direct_gsum_s[direct_gsum_count] = proves ? sel : 0-sel;
-        direct_gsum_e[direct_gsum_count] = cols_compressed;
-        direct_gsum_count++;
+    // Update global constraints
+    on final proof piop_gsum_proof();
+}
+
+private function gsum_update_global_constraint_data(int proves, expr sel, expr cols_compressed) {
+    use proof.std.gsum;
+
+    direct_gsum_s[direct_gsum_nargs] = proves ? sel : 0 - sel;
+    direct_gsum_e[direct_gsum_nargs] = cols_compressed;
+    direct_gsum_nargs++;
+}
+
+private function gsum_update_air_constraint_data(int proves, expr sel, expr cols_compressed, int direct_type) {
+    use air.std.gsum;
+
+    if (direct_type == PIOP_DIRECT_TYPE_AIR) {
+        direct_gsum_s[direct_gsum_nargs] = proves ? sel : 0 - sel;
+        direct_gsum_e[direct_gsum_nargs] = cols_compressed;
+        direct_gsum_nargs++;
     } else {
-        use air.std.gsum;
-
-        gsum_s[gsum_nargs] = proves ? sel : 0-sel;
+        gsum_s[gsum_nargs] = proves ? sel : 0 - sel;
         gsum_e[gsum_nargs] = cols_compressed;
         gsum_t[gsum_nargs] = proves;
         gsum_nargs++;
 
+        // Additional processing for air constraints
         // TODO: Uncomment when expression comparison is implemented
         // on final air find_repeated_proves();
-
-        // define constraints at the air level
-        on final air piop_gsum_air();
-
-        // update the contributions at the airgroup level
-        on final airgroup piop_gsum_airgroup();
 
         // at the end, check consistency of all the opids
         on final proof check_opids_were_completed_sum();
     }
 
-    // adds the global constraint
-    on final proof piop_gsum_proof();
+    // Define and update constraints at the air level
+    on final air piop_gsum_air();
+
+    // Define and update constraints at the airgroup level
+    on final airgroup piop_gsum_airgroup();
 }
 
 /**
@@ -215,7 +241,7 @@ private function piop_gsum_air(const int blowupFactor = 2) {
         }
     }
 
-    expr sumIms = 0;
+    expr sum_ims = 0;
     if (low_degree_len > 0) {
         // Group terms in clusters so that the degree of the constraint
         // is lower than the maximum allowed
@@ -252,7 +278,7 @@ private function piop_gsum_air(const int blowupFactor = 2) {
             //                    mul[3*i]*t[3*i+1]*t[3*i+2] + mul[3*i+1]*t[3*i]*t[3*i+2] + mul[3*i+2]*t[3*i]*t[3*i+1];
             im[i] * prods === sums;
 
-            sumIms += im[i];
+            sum_ims += im[i];
         }
 
         const int nRemTerms = low_degree_len % blowupFactor;
@@ -276,7 +302,7 @@ private function piop_gsum_air(const int blowupFactor = 2) {
 
             im_extra * prods === sums;
 
-            sumIms += im_extra;
+            sum_ims += im_extra;
         }
     }
 
@@ -295,13 +321,37 @@ private function piop_gsum_air(const int blowupFactor = 2) {
             @im_col{reference: im_high_degree[i], numerator: gsum_s[index], denominator: gsum_e[index] + std_gamma};
 
             im_high_degree[i] * (gsum_e[index] + std_gamma) === gsum_s[index];
-            sumIms += im_high_degree[i];
+            sum_ims += im_high_degree[i];
         }
     }
 
-    @gsum_col{reference: gsum, expression: sumIms, result: airgroup.std.gsum.gsum_result};
+    /*
+     At this point, the constraint has been transformed to:
+          gsum === 'gsum * (1 - L1) + ∑ᵢ imᵢ
 
-    gsum === 'gsum * (1 - __L1) + sumIms;
+     Now, we whould add the direct terms to the constraint:
+          gsum === 'gsum * (1 - L1) + ∑ᵢ imᵢ + ∑ⱼ sⱼ / (eⱼ + ɣ)
+     where both sⱼ and eⱼ are field elements, for all j.
+
+     We rewrite it as:
+          (gsum - 'gsum * (1 - L1) - ∑ᵢ imᵢ)·∏ⱼ (eⱼ + ɣ) - ∑ⱼ sⱼ · ∏ₖ≠ⱼ (eₖ + ɣ)  === 0
+    */
+
+    expr direct_num = 0;
+    expr direct_den = 1;
+    for (int i = 0; i < direct_gsum_nargs; i++) {
+        direct_den *= (direct_gsum_e[i] + std_gamma);
+
+        expr _tmp = direct_gsum_s[i];
+        for (int j = 0; j < direct_gsum_nargs; j++) {
+            if (j != i) tmp *= (direct_gsum_e[j] + std_gamma);
+        }
+        direct_num += _tmp;
+    }
+
+    @gsum_col{reference: gsum, direct_num: direct_num, direct_den: direct_den, sum_ims: sum_ims, result: airgroup.std.gsum.gsum_result};
+
+    (gsum - 'gsum * (1 - __L1) - sum_ims) * direct_den - direct_num === 0;
     __L1' * (gsum - airgroup.std.gsum.gsum_result) === 0;
 }
 
@@ -338,19 +388,19 @@ private function piop_gsum_proof() {
     // Note: We cannot update this constraint directly if some of the elements
     //       are not globally defined: constants, public inputs, airgroupvalues, ...
 
-    expr LHS = 1;
-    expr RHS = 0;
-    for (int i = 0; i < direct_gsum_count; i++) {
-        LHS *= (direct_gsum_e[i] + std_gamma);
+    expr global_num = 0;
+    expr global_den = 1;
+    for (int i = 0; i < direct_gsum_nargs; i++) {
+        global_den *= (direct_gsum_e[i] + std_gamma);
 
         expr tmp = direct_gsum_s[i];
-        for (int j = 0; j < direct_gsum_count; j++) {
+        for (int j = 0; j < direct_gsum_nargs; j++) {
             if (j != i) tmp *= (direct_gsum_e[j] + std_gamma);
         }
-        RHS += tmp;
+        global_num += tmp;
     }
 
-    gsum * LHS + RHS === 0;
+    gsum * global_den + global_num === 0;
 }
 
 /**

--- a/pil2-components/lib/std/rs/src/std_prod.rs
+++ b/pil2-components/lib/std/rs/src/std_prod.rs
@@ -234,6 +234,7 @@ impl<F: PrimeField> WitnessComponent<F> for StdProd<F> {
                         "denominator",
                         HintFieldOptions::default(),
                         HintFieldOptions::inverse(),
+                        false,
                     );
 
                     air_instance.set_commit_calculated(pol_id as usize);

--- a/pil2-components/lib/std/rs/src/std_sum.rs
+++ b/pil2-components/lib/std/rs/src/std_sum.rs
@@ -14,8 +14,8 @@ use log::debug;
 use proofman::{WitnessComponent, WitnessManager};
 use proofman_common::{AirInstance, ExecutionCtx, ProofCtx, SetupCtx};
 use proofman_hints::{
-    format_vec, get_hint_field, get_hint_field_a, get_hint_ids_by_name, mul_hint_fields, set_hint_field,
-    set_hint_field_val, HintFieldOptions, HintFieldOutput,
+    format_vec, get_hint_field, get_hint_field_a, get_hint_ids_by_name, mul_hint_fields, acc_mul_add_hint_fields,
+    HintFieldOptions, HintFieldOutput,
 };
 
 use crate::{Decider, StdMode, ModeName};
@@ -258,47 +258,25 @@ impl<F: PrimeField> WitnessComponent<F> for StdSum<F> {
                     // This call accumulates "expression" into "reference" expression and stores its last value to "result"
                     // Alternatively, this could be done using get_hint_field and set_hint_field methods and doing the accumulation in Rust,
                     // TODO: GENERALIZE CALLS
-                    let direct_num = get_hint_field::<F>(
-                        &sctx,
-                        &pctx,
-                        air_instance,
-                        gsum_hint,
-                        "direct_num",
-                        HintFieldOptions::default(),
-                    );
-                    let direct_den = get_hint_field::<F>(
-                        &sctx,
-                        &pctx,
-                        air_instance,
-                        gsum_hint,
-                        "direct_den",
-                        HintFieldOptions::inverse(),
-                    );
-                    let sum_ims = get_hint_field::<F>(
-                        &sctx,
-                        &pctx,
-                        air_instance,
-                        gsum_hint,
-                        "sum_ims",
-                        HintFieldOptions::default(),
-                    );
-                    let mut gsum = get_hint_field::<F>(
+
+                    let (pol_id, airgroupvalue_id) = acc_mul_add_hint_fields::<F>(
                         &sctx,
                         &pctx,
                         air_instance,
                         gsum_hint,
                         "reference",
+                        "result",
+                        "direct_num",
+                        "direct_den",
+                        "sum_ims",
                         HintFieldOptions::default(),
+                        HintFieldOptions::inverse(),
+                        HintFieldOptions::default(),
+                        true,
                     );
-                    gsum.set(0, direct_num.get(0) * direct_den.get(0) + sum_ims.get(0));
-                    for i in 1..num_rows {
-                        gsum.set(i, gsum.get(i - 1) + direct_num.get(i) * direct_den.get(i) + sum_ims.get(i));
-                    }
 
-                    let result = gsum.get(num_rows - 1);
-
-                    set_hint_field::<F>(&sctx, air_instance, gsum_hint as u64, "reference", &gsum);
-                    set_hint_field_val::<F>(&sctx, air_instance, gsum_hint as u64, "result", result);
+                    air_instance.set_commit_calculated(pol_id as usize);
+                    air_instance.set_airgroupvalue_calculated(airgroupvalue_id as usize);
                 }
             }
         }

--- a/pil2-components/lib/std/rs/src/std_sum.rs
+++ b/pil2-components/lib/std/rs/src/std_sum.rs
@@ -14,8 +14,8 @@ use log::debug;
 use proofman::{WitnessComponent, WitnessManager};
 use proofman_common::{AirInstance, ExecutionCtx, ProofCtx, SetupCtx};
 use proofman_hints::{
-    acc_hint_field, format_vec, get_hint_field, get_hint_field_a, get_hint_ids_by_name, mul_hint_fields,
-    HintFieldOptions, HintFieldOutput,
+    format_vec, get_hint_field, get_hint_field_a, get_hint_ids_by_name, mul_hint_fields, set_hint_field,
+    set_hint_field_val, HintFieldOptions, HintFieldOutput,
 };
 
 use crate::{Decider, StdMode, ModeName};
@@ -258,11 +258,47 @@ impl<F: PrimeField> WitnessComponent<F> for StdSum<F> {
                     // This call accumulates "expression" into "reference" expression and stores its last value to "result"
                     // Alternatively, this could be done using get_hint_field and set_hint_field methods and doing the accumulation in Rust,
                     // TODO: GENERALIZE CALLS
-                    let (pol_id, airgroupvalue_id) =
-                        acc_hint_field::<F>(&sctx, &pctx, air_instance, gsum_hint, "reference", "result", "expression");
+                    let direct_num = get_hint_field::<F>(
+                        &sctx,
+                        &pctx,
+                        air_instance,
+                        gsum_hint,
+                        "direct_num",
+                        HintFieldOptions::default(),
+                    );
+                    let direct_den = get_hint_field::<F>(
+                        &sctx,
+                        &pctx,
+                        air_instance,
+                        gsum_hint,
+                        "direct_den",
+                        HintFieldOptions::inverse(),
+                    );
+                    let sum_ims = get_hint_field::<F>(
+                        &sctx,
+                        &pctx,
+                        air_instance,
+                        gsum_hint,
+                        "sum_ims",
+                        HintFieldOptions::default(),
+                    );
+                    let mut gsum = get_hint_field::<F>(
+                        &sctx,
+                        &pctx,
+                        air_instance,
+                        gsum_hint,
+                        "reference",
+                        HintFieldOptions::default(),
+                    );
+                    gsum.set(0, direct_num.get(0) * direct_den.get(0) + sum_ims.get(0));
+                    for i in 1..num_rows {
+                        gsum.set(i, gsum.get(i - 1) + direct_num.get(i) * direct_den.get(i) + sum_ims.get(i));
+                    }
 
-                    air_instance.set_commit_calculated(pol_id as usize);
-                    air_instance.set_airgroupvalue_calculated(airgroupvalue_id as usize);
+                    let result = gsum.get(num_rows - 1);
+
+                    set_hint_field::<F>(&sctx, air_instance, gsum_hint as u64, "reference", &gsum);
+                    set_hint_field_val::<F>(&sctx, air_instance, gsum_hint as u64, "result", result);
                 }
             }
         }

--- a/pil2-components/test/README.md
+++ b/pil2-components/test/README.md
@@ -11,6 +11,7 @@ mkdir -p ./pil2-components/test/simple/build/ \
 && node ../pil2-proofman-js/src/main_setup.js \
      -a ./pil2-components/test/simple/build/build.pilout \
      -b ./pil2-components/test/simple/build \
+     -t ./pil2-stark/build/bctree \
 && cargo run --bin proofman-cli pil-helpers \
      --pilout ./pil2-components/test/simple/build/build.pilout \
      --path ./pil2-components/test/simple/rs/src -o \
@@ -35,6 +36,7 @@ mkdir -p ./pil2-components/test/std/connection/build/ \
 && node ../pil2-proofman-js/src/main_setup.js \
      -a ./pil2-components/test/std/connection/build/build.pilout \
      -b ./pil2-components/test/std/connection/build \
+     -t ./pil2-stark/build/bctree \
 && cargo run --bin proofman-cli pil-helpers \
      --pilout ./pil2-components/test/std/connection/build/build.pilout \
      --path ./pil2-components/test/std/connection/rs/src -o \
@@ -59,6 +61,7 @@ mkdir -p ./pil2-components/test/std/lookup/build/ \
 && node ../pil2-proofman-js/src/main_setup.js \
      -a ./pil2-components/test/std/lookup/build/build.pilout \
      -b ./pil2-components/test/std/lookup/build \
+     -t ./pil2-stark/build/bctree \
 && cargo run --bin proofman-cli pil-helpers \
      --pilout ./pil2-components/test/std/lookup/build/build.pilout \
      --path ./pil2-components/test/std/lookup/rs/src -o \
@@ -83,6 +86,7 @@ mkdir -p ./pil2-components/test/std/permutation/build/ \
 && node ../pil2-proofman-js/src/main_setup.js \
      -a ./pil2-components/test/std/permutation/build/build.pilout \
      -b ./pil2-components/test/std/permutation/build \
+     -t ./pil2-stark/build/bctree \
 && cargo run --bin proofman-cli pil-helpers \
      --pilout ./pil2-components/test/std/permutation/build/build.pilout \
      --path ./pil2-components/test/std/permutation/rs/src -o \
@@ -107,6 +111,7 @@ mkdir -p ./pil2-components/test/std/range_check/build/ \
 && node ../pil2-proofman-js/src/main_setup.js \
      -a ./pil2-components/test/std/range_check/build/build.pilout \
      -b ./pil2-components/test/std/range_check/build \
+     -t ./pil2-stark/build/bctree \
 && cargo run --bin proofman-cli pil-helpers \
      --pilout ./pil2-components/test/std/range_check/build/build.pilout \
      --path ./pil2-components/test/std/range_check/rs/src -o \

--- a/pil2-components/test/simple/rs/src/simple_left.rs
+++ b/pil2-components/test/simple/rs/src/simple_left.rs
@@ -80,8 +80,7 @@ where
             let num_rows = pctx.pilout.get_air(airgroup_id, air_id).num_rows();
 
             // I cannot, programatically, link the permutation trace with its air_id
-            let mut trace =
-                SimpleLeftTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = SimpleLeftTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // Assumes
             for i in 0..num_rows {

--- a/pil2-components/test/simple/rs/src/simple_right.rs
+++ b/pil2-components/test/simple/rs/src/simple_right.rs
@@ -77,8 +77,7 @@ where
             let num_rows = pctx.pilout.get_air(airgroup_id, air_id).num_rows();
 
             // I cannot, programatically, link the permutation trace with its air_id
-            let mut trace =
-                SimpleRightTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = SimpleRightTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // Proves
             for i in 0..num_rows {

--- a/pil2-components/test/std/connection/rs/src/connection1.rs
+++ b/pil2-components/test/std/connection/rs/src/connection1.rs
@@ -81,8 +81,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(CONNECTION_AIRGROUP_ID, CONNECTION_1_AIR_IDS[0]).num_rows();
-            let mut trace =
-            Connection1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Connection1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             for i in 0..num_rows {
                 trace[i].a = rng.gen();

--- a/pil2-components/test/std/connection/rs/src/connection2.rs
+++ b/pil2-components/test/std/connection/rs/src/connection2.rs
@@ -81,8 +81,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(CONNECTION_AIRGROUP_ID, CONNECTION_2_AIR_IDS[0]).num_rows();
-            let mut trace =
-            Connection2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Connection2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             for i in 0..num_rows {
                 trace[i].a = rng.gen();

--- a/pil2-components/test/std/lookup/rs/src/lookup0.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup0.rs
@@ -74,8 +74,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_0_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup0Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup0Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let num_lookups = trace[0].sel.len();
 

--- a/pil2-components/test/std/lookup/rs/src/lookup1.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup1.rs
@@ -74,8 +74,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_1_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let num_lookups = trace[0].sel.len();
 

--- a/pil2-components/test/std/lookup/rs/src/lookup2_12.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup2_12.rs
@@ -77,8 +77,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_2_12_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup2_12Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup2_12Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to lookup3
             //       and consequently add random selectors

--- a/pil2-components/test/std/lookup/rs/src/lookup2_13.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup2_13.rs
@@ -77,8 +77,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_2_13_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup2_13Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup2_13Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to lookup3
             //       and consequently add random selectors

--- a/pil2-components/test/std/lookup/rs/src/lookup2_15.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup2_15.rs
@@ -77,8 +77,7 @@ where
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_2_15_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup2_15Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup2_15Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to lookup3
             //       and consequently add random selectors

--- a/pil2-components/test/std/lookup/rs/src/lookup3.rs
+++ b/pil2-components/test/std/lookup/rs/src/lookup3.rs
@@ -65,8 +65,7 @@ impl<F: PrimeField + Copy> WitnessComponent<F> for Lookup3<F> {
             let buffer = &mut air_instance.buffer;
 
             let num_rows = pctx.pilout.get_air(LOOKUP_AIRGROUP_ID, LOOKUP_3_AIR_IDS[0]).num_rows();
-            let mut trace =
-                Lookup3Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = Lookup3Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             for i in 0..num_rows {
                 trace[i].c1 = F::from_canonical_usize(i);

--- a/pil2-components/test/std/permutation/rs/src/permutation1_6.rs
+++ b/pil2-components/test/std/permutation/rs/src/permutation1_6.rs
@@ -93,8 +93,7 @@ where
 
             // I cannot, programatically, link the permutation trace with its air_id
             let mut trace =
-                Permutation1_6Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                Permutation1_6Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to permutation2
             //       and consequently add random selectors

--- a/pil2-components/test/std/permutation/rs/src/permutation1_7.rs
+++ b/pil2-components/test/std/permutation/rs/src/permutation1_7.rs
@@ -83,8 +83,7 @@ where
 
             // I cannot, programatically, link the permutation trace with its air_id
             let mut trace =
-                Permutation1_7Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                Permutation1_7Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to permutation2
             //       and consequently add random selectors

--- a/pil2-components/test/std/permutation/rs/src/permutation1_8.rs
+++ b/pil2-components/test/std/permutation/rs/src/permutation1_8.rs
@@ -83,8 +83,7 @@ where
 
             // I cannot, programatically, link the permutation trace with its air_id
             let mut trace =
-                Permutation1_8Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                Permutation1_8Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // TODO: Add the ability to send inputs to permutation2
             //       and consequently add random selectors

--- a/pil2-components/test/std/permutation/rs/src/permutation2.rs
+++ b/pil2-components/test/std/permutation/rs/src/permutation2.rs
@@ -73,8 +73,7 @@ impl<F: PrimeField + Copy> WitnessComponent<F> for Permutation2<F> {
 
             let num_rows = pctx.pilout.get_air(airgroup_id, air_id).num_rows();
             let mut trace =
-                Permutation2_6Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                Permutation2_6Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             // Note: Here it is assumed that num_rows of permutation2 is equal to
             //       the sum of num_rows of each variant of permutation1.

--- a/pil2-components/test/std/range_check/rs/src/multi_range_check1.rs
+++ b/pil2-components/test/std/range_check/rs/src/multi_range_check1.rs
@@ -88,8 +88,7 @@ where
             let num_rows =
                 pctx.pilout.get_air(MULTI_RANGE_CHECK_1_AIRGROUP_ID, MULTI_RANGE_CHECK_1_AIR_IDS[0]).num_rows();
             let mut trace =
-                MultiRangeCheck1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                MultiRangeCheck1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 7) - 1), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/multi_range_check2.rs
+++ b/pil2-components/test/std/range_check/rs/src/multi_range_check2.rs
@@ -88,8 +88,7 @@ where
             let num_rows =
                 pctx.pilout.get_air(MULTI_RANGE_CHECK_2_AIRGROUP_ID, MULTI_RANGE_CHECK_2_AIR_IDS[0]).num_rows();
             let mut trace =
-                MultiRangeCheck2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                MultiRangeCheck2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(1 << 5), BigInt::from((1 << 8) - 1), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(1 << 8), BigInt::from((1 << 9) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/std/range_check/rs/src/pil_helpers/traces.rs
@@ -50,3 +50,5 @@ trace!(U8AirRow, U8AirTrace<F> {
 trace!(SpecifiedRangesRow, SpecifiedRangesTrace<F> {
  mul: [F; 20],
 });
+
+

--- a/pil2-components/test/std/range_check/rs/src/range_check1.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check1.rs
@@ -77,8 +77,7 @@ where
             let mut buffer = vec![F::zero(); buffer_size as usize];
 
             let num_rows = pctx.pilout.get_air(RANGE_CHECK_1_AIRGROUP_ID, RANGE_CHECK_1_AIR_IDS[0]).num_rows();
-            let mut trace =
-                RangeCheck1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = RangeCheck1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 4) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/range_check2.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check2.rs
@@ -77,8 +77,7 @@ where
             let mut buffer = vec![F::zero(); buffer_size as usize];
 
             let num_rows = pctx.pilout.get_air(RANGE_CHECK_2_AIRGROUP_ID, RANGE_CHECK_2_AIR_IDS[0]).num_rows();
-            let mut trace =
-                RangeCheck2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = RangeCheck2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 9) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/range_check3.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check3.rs
@@ -77,8 +77,7 @@ where
             let mut buffer = vec![F::zero(); buffer_size as usize];
 
             let num_rows = pctx.pilout.get_air(RANGE_CHECK_3_AIRGROUP_ID, RANGE_CHECK_3_AIR_IDS[0]).num_rows();
-            let mut trace =
-                RangeCheck3Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = RangeCheck3Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 4) - 1), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/range_check4.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check4.rs
@@ -78,8 +78,7 @@ where
             let mut buffer = vec![F::zero(); buffer_size as usize];
 
             let num_rows = pctx.pilout.get_air(RANGE_CHECK_4_AIRGROUP_ID, RANGE_CHECK_4_AIR_IDS[0]).num_rows();
-            let mut trace =
-                RangeCheck4Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
+            let mut trace = RangeCheck4Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 16) - 1), Some(true));
             let range2 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(true));

--- a/pil2-components/test/std/range_check/rs/src/range_check_dynamic1.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check_dynamic1.rs
@@ -90,12 +90,8 @@ where
 
             let num_rows =
                 pctx.pilout.get_air(RANGE_CHECK_DYNAMIC_1_AIRGROUP_ID, RANGE_CHECK_DYNAMIC_1_AIR_IDS[0]).num_rows();
-            let mut trace = RangeCheckDynamic1Trace::map_buffer(
-                buffer.as_mut_slice(),
-                num_rows,
-                offsets[0] as usize,
-            )
-            .unwrap();
+            let mut trace =
+                RangeCheckDynamic1Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range7 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 7) - 1), Some(false));
             let range8 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/range_check_dynamic2.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check_dynamic2.rs
@@ -91,12 +91,8 @@ where
 
             let num_rows =
                 pctx.pilout.get_air(RANGE_CHECK_DYNAMIC_2_AIRGROUP_ID, RANGE_CHECK_DYNAMIC_2_AIR_IDS[0]).num_rows();
-            let mut trace = RangeCheckDynamic2Trace::map_buffer(
-                buffer.as_mut_slice(),
-                num_rows,
-                offsets[0] as usize,
-            )
-            .unwrap();
+            let mut trace =
+                RangeCheckDynamic2Trace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(5225), BigInt::from(29023), Some(false));
             let range2 = self.std_lib.get_range(BigInt::from(-8719), BigInt::from(-7269), Some(false));

--- a/pil2-components/test/std/range_check/rs/src/range_check_mix.rs
+++ b/pil2-components/test/std/range_check/rs/src/range_check_mix.rs
@@ -83,8 +83,7 @@ where
 
             let num_rows = pctx.pilout.get_air(RANGE_CHECK_MIX_AIRGROUP_ID, RANGE_CHECK_MIX_AIR_IDS[0]).num_rows();
             let mut trace =
-                RangeCheckMixTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize)
-                    .unwrap();
+                RangeCheckMixTrace::map_buffer(buffer.as_mut_slice(), num_rows, offsets[0] as usize).unwrap();
 
             let range1 = self.std_lib.get_range(BigInt::from(0), BigInt::from((1 << 8) - 1), None);
             let range2 = self.std_lib.get_range(BigInt::from(50), BigInt::from((1 << 7) - 1), None);

--- a/pil2-components/test/std/special/direct_update.pil
+++ b/pil2-components/test/std/special/direct_update.pil
@@ -6,18 +6,31 @@ const int OP_BUS_ID1 = 100;
 const int OPID1 = 333;
 public input1[10];
 
-airtemplate DirectUpdatePermutation(const int N = 2**4) {
+airtemplate DirectUpdatePermutationAir(const int N = 2**4) {
     col witness a[2],b[2],c[2];
     col witness flag;
     col witness perform_operation;
+
+    airval d[6];
+
+    direct_update(OP_BUS_ID1, [OPID1, ...d, 0], proves: 0, bus_type: PIOP_BUS_PROD);
+
     permutation_proves(OP_BUS_ID1, [OPID1, ...a, ...b, ...c, flag], sel: perform_operation, bus_type: PIOP_BUS_PROD);
 }
 
-airgroup Permutation {
-    DirectUpdatePermutation();
+airtemplate DirectUpdatePermutationGlobal(const int N = 2**4) {
+    col witness a[2],b[2],c[2];
+    col witness flag;
+    col witness perform_operation;
+    permutation_assumes(OP_BUS_ID1, [OPID1, ...a, ...b, ...c, flag], sel: perform_operation, bus_type: PIOP_BUS_PROD);
+}
 
+airgroup Permutation {
+    DirectUpdatePermutationAir();
+
+    DirectUpdatePermutationGlobal();
     for (int i = 0; i < length(input1)/2; i++) {
-        direct_update(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], proves: 0, bus_type: PIOP_BUS_PROD);
+        direct_update(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], proves: 1, bus_type: PIOP_BUS_PROD);
     }
 }
 
@@ -25,19 +38,33 @@ const int OP_BUS_ID2 = 200;
 const int OPID2 = 444;
 public input2[20];
 
-airtemplate DirectUpdateLookup(const int N = 2**5) {
+airtemplate DirectUpdateLookupAir(const int N = 2**5) {
     col witness a[2],b[2],c[2];
     col witness flag;
     col witness perform_operation;
+
+    airval d[6];
+
     lookup_assumes(OP_BUS_ID2, [OPID2, ...a, ...b, ...c, flag], sel: perform_operation);
+
+    direct_update(OP_BUS_ID2, [OPID2, ...d, 0]);
+}
+
+airtemplate DirectUpdateLookupGlobal(const int N = 2**5) {
+    col witness a[2],b[2],c[2];
+    col witness flag;
+    col witness perform_operation;
+    lookup_proves(OP_BUS_ID2, [OPID2, ...a, ...b, ...c, flag], mul: perform_operation);
 }
 
 airgroup Lookup {
+    DirectUpdateLookupAir();
+
     for (int i = 0; i < length(input2)/2; i++) {
-        direct_update(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0])
+        direct_update(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0], proves: 0);
     }
 
-    DirectUpdateLookup();
+    DirectUpdateLookupGlobal();
 }
 
 // TODO: Do an example with multiple elements in the direct_update

--- a/pil2-components/test/std/special/direct_update.pil
+++ b/pil2-components/test/std/special/direct_update.pil
@@ -13,7 +13,7 @@ airtemplate DirectUpdatePermutationAir(const int N = 2**4) {
 
     airval d[6];
 
-    direct_update(OP_BUS_ID1, [OPID1, ...d, 0], proves: 0, bus_type: PIOP_BUS_PROD);
+    direct_update_assumes(OP_BUS_ID1, [OPID1, ...d, 0], bus_type: PIOP_BUS_PROD);
 
     permutation_proves(OP_BUS_ID1, [OPID1, ...a, ...b, ...c, flag], sel: perform_operation, bus_type: PIOP_BUS_PROD);
 }
@@ -30,7 +30,7 @@ airgroup Permutation {
 
     DirectUpdatePermutationGlobal();
     for (int i = 0; i < length(input1)/2; i++) {
-        direct_update(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], proves: 1, bus_type: PIOP_BUS_PROD);
+        direct_update_proves(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], bus_type: PIOP_BUS_PROD);
     }
 }
 
@@ -47,7 +47,7 @@ airtemplate DirectUpdateLookupAir(const int N = 2**5) {
 
     lookup_assumes(OP_BUS_ID2, [OPID2, ...a, ...b, ...c, flag], sel: perform_operation);
 
-    direct_update(OP_BUS_ID2, [OPID2, ...d, 0]);
+    direct_update_proves(OP_BUS_ID2, [OPID2, ...d, 0]);
 }
 
 airtemplate DirectUpdateLookupGlobal(const int N = 2**5) {
@@ -61,7 +61,7 @@ airgroup Lookup {
     DirectUpdateLookupAir();
 
     for (int i = 0; i < length(input2)/2; i++) {
-        direct_update(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0], proves: 0);
+        direct_update_assumes(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0]);
     }
 
     DirectUpdateLookupGlobal();

--- a/pil2-stark/lib/include/starks_lib.h
+++ b/pil2-stark/lib/include/starks_lib.h
@@ -62,8 +62,9 @@
     // ========================================================================================
     void *get_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char* hintFieldName, void* hintOptions);
     uint64_t mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldName1, char *hintFieldName2, void* hintOptions1, void *hintOptions2); 
-    void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName);
-    void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2,  void* hintOptions1, void *hintOptions2);
+    void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName, bool add);
+    void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2,  void* hintOptions1, void *hintOptions2, bool add);
+    void *acc_mul_add_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2, char *hintFieldName3, void* hintOptions1, void *hintOptions2, void *hintOptions3, bool add);
     uint64_t set_hint_field(void *pSetupCtx, void* stepsParams, void *values, uint64_t hintId, char* hintFieldName);
 
     // Starks

--- a/pil2-stark/src/api/starks_api.cpp
+++ b/pil2-stark/src/api/starks_api.cpp
@@ -317,12 +317,16 @@ uint64_t mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, ch
     return multiplyHintFields(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldName1), string(hintFieldName2), *(HintFieldOptions *)hintOptions1,  *(HintFieldOptions *)hintOptions2);
 }
 
-void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName) {
-    return new VecU64Result(accHintField(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldNameAirgroupVal), string(hintFieldName)));
+void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName, bool add) {
+    return new VecU64Result(accHintField(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldNameAirgroupVal), string(hintFieldName), add));
 }
 
-void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2, void* hintOptions1, void *hintOptions2) {
-    return new VecU64Result(accMulHintFields(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldNameAirgroupVal), string(hintFieldName1), string(hintFieldName2),*(HintFieldOptions *)hintOptions1,  *(HintFieldOptions *)hintOptions2));
+void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2, void* hintOptions1, void *hintOptions2, bool add) {
+    return new VecU64Result(accMulHintFields(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldNameAirgroupVal), string(hintFieldName1), string(hintFieldName2),*(HintFieldOptions *)hintOptions1,  *(HintFieldOptions *)hintOptions2, add));
+}
+
+void *acc_mul_add_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2, char *hintFieldName3, void* hintOptions1, void *hintOptions2, void *hintOptions3, bool add) {
+    return new VecU64Result(accMulAddHintFields(*(SetupCtx *)pSetupCtx, *(StepsParams *)stepsParams, hintId, string(hintFieldNameDest), string(hintFieldNameAirgroupVal), string(hintFieldName1), string(hintFieldName2), string(hintFieldName3),*(HintFieldOptions *)hintOptions1,  *(HintFieldOptions *)hintOptions2, *(HintFieldOptions *)hintOptions3, add));
 }
 
 

--- a/pil2-stark/src/api/starks_api.hpp
+++ b/pil2-stark/src/api/starks_api.hpp
@@ -62,8 +62,9 @@
     // ========================================================================================
     void *get_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char* hintFieldName, void* hintOptions);
     uint64_t mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldName1, char *hintFieldName2, void* hintOptions1, void *hintOptions2); 
-    void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName);
-    void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2,  void* hintOptions1, void *hintOptions2);
+    void *acc_hint_field(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName, bool add);
+    void *acc_mul_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2,  void* hintOptions1, void *hintOptions2, bool add);
+    void *acc_mul_add_hint_fields(void *pSetupCtx, void* stepsParams, uint64_t hintId, char *hintFieldNameDest, char *hintFieldNameAirgroupVal, char *hintFieldName1, char *hintFieldName2, char *hintFieldName3, void* hintOptions1, void *hintOptions2, void *hintOptions3, bool add);
     uint64_t set_hint_field(void *pSetupCtx, void* stepsParams, void *values, uint64_t hintId, char* hintFieldName);
 
     // Starks

--- a/pil2-stark/src/starkpil/expressions_avx.hpp
+++ b/pil2-stark/src/starkpil/expressions_avx.hpp
@@ -220,7 +220,7 @@ public:
                     Goldilocks::copy_avx(vals3[2], destVals[i][2]);
                     dim = FIELD_EXTENSION;
                 }
-            } else if(dests[i].params.size() == 2) {
+            } else if(dests[i].params.size() == 2 || dests[i].params.size() == 3) {
                 if(dests[i].params[0].dim == FIELD_EXTENSION && dests[i].params[1].dim == FIELD_EXTENSION) {
                     Goldilocks3::op_avx(2, (Goldilocks3::Element_avx &)vals3, (Goldilocks3::Element_avx &)destVals[i][0], (Goldilocks3::Element_avx &)destVals[i][FIELD_EXTENSION]);
                     dim = FIELD_EXTENSION;
@@ -234,8 +234,24 @@ public:
                     Goldilocks::op_avx(2, vals1, destVals[i][0], destVals[i][FIELD_EXTENSION]);
                     dim = 1;
                 }
+
+                if(dests[i].params.size() == 3) {
+                    if(dim == FIELD_EXTENSION && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_avx(0, (Goldilocks3::Element_avx &)vals3, (Goldilocks3::Element_avx &)vals3, (Goldilocks3::Element_avx &)destVals[i][2*FIELD_EXTENSION]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == FIELD_EXTENSION && dests[i].params[2].dim == 1) {
+                        Goldilocks3::op_31_avx(0, (Goldilocks3::Element_avx &)vals3, (Goldilocks3::Element_avx &)vals3, destVals[i][2*FIELD_EXTENSION]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == 1 && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_31_avx(0, (Goldilocks3::Element_avx &)vals3, (Goldilocks3::Element_avx &)destVals[i][2*FIELD_EXTENSION], vals1);
+                        dim = FIELD_EXTENSION;
+                    } else {
+                        Goldilocks::op_avx(0, vals1, vals1, destVals[i][2*FIELD_EXTENSION]);
+                        dim = 1;
+                    }
+                }
             } else {
-                zklog.error("Currently only length 1 and 2 are supported");
+                zklog.error("Currently only length 1 and 2 and 3 are supported");
                 exitProcess();
             }
             if(dim == 1) {

--- a/pil2-stark/src/starkpil/expressions_avx512.hpp
+++ b/pil2-stark/src/starkpil/expressions_avx512.hpp
@@ -220,7 +220,7 @@ public:
                     Goldilocks::copy_avx512(vals3[2], destVals[i][2]);
                     dim = FIELD_EXTENSION;
                 }
-            } else if(dests[i].params.size() == 2) {
+            } else if(dests[i].params.size() == 2 || dests[i].params.size() == 3) {
                 if(dests[i].params[0].dim == FIELD_EXTENSION && dests[i].params[1].dim == FIELD_EXTENSION) {
                     Goldilocks3::op_avx512(2, (Goldilocks3::Element_avx512 &)vals3, (Goldilocks3::Element_avx512 &)destVals[i][0], (Goldilocks3::Element_avx512 &)destVals[i][FIELD_EXTENSION]);
                     dim = FIELD_EXTENSION;
@@ -234,8 +234,24 @@ public:
                     Goldilocks::op_avx512(2, vals1, destVals[i][0], destVals[i][FIELD_EXTENSION]);
                     dim = 1;
                 }
+
+                if(dests[i].params.size() == 3) {
+                    if(dim == FIELD_EXTENSION && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_avx512(0, (Goldilocks3::Element_avx512 &)vals3, (Goldilocks3::Element_avx512 &)vals3, (Goldilocks3::Element_avx512 &)destVals[i][2*FIELD_EXTENSION]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == FIELD_EXTENSION && dests[i].params[2].dim == 1) {
+                        Goldilocks3::op_31_avx512(0, (Goldilocks3::Element_avx512 &)vals3, (Goldilocks3::Element_avx512 &)vals3, destVals[i][2*FIELD_EXTENSION]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == 1 && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_31_avx512(0, (Goldilocks3::Element_avx512 &)vals3, (Goldilocks3::Element_avx512 &)destVals[i][2*FIELD_EXTENSION], vals1);
+                        dim = FIELD_EXTENSION;
+                    } else {
+                        Goldilocks::op_avx512(0, vals1, vals1, destVals[i][2*FIELD_EXTENSION]);
+                        dim = 1;
+                    }
+                }
             } else {
-                zklog.error("Currently only length 1 and 2 are supported");
+                zklog.error("Currently only length 1 and 2 and 3 are supported");
                 exitProcess();
             }
             if(dim == 1) {

--- a/pil2-stark/src/starkpil/expressions_ctx.hpp
+++ b/pil2-stark/src/starkpil/expressions_ctx.hpp
@@ -81,12 +81,6 @@ public:
         std::vector<Dest> dests = {destStruct};
         calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, domainSize);
     }
-
-    void multiplyExpressions(StepsParams &params, Dest &dest) {
-        uint64_t domainSize = 1 << setupCtx.starkInfo.starkStruct.nBits;
-        std::vector<Dest> dests = {dest};
-        calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, domainSize);
-    }
 };
 
 #endif

--- a/pil2-stark/src/starkpil/expressions_pack.hpp
+++ b/pil2-stark/src/starkpil/expressions_pack.hpp
@@ -204,7 +204,7 @@ public:
                     Goldilocks::copy_pack(nrowsPack, &vals[nrowsPack], &destVals[i][nrowsPack]);
                     Goldilocks::copy_pack(nrowsPack, &vals[2*nrowsPack], &destVals[i][2*nrowsPack]);
                 }
-            } else if(dests[i].params.size() == 2) {
+            } else if(dests[i].params.size() == 2 || dests[i].params.size() == 3) {
                 if(dests[i].params[0].dim == FIELD_EXTENSION && dests[i].params[1].dim == FIELD_EXTENSION) {
                     Goldilocks3::op_pack(nrowsPack, 2, &vals[0], &destVals[i][0], &destVals[i][FIELD_EXTENSION*nrowsPack]);
                     dim = FIELD_EXTENSION;
@@ -218,8 +218,24 @@ public:
                     Goldilocks::op_pack(nrowsPack, 2, &vals[0], &destVals[i][0], &destVals[i][FIELD_EXTENSION*nrowsPack]);
                     dim = 1;
                 }
+
+                if(dests[i].params.size() == 3) {
+                    if(dim == FIELD_EXTENSION && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_pack(nrowsPack, 0, &vals[0], &vals[0], &destVals[i][2*FIELD_EXTENSION*nrowsPack]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == FIELD_EXTENSION && dests[i].params[2].dim == 1) {
+                        Goldilocks3::op_31_pack(nrowsPack, 0, &vals[0], &vals[0], &destVals[i][2*FIELD_EXTENSION*nrowsPack]);
+                        dim = FIELD_EXTENSION;
+                    } else if(dim == 1 && dests[i].params[2].dim == FIELD_EXTENSION) {
+                        Goldilocks3::op_31_pack(nrowsPack, 0, &vals[0], &destVals[i][2*FIELD_EXTENSION*nrowsPack], &vals[0]);
+                        dim = FIELD_EXTENSION;
+                    } else {
+                        Goldilocks::op_pack(nrowsPack, 0, &vals[0], &vals[0], &destVals[i][2*FIELD_EXTENSION*nrowsPack]);
+                        dim = 1;
+                    }
+                }
             } else {
-                zklog.error("Currently only length 1 and 2 are supported");
+                zklog.error("Currently only length 1 and 2 and 3 are supported");
                 exitProcess();
             }
             if(dim == 1) {

--- a/provers/starks-lib-c/bindings_starks.rs
+++ b/provers/starks-lib-c/bindings_starks.rs
@@ -233,7 +233,7 @@ extern "C" {
     ) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_Z14acc_hint_fieldPvS_mPcS0_S0_"]
+    #[link_name = "\u{1}_Z14acc_hint_fieldPvS_mPcS0_S0_b"]
     pub fn acc_hint_field(
         pSetupCtx: *mut ::std::os::raw::c_void,
         stepsParams: *mut ::std::os::raw::c_void,
@@ -241,10 +241,11 @@ extern "C" {
         hintFieldNameDest: *mut ::std::os::raw::c_char,
         hintFieldNameAirgroupVal: *mut ::std::os::raw::c_char,
         hintFieldName: *mut ::std::os::raw::c_char,
+        add: bool,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_Z19acc_mul_hint_fieldsPvS_mPcS0_S0_S0_S_S_"]
+    #[link_name = "\u{1}_Z19acc_mul_hint_fieldsPvS_mPcS0_S0_S0_S_S_b"]
     pub fn acc_mul_hint_fields(
         pSetupCtx: *mut ::std::os::raw::c_void,
         stepsParams: *mut ::std::os::raw::c_void,
@@ -255,6 +256,24 @@ extern "C" {
         hintFieldName2: *mut ::std::os::raw::c_char,
         hintOptions1: *mut ::std::os::raw::c_void,
         hintOptions2: *mut ::std::os::raw::c_void,
+        add: bool,
+    ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    #[link_name = "\u{1}_Z23acc_mul_add_hint_fieldsPvS_mPcS0_S0_S0_S0_S_S_S_b"]
+    pub fn acc_mul_add_hint_fields(
+        pSetupCtx: *mut ::std::os::raw::c_void,
+        stepsParams: *mut ::std::os::raw::c_void,
+        hintId: u64,
+        hintFieldNameDest: *mut ::std::os::raw::c_char,
+        hintFieldNameAirgroupVal: *mut ::std::os::raw::c_char,
+        hintFieldName1: *mut ::std::os::raw::c_char,
+        hintFieldName2: *mut ::std::os::raw::c_char,
+        hintFieldName3: *mut ::std::os::raw::c_char,
+        hintOptions1: *mut ::std::os::raw::c_void,
+        hintOptions2: *mut ::std::os::raw::c_void,
+        hintOptions3: *mut ::std::os::raw::c_void,
+        add: bool,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -348,6 +348,7 @@ pub fn acc_hint_field_c(
     hint_field_dest: &str,
     hint_field_airgroupvalue: &str,
     hint_field_name: &str,
+    add: bool,
 ) -> *mut c_void {
     let field_dest = CString::new(hint_field_dest).unwrap();
     let field_airgroupvalue = CString::new(hint_field_airgroupvalue).unwrap();
@@ -361,6 +362,7 @@ pub fn acc_hint_field_c(
             field_dest.as_ptr() as *mut std::os::raw::c_char,
             field_airgroupvalue.as_ptr() as *mut std::os::raw::c_char,
             field_name.as_ptr() as *mut std::os::raw::c_char,
+            add,
         )
     }
 }
@@ -377,6 +379,7 @@ pub fn acc_mul_hint_fields_c(
     hint_field_name2: &str,
     hint_options1: *mut c_void,
     hint_options2: *mut c_void,
+    add: bool,
 ) -> *mut c_void {
     let field_dest = CString::new(hint_field_dest).unwrap();
     let field_airgroupvalue = CString::new(hint_field_airgroupvalue).unwrap();
@@ -394,6 +397,47 @@ pub fn acc_mul_hint_fields_c(
             field_name2.as_ptr() as *mut std::os::raw::c_char,
             hint_options1,
             hint_options2,
+            add,
+        )
+    }
+}
+
+#[cfg(not(feature = "no_lib_link"))]
+#[allow(clippy::too_many_arguments)]
+pub fn acc_mul_add_hint_fields_c(
+    p_setup_ctx: *mut c_void,
+    p_steps_params: *mut c_void,
+    hint_id: u64,
+    hint_field_dest: &str,
+    hint_field_airgroupvalue: &str,
+    hint_field_name1: &str,
+    hint_field_name2: &str,
+    hint_field_name3: &str,
+    hint_options1: *mut c_void,
+    hint_options2: *mut c_void,
+    hint_options3: *mut c_void,
+    add: bool,
+) -> *mut c_void {
+    let field_dest = CString::new(hint_field_dest).unwrap();
+    let field_airgroupvalue = CString::new(hint_field_airgroupvalue).unwrap();
+    let field_name1 = CString::new(hint_field_name1).unwrap();
+    let field_name2: CString = CString::new(hint_field_name2).unwrap();
+    let field_name3: CString = CString::new(hint_field_name3).unwrap();
+
+    unsafe {
+        acc_mul_add_hint_fields(
+            p_setup_ctx,
+            p_steps_params,
+            hint_id,
+            field_dest.as_ptr() as *mut std::os::raw::c_char,
+            field_airgroupvalue.as_ptr() as *mut std::os::raw::c_char,
+            field_name1.as_ptr() as *mut std::os::raw::c_char,
+            field_name2.as_ptr() as *mut std::os::raw::c_char,
+            field_name3.as_ptr() as *mut std::os::raw::c_char,
+            hint_options1,
+            hint_options2,
+            hint_options3,
+            add,
         )
     }
 }
@@ -1175,6 +1219,7 @@ pub fn acc_hint_field_c(
     _hint_field_dest: &str,
     _hint_field_airgroupvalue: &str,
     _hint_field_name: &str,
+    _add: bool,
 ) -> *mut c_void {
     trace!("{}: ··· {}", "ffi     ", "acc_hint_fields: This is a mock call because there is no linked library");
     std::ptr::null_mut()
@@ -1192,8 +1237,29 @@ pub fn acc_mul_hint_fields_c(
     _hint_field_name2: &str,
     _hint_options1: *mut c_void,
     _hint_options2: *mut c_void,
+    _add: bool,
 ) -> *mut c_void {
     trace!("{}: ··· {}", "ffi     ", "acc_mul_hint_fields: This is a mock call because there is no linked library");
+    std::ptr::null_mut()
+}
+
+#[cfg(feature = "no_lib_link")]
+#[allow(clippy::too_many_arguments)]
+pub fn acc_mul_add_hint_fields_c(
+    _p_setup_ctx: *mut c_void,
+    _p_steps_params: *mut c_void,
+    _hint_id: u64,
+    _hint_field_dest: &str,
+    _hint_field_airgroupvalue: &str,
+    _hint_field_name1: &str,
+    _hint_field_name2: &str,
+    _hint_field_name3: &str,
+    _hint_options1: *mut c_void,
+    _hint_options2: *mut c_void,
+    _hint_options3: *mut c_void,
+    _add: bool,
+) -> *mut c_void {
+    trace!("{}: ··· {}", "ffi     ", "acc_mul_add_hint_fields: This is a mock call because there is no linked library");
     std::ptr::null_mut()
 }
 


### PR DESCRIPTION
This PR introduces a new feature to update either the **air constraint** or the **global constraint** directly, depending on the calling context. The new functionality is implemented via the following API:
```
function direct_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {...}
```
(It can also be used `direct_update_assumes` and `direct_update_proves`.

## Behavior:

1. **Outside of any airgroup**:  
   The function will fail if invoked in a context that is not within any airgroup.

2. **Inside an airgroup but outside any air**:  
   The function updates the global constraint for the specified airgroup.

3. **Inside a specific air**:  
   The function updates the air constraint associated with the current air.