### PR TITLE
Direct Update Fix

### DIFF
--- a/pil2-components/lib/std/pil/std_common.pil
+++ b/pil2-components/lib/std/pil/std_common.pil
@@ -5,8 +5,45 @@ require "std_prod.pil";
 const int DEFAULT_DIRECT_NAME = PIOP_NAME_DIRECT;
 const int DEFAULT_DIRECT_BUS_TYPE = PIOP_BUS_SUM;
 
-// Updates either the air or global constraint directly
+// Updates the global constraint directly
+function direct_global_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_initial_checks(cols, sel);
+
+    if (AIR_ID != -1) {
+        error("A direct global update has to be performed outside every air");
+    }
+
+    direct_to_bus(opid, cols, sel, proves, bus_type, name, PIOP_DIRECT_TYPE_GLOBAL);
+}
+
+function direct_global_update_assumes(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_global_update(opid, cols, sel, 0, bus_type, name);
+}
+
+function direct_global_update_proves(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_global_update(opid, cols, sel, 1, bus_type, name);
+}
+
+// Updates the air constraint directly
 function direct_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_initial_checks(cols, sel);
+
+    if (AIR_ID == -1) {
+        error("A direct update has to be performed inside an air");
+    }
+
+    direct_to_bus(opid, cols, sel, proves, bus_type, name, PIOP_DIRECT_TYPE_AIR);
+}
+
+function direct_update_assumes(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_update(opid, cols, sel, 0, bus_type, name);
+}
+
+function direct_update_proves(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
+    direct_update(opid, cols, sel, 1, bus_type, name);
+}
+
+private function direct_initial_checks(const expr cols[], const expr sel) {
     if (AIRGROUP_ID == -1) {
         error("A direct update has to be performed inside an airgroup");
     }
@@ -20,9 +57,9 @@ function direct_update(const int opid, const expr cols[], const expr sel = 1, co
     if (degree(sel) > 0) {
         error(`Only field elements can be used for a direct update. The selector = ${sel} is not a field element`);
     }
+}
 
-    const int direct_type = AIR_ID == -1 ? PIOP_DIRECT_TYPE_GLOBAL : PIOP_DIRECT_TYPE_AIR;
-
+private function direct_to_bus(const int opid, const expr cols[], const expr sel, const int proves, const int bus_type, const int name, const int direct_type) {
     if (name == PIOP_NAME_DEFAULT) name = DEFAULT_DIRECT_NAME;
 
     if (bus_type == PIOP_BUS_DEFAULT) bus_type = DEFAULT_DIRECT_BUS_TYPE;
@@ -43,12 +80,4 @@ function direct_update(const int opid, const expr cols[], const expr sel = 1, co
         default:
             error(`Unknown bus type: ${bus_type} for opid: ${opid}`);
     }
-}
-
-function direct_update_assumes(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
-    direct_update(opid, cols, sel, 0, bus_type, name);
-}
-
-function direct_update_proves(const int opid, const expr cols[], const expr sel = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
-    direct_update(opid, cols, sel, 1, bus_type, name);
 }

--- a/pil2-components/lib/std/pil/std_common.pil
+++ b/pil2-components/lib/std/pil/std_common.pil
@@ -9,10 +9,6 @@ const int DEFAULT_DIRECT_BUS_TYPE = PIOP_BUS_SUM;
 function direct_global_update(const int opid, const expr cols[], const expr sel = 1, const int proves = 1, const int bus_type = PIOP_BUS_DEFAULT, const int name = PIOP_NAME_DEFAULT) {
     direct_initial_checks(cols, sel);
 
-    if (AIR_ID != -1) {
-        error("A direct global update has to be performed outside every air");
-    }
-
     direct_to_bus(opid, cols, sel, proves, bus_type, name, PIOP_DIRECT_TYPE_GLOBAL);
 }
 

--- a/pil2-components/test/std/special/direct_update.pil
+++ b/pil2-components/test/std/special/direct_update.pil
@@ -31,7 +31,7 @@ airgroup Permutation {
 
     DirectUpdatePermutationGlobal();
     for (int i = 0; i < length(input1)/2; i++) {
-        direct_update_proves(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], bus_type: PIOP_BUS_PROD);
+        direct_global_update_proves(OP_BUS_ID1, [OPID1, 0, 0, i, 0, input1[2*i], input1[2*i+1], 0], bus_type: PIOP_BUS_PROD);
     }
 }
 
@@ -64,7 +64,7 @@ airgroup Lookup {
     DirectUpdateLookupAir();
 
     for (int i = 0; i < length(input2)/2; i++) {
-        direct_update_assumes(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0]);
+        direct_global_update_assumes(OP_BUS_ID2, [OPID2, 0, 0, i, 0, input2[2*i], input2[2*i+1], 0]);
     }
 
     DirectUpdateLookupGlobal();


### PR DESCRIPTION
This pull request introduces new functions for handling global constraints and refactors existing functions for better code organization and clarity. The changes include the addition of new functions for global updates, the refactoring of existing direct update functions, and the corresponding updates in the test files.

### New functions for directly update:

* [`pil2-components/lib/std/pil/std_common.pil`](diffhunk://#diff-e2ceaa52f225b5400ad1139036bc30e133fb3fa81e721d64d6299f5354a0f04eL8-R46): Added `direct_global_update`, `direct_global_update_assumes`, and `direct_global_update_proves` functions to handle global constraint updates. These functions ensure that updates are performed outside of any air and call the `direct_to_bus` function with the appropriate parameters.