### PR TITLE
Global values in debug mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"

--- a/cli/src/commands/prove.rs
+++ b/cli/src/commands/prove.rs
@@ -62,6 +62,9 @@ pub struct ProveCmd {
     #[clap(long)]
     pub print: Option<usize>,
 
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub print_to_file: bool,
+
     #[clap(long, action = clap::ArgAction::Append)]
     pub opids: Option<Vec<String>>,
 }
@@ -92,7 +95,8 @@ impl ProveCmd {
             });
 
             let n_values = self.print.unwrap_or(DEFAULT_PRINT_VALS);
-            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values)
+            let print_to_file = self.print_to_file;
+            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values, print_to_file)
         } else {
             self.debug.into()
         };

--- a/cli/src/commands/verify_constraints.rs
+++ b/cli/src/commands/verify_constraints.rs
@@ -50,6 +50,9 @@ pub struct VerifyConstraintsCmd {
     #[clap(long)]
     pub print: Option<usize>,
 
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub print_to_file: bool,
+
     #[clap(long, action = clap::ArgAction::Append)]
     pub opids: Option<Vec<String>>,
 }
@@ -74,7 +77,8 @@ impl VerifyConstraintsCmd {
             });
 
             let n_values = self.print.unwrap_or(DEFAULT_PRINT_VALS);
-            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values)
+            let print_to_file = self.print_to_file;
+            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values, print_to_file)
         } else {
             self.debug.into()
         };

--- a/common/src/air_instance.rs
+++ b/common/src/air_instance.rs
@@ -1,4 +1,5 @@
 use std::mem::MaybeUninit;
+use std::ptr;
 use std::{collections::HashMap, os::raw::c_void, sync::Arc};
 use std::path::PathBuf;
 use p3_field::Field;
@@ -24,6 +25,24 @@ pub struct StepsParams {
 impl From<&StepsParams> for *mut c_void {
     fn from(params: &StepsParams) -> *mut c_void {
         params as *const StepsParams as *mut c_void
+    }
+}
+
+impl Default for StepsParams {
+    fn default() -> Self {
+        StepsParams {
+            trace: ptr::null_mut(),
+            pols: ptr::null_mut(),
+            public_inputs: ptr::null_mut(),
+            challenges: ptr::null_mut(),
+            airgroup_values: ptr::null_mut(),
+            airvalues: ptr::null_mut(),
+            evals: ptr::null_mut(),
+            xdivxsub: ptr::null_mut(),
+            p_const_pols: ptr::null_mut(),
+            p_const_tree: ptr::null_mut(),
+            custom_commits: [ptr::null_mut(); 10],
+        }
     }
 }
 

--- a/common/src/std_mode.rs
+++ b/common/src/std_mode.rs
@@ -9,23 +9,24 @@ pub struct StdMode {
     pub name: ModeName,
     pub opids: Option<Vec<u64>>,
     pub n_vals: usize,
+    pub print_to_file: bool,
 }
 
 impl StdMode {
-    pub const fn new(name: ModeName, opids: Option<Vec<u64>>, n_vals: usize) -> Self {
+    pub const fn new(name: ModeName, opids: Option<Vec<u64>>, n_vals: usize, print_to_file: bool) -> Self {
         if n_vals == 0 {
             panic!("n_vals must be greater than 0");
         }
 
-        Self { name, opids, n_vals }
+        Self { name, opids, n_vals, print_to_file }
     }
 }
 
 impl From<u8> for StdMode {
     fn from(v: u8) -> Self {
         match v {
-            0 => StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS),
-            1 => StdMode::new(ModeName::Debug, None, DEFAULT_PRINT_VALS),
+            0 => StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS, false),
+            1 => StdMode::new(ModeName::Debug, None, DEFAULT_PRINT_VALS, false),
             _ => panic!("Invalid mode"),
         }
     }
@@ -33,7 +34,7 @@ impl From<u8> for StdMode {
 
 impl Default for StdMode {
     fn default() -> Self {
-        StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS)
+        StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS, false)
     }
 }
 

--- a/hints/src/hints.rs
+++ b/hints/src/hints.rs
@@ -49,6 +49,7 @@ pub struct HintFieldOptions {
     pub inverse: bool,
     pub print_expression: bool,
     pub initialize_zeros: bool,
+    pub compilation_time: bool,
 }
 
 impl From<&HintFieldOptions> for *mut c_void {
@@ -68,6 +69,10 @@ impl HintFieldOptions {
 
     pub fn inverse() -> Self {
         Self { inverse: true, ..Default::default() }
+    }
+
+    pub fn compilation_time() -> Self {
+        Self { compilation_time: true, ..Default::default() }
     }
 
     pub fn inverse_and_print_expression() -> Self {
@@ -980,23 +985,13 @@ pub fn get_hint_field_constant<F: Field>(
     air_id: usize,
     hint_id: usize,
     hint_field_name: &str,
-    options: HintFieldOptions,
+    mut options: HintFieldOptions,
 ) -> HintFieldValue<F> {
+    options.compilation_time = true;
+
     let setup = setup_ctx.get_setup(airgroup_id, air_id);
 
-    let steps_params = StepsParams {
-        trace: std::ptr::null_mut(),
-        pols: std::ptr::null_mut(),
-        public_inputs: std::ptr::null_mut(),
-        challenges: std::ptr::null_mut(),
-        airgroup_values: std::ptr::null_mut(),
-        airvalues: std::ptr::null_mut(),
-        evals: std::ptr::null_mut(),
-        xdivxsub: std::ptr::null_mut(),
-        p_const_pols: std::ptr::null_mut(),
-        p_const_tree: std::ptr::null_mut(),
-        custom_commits: [std::ptr::null_mut(); 10],
-    };
+    let steps_params = StepsParams::default();
 
     let raw_ptr = get_hint_field_c(
         (&setup.p_setup).into(),
@@ -1022,23 +1017,13 @@ pub fn get_hint_field_constant_a<F: Field>(
     air_id: usize,
     hint_id: usize,
     hint_field_name: &str,
-    options: HintFieldOptions,
+    mut options: HintFieldOptions,
 ) -> Vec<HintFieldValue<F>> {
+    options.compilation_time = true;
+
     let setup = setup_ctx.get_setup(airgroup_id, air_id);
 
-    let steps_params = StepsParams {
-        trace: std::ptr::null_mut(),
-        pols: std::ptr::null_mut(),
-        public_inputs: std::ptr::null_mut(),
-        challenges: std::ptr::null_mut(),
-        airgroup_values: std::ptr::null_mut(),
-        airvalues: std::ptr::null_mut(),
-        evals: std::ptr::null_mut(),
-        xdivxsub: std::ptr::null_mut(),
-        p_const_pols: std::ptr::null_mut(),
-        p_const_tree: std::ptr::null_mut(),
-        custom_commits: [std::ptr::null_mut(); 10],
-    };
+    let steps_params = StepsParams::default();
 
     let raw_ptr = get_hint_field_c(
         (&setup.p_setup).into(),
@@ -1070,23 +1055,13 @@ pub fn get_hint_field_constant_m<F: Field>(
     air_id: usize,
     hint_id: usize,
     hint_field_name: &str,
-    options: HintFieldOptions,
+    mut options: HintFieldOptions,
 ) -> HintFieldValues<F> {
+    options.compilation_time = true;
+
     let setup = setup_ctx.get_setup(airgroup_id, air_id);
 
-    let steps_params = StepsParams {
-        trace: std::ptr::null_mut(),
-        pols: std::ptr::null_mut(),
-        public_inputs: std::ptr::null_mut(),
-        challenges: std::ptr::null_mut(),
-        airgroup_values: std::ptr::null_mut(),
-        airvalues: std::ptr::null_mut(),
-        evals: std::ptr::null_mut(),
-        xdivxsub: std::ptr::null_mut(),
-        p_const_pols: std::ptr::null_mut(),
-        p_const_tree: std::ptr::null_mut(),
-        custom_commits: [std::ptr::null_mut(); 10],
-    };
+    let steps_params = StepsParams::default();
 
     let raw_ptr = get_hint_field_c(
         (&setup.p_setup).into(),
@@ -1127,19 +1102,9 @@ pub fn set_hint_field<F: Field>(
     hint_field_name: &str,
     values: &HintFieldValue<F>,
 ) {
-    let steps_params = StepsParams {
-        trace: air_instance.get_trace_ptr() as *mut c_void,
-        pols: air_instance.get_buffer_ptr() as *mut c_void,
-        public_inputs: std::ptr::null_mut(),
-        challenges: std::ptr::null_mut(),
-        airgroup_values: std::ptr::null_mut(),
-        airvalues: std::ptr::null_mut(),
-        evals: std::ptr::null_mut(),
-        xdivxsub: std::ptr::null_mut(),
-        p_const_pols: std::ptr::null_mut(),
-        p_const_tree: std::ptr::null_mut(),
-        custom_commits: [std::ptr::null_mut(); 10],
-    };
+    let mut steps_params = StepsParams::default();
+    steps_params.trace = air_instance.get_trace_ptr() as *mut c_void;
+    steps_params.pols = air_instance.get_buffer_ptr() as *mut c_void;
 
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 
@@ -1161,19 +1126,9 @@ pub fn set_hint_field_val<F: Field>(
     hint_field_name: &str,
     value: HintFieldOutput<F>,
 ) {
-    let steps_params = StepsParams {
-        trace: std::ptr::null_mut(),
-        pols: std::ptr::null_mut(),
-        public_inputs: std::ptr::null_mut(),
-        challenges: std::ptr::null_mut(),
-        airgroup_values: air_instance.airgroup_values.as_mut_ptr() as *mut c_void,
-        airvalues: air_instance.airvalues.as_mut_ptr() as *mut c_void,
-        evals: std::ptr::null_mut(),
-        xdivxsub: std::ptr::null_mut(),
-        p_const_pols: std::ptr::null_mut(),
-        p_const_tree: std::ptr::null_mut(),
-        custom_commits: [std::ptr::null_mut(); 10],
-    };
+    let mut steps_params = StepsParams::default();
+    steps_params.airgroup_values = air_instance.airgroup_values.as_mut_ptr() as *mut c_void;
+    steps_params.airvalues = air_instance.airvalues.as_mut_ptr() as *mut c_void;
 
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 

--- a/hints/src/hints.rs
+++ b/hints/src/hints.rs
@@ -1102,9 +1102,19 @@ pub fn set_hint_field<F: Field>(
     hint_field_name: &str,
     values: &HintFieldValue<F>,
 ) {
-    let mut steps_params = StepsParams::default();
-    steps_params.trace = air_instance.get_trace_ptr() as *mut c_void;
-    steps_params.pols = air_instance.get_buffer_ptr() as *mut c_void;
+    let steps_params = StepsParams {
+        trace: air_instance.get_trace_ptr() as *mut c_void,
+        pols: air_instance.get_buffer_ptr() as *mut c_void,
+        public_inputs: std::ptr::null_mut(),
+        challenges: std::ptr::null_mut(),
+        airgroup_values: std::ptr::null_mut(),
+        airvalues: std::ptr::null_mut(),
+        evals: std::ptr::null_mut(),
+        xdivxsub: std::ptr::null_mut(),
+        p_const_pols: std::ptr::null_mut(),
+        p_const_tree: std::ptr::null_mut(),
+        custom_commits: [std::ptr::null_mut(); 10],
+    };
 
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 
@@ -1126,9 +1136,19 @@ pub fn set_hint_field_val<F: Field>(
     hint_field_name: &str,
     value: HintFieldOutput<F>,
 ) {
-    let mut steps_params = StepsParams::default();
-    steps_params.airgroup_values = air_instance.airgroup_values.as_mut_ptr() as *mut c_void;
-    steps_params.airvalues = air_instance.airvalues.as_mut_ptr() as *mut c_void;
+    let steps_params = StepsParams {
+        trace: std::ptr::null_mut(),
+        pols: std::ptr::null_mut(),
+        public_inputs: std::ptr::null_mut(),
+        challenges: std::ptr::null_mut(),
+        airgroup_values: air_instance.airgroup_values.as_mut_ptr() as *mut c_void,
+        airvalues: air_instance.airvalues.as_mut_ptr() as *mut c_void,
+        evals: std::ptr::null_mut(),
+        xdivxsub: std::ptr::null_mut(),
+        p_const_pols: std::ptr::null_mut(),
+        p_const_tree: std::ptr::null_mut(),
+        custom_commits: [std::ptr::null_mut(); 10],
+    };
 
     let setup = setup_ctx.get_setup(air_instance.airgroup_id, air_instance.air_id);
 

--- a/pil2-components/lib/std/pil/std_prod.pil
+++ b/pil2-components/lib/std/pil/std_prod.pil
@@ -41,7 +41,7 @@ private function init_proof_containers_prod(int name, int opid) {
     }
 }
 
-private function init_air_containers_prod(int name, int opid) {
+private function init_air_containers_prod(int name) {
     container air.std.gprod {
         int gprod_assumes_count = 0;
         expr gprod_assumes_sel[100];
@@ -62,17 +62,15 @@ private function init_air_containers_prod(int name, int opid) {
     }
 }
 
-private function initial_checks_prod(int proves, int opid, expr cols[], int direct_type) {
-    const int cols_count = length(cols);
-
-    // Assumes and proves of the same opid must have the same number of columns (except for the direct_type case)
+private function initial_checks_prod(int proves, int opid, int cols_count, int direct_type) {
+    // Assumes and proves of the same opid must have the same number of columns
     if (proof.std.gprod.`id${opid}`.cols == 0) {
         // first time called
         proof.std.gprod.`id${opid}`.cols = cols_count;
         // add opid on a list to verify at final
         proof.std.gprod.opids[proof.std.gprod.opids_count] = opid;
         proof.std.gprod.opids_count++;
-    } else if (direct_type == PIOP_DIRECT_TYPE_DEFAULT && cols_count != proof.std.gprod.`id${opid}`.cols) {
+    } else if (cols_count != proof.std.gprod.`id${opid}`.cols) {
         const int expected_cols = proof.std.gprod.`id${opid}`.cols;
         error(`The number of columns of PIOP #${opid} must be ${expected_cols} but was ${cols_count}`);
     }
@@ -104,19 +102,20 @@ private function update_piop_prod(int name, int proves, int opid, expr sel, expr
     init_proof_containers_prod(name, opid);
 
     if (direct_type == PIOP_DIRECT_TYPE_AIR || direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
-        init_air_containers_prod(name, opid);
-
-        // Create debug hints for the witness computation
-        string name_cols[cols_count];
-        expr sum_expr = 0;
-        for (int i = 0; i < cols_count; i++) {
-            name_cols[i] = string(cols[i]);
-            sum_expr += cols[i];
-        }
-        @gprod_member_data{name_piop: get_piop_name(name), name_expr: name_expr, opid: opid, proves: proves, selector: sel, expressions: cols, deg_expr: degree(sum_expr), deg_sel: degree(sel)};
+        init_air_containers_prod(name);
     }
 
-    initial_checks_prod(proves, opid, cols, direct_type);
+    // Create debug hints for the witness computation
+    string name_cols[cols_count];
+    expr sum_expr = 0;
+    for (int i = 0; i < cols_count; i++) {
+        name_cols[i] = string(cols[i]);
+        sum_expr += cols[i];
+    }
+    @gprod_member_data{name_piop: get_piop_name(name), name_expr: name_expr, opid: opid, is_global: direct_type == PIOP_DIRECT_TYPE_GLOBAL,
+                          proves: proves, selector: sel, expressions: cols, deg_expr: degree(sum_expr), deg_sel: degree(sel)};
+
+    initial_checks_prod(proves, opid, cols_count, direct_type);
 
     init_challenges();
 
@@ -297,10 +296,12 @@ private function check_opids_were_completed_prod() {
         int opid = proof.std.gprod.opids[i];
         use proof.std.gprod.`id${opid}`;
 
+        // If the PIOP is isolated, avoid any check
         if (name == PIOP_NAME_ISOLATED) continue;
 
         const string name_str = get_piop_name(name);
 
+        // At least one assume and one prove must be defined
         if (assumes == 0) {
             error(`${name_str} #${opid} defined without assume`);
         } else if (proves == 0) {

--- a/pil2-components/lib/std/pil/std_sum.pil
+++ b/pil2-components/lib/std/pil/std_sum.pil
@@ -47,7 +47,7 @@ private function init_proof_containers_sum(int name, int opid[]) {
     }
 }
 
-private function init_air_containers_sum(int name, int opid[]) {
+private function init_air_containers_sum(int name) {
     container air.std.gsum {
         int gsum_nargs = 0;
         expr gsum_s[100];
@@ -61,11 +61,9 @@ private function init_air_containers_sum(int name, int opid[]) {
     }
 }
 
-private function initial_checks_sum(int proves, int opid[], expr cols[], int direct_type) {
-    const int cols_count = length(cols);
-
+private function initial_checks_sum(int proves, int opid[], int cols_count, int direct_type) {
     for (int i = 0; i < length(opid); i++) {
-        // Assumes and proves of the same opid must have the same number of columns (except for the direct_type case)
+        // Assumes and proves of the same opid must have the same number of columns
         if (proof.std.gsum.`id${opid[i]}`.cols == 0) {
             // first time called
             proof.std.gsum.`id${opid[i]}`.cols = cols_count;
@@ -73,7 +71,7 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int dir
             // add opid on a list to verify at final
             proof.std.gsum.opids[proof.std.gsum.opids_count] = opid[i];
             proof.std.gsum.opids_count++;
-        } else if (direct_type == PIOP_DIRECT_TYPE_DEFAULT && cols_count != proof.std.gsum.`id${opid[i]}`.cols) {
+        } else if (cols_count != proof.std.gsum.`id${opid[i]}`.cols) {
             const int expected_cols = proof.std.gsum.`id${opid[i]}`.cols;
             error(`The number of columns of PIOP #${opid[i]} must be ${expected_cols} but was ${cols_count}`);
         }
@@ -81,10 +79,12 @@ private function initial_checks_sum(int proves, int opid[], expr cols[], int dir
         // The same opid is shared among multiple instances of the same air, so we must keep track of the number of
         // proves and assumes to verify at the end that all of them match
         if (proves == 2) {
-            // proves = 2 marks that the user is responsible for the use of proves and assumes
+            // proves = 2 indicates the user is responsible for the use of proves and assumes
+            // so we mark it as both a prove and an assume
             proof.std.gsum.`id${opid[i]}`.proves++;
             proof.std.gsum.`id${opid[i]}`.assumes++;
         } else {
+            // otherwise, we mark it correctly
             const string name_str = proves ? "proves" : "assumes";
             proof.std.gsum.`id${opid[i]}`.`${name_str}`++;
         }
@@ -112,20 +112,21 @@ private function update_piop_sum(int name, int proves, int opid[], expr sumid, e
     init_proof_containers_sum(name, opid);
 
     if (direct_type == PIOP_DIRECT_TYPE_AIR || direct_type == PIOP_DIRECT_TYPE_DEFAULT) {
-        init_air_containers_sum(name, opid);
-
-        // Create debug hints for the witness computation
-        string name_expr[cols_count];
-        expr sum_expr = 0;
-        for (int i = 0; i < cols_count; i++) {
-            name_expr[i] = string(cols[i]);
-            sum_expr += cols[i];
-        }
-        // proves = 2 marks that the user is responsible for the use of proves and assumes
-        @gsum_member_data{name_piop: get_piop_name(name), name_expr: name_expr, opid: sumid, proves: proves == 2 ? sel : proves, selector: sel, expressions: cols, deg_expr: degree(sum_expr), deg_sel: degree(sel)};
+        init_air_containers_sum(name);
     }
 
-    initial_checks_sum(proves, opid, cols, direct_type);
+    // Create debug hints for the witness computation
+    string name_expr[cols_count];
+    expr sum_expr = 0;
+    for (int i = 0; i < cols_count; i++) {
+        name_expr[i] = string(cols[i]);
+        sum_expr += cols[i];
+    }
+    // proves = 2 marks that the user is responsible for the use of proves and assumes
+    @gsum_member_data{name_piop: get_piop_name(name), name_expr: name_expr, opid: sumid, is_global: direct_type == PIOP_DIRECT_TYPE_GLOBAL,
+                         proves: proves == 2 ? sel : proves, selector: sel, expressions: cols, deg_expr: degree(sum_expr), deg_sel: degree(sel)};
+
+    initial_checks_sum(proves, opid, cols_count, direct_type);
 
     init_challenges();
 
@@ -444,10 +445,12 @@ private function check_opids_were_completed_sum() {
         int opid = proof.std.gsum.opids[i];
         use proof.std.gsum.`id${opid}`;
 
+        // If the PIOP is isolated, avoid any check
         if (name == PIOP_NAME_ISOLATED) continue;
 
         const string name_str = get_piop_name(name);
 
+        // At least one assume and one prove must be defined
         if (assumes == 0) {
             error(`${name_str} #${opid} defined without assume`);
         } else if (proves == 0) {

--- a/pil2-components/lib/std/rs/src/std_prod.rs
+++ b/pil2-components/lib/std/rs/src/std_prod.rs
@@ -320,8 +320,9 @@ impl<F: PrimeField> WitnessComponent<F> for StdProd<F> {
         if self.mode.name == ModeName::Debug {
             let name = Self::MY_NAME;
             let max_values_to_print = self.mode.n_vals;
+            let print_to_file = self.mode.print_to_file;
             let debug_data = self.debug_data.as_ref().expect("Debug data missing");
-            print_debug_info(name, max_values_to_print, debug_data);
+            print_debug_info(name, max_values_to_print, print_to_file, debug_data);
         }
     }
 }

--- a/pil2-components/lib/std/rs/src/std_prod.rs
+++ b/pil2-components/lib/std/rs/src/std_prod.rs
@@ -106,16 +106,35 @@ impl<F: PrimeField> StdProd<F> {
                 panic!("sumid must be a field element");
             };
 
-            let proves =
-                get_hint_field::<F>(sctx, pctx, air_instance, *hint as usize, "proves", HintFieldOptions::default());
-            let proves = if let HintFieldValue::Field(proves) = proves {
-                if !proves.is_zero() && !proves.is_one() {
-                    log::error!("Proves hint must be either 0 or 1");
-                    panic!();
-                }
-                proves.is_one()
+            let HintFieldValue::Field(is_global) = get_hint_field_constant::<F>(
+                sctx,
+                airgroup_id,
+                air_id,
+                *hint as usize,
+                "is_global",
+                HintFieldOptions::default(),
+            ) else {
+                log::error!("is_global hint must be a field element");
+                panic!();
+            };
+
+            let HintFieldValue::Field(proves) = get_hint_field_constant::<F>(
+                sctx,
+                airgroup_id,
+                air_id,
+                *hint as usize,
+                "proves",
+                HintFieldOptions::default(),
+            ) else {
+                log::error!("proves hint must be a field element");
+                panic!();
+            };
+            let proves = if proves.is_zero() {
+                false
+            } else if proves.is_one() {
+                true
             } else {
-                log::error!("Proves hint must be a field element");
+                log::error!("Proves hint must be either 0 or 1");
                 panic!();
             };
 
@@ -143,7 +162,7 @@ impl<F: PrimeField> StdProd<F> {
                 panic!();
             };
 
-            let HintFieldValue::Field(deg_mul) = get_hint_field_constant::<F>(
+            let HintFieldValue::Field(deg_sel) = get_hint_field_constant::<F>(
                 sctx,
                 airgroup_id,
                 air_id,
@@ -151,17 +170,38 @@ impl<F: PrimeField> StdProd<F> {
                 "deg_sel",
                 HintFieldOptions::default(),
             ) else {
-                log::error!("deg_mul hint must be a field element");
+                log::error!("deg_sel hint must be a field element");
                 panic!();
             };
 
-            // If both the expresion and the mul are of degree zero, then simply update the bus once
-            if deg_expr.is_zero() && deg_mul.is_zero() {
-                update_bus(airgroup_id, air_id, instance_id, opid, proves, &selector, &expressions, 0, debug_data);
+            if deg_expr.is_zero() && deg_sel.is_zero() {
+                update_bus(
+                    airgroup_id,
+                    air_id,
+                    instance_id,
+                    opid,
+                    proves,
+                    &selector,
+                    &expressions,
+                    0,
+                    debug_data,
+                    is_global.is_one(),
+                );
             } else {
                 // Otherwise, update the bus for each row
                 for j in 0..num_rows {
-                    update_bus(airgroup_id, air_id, instance_id, opid, proves, &selector, &expressions, j, debug_data);
+                    update_bus(
+                        airgroup_id,
+                        air_id,
+                        instance_id,
+                        opid,
+                        proves,
+                        &selector,
+                        &expressions,
+                        j,
+                        debug_data,
+                        false,
+                    );
                 }
             }
 
@@ -176,6 +216,7 @@ impl<F: PrimeField> StdProd<F> {
                 expressions: &HintFieldValuesVec<F>,
                 row: usize,
                 debug_data: &DebugData<F>,
+                is_global: bool,
             ) {
                 let sel = if let HintFieldOutput::Field(selector) = selector.get(row) {
                     if !selector.is_zero() && !selector.is_one() {
@@ -199,6 +240,7 @@ impl<F: PrimeField> StdProd<F> {
                         row,
                         proves,
                         F::one(),
+                        is_global,
                     );
                 }
             }

--- a/pil2-components/lib/std/rs/src/std_sum.rs
+++ b/pil2-components/lib/std/rs/src/std_sum.rs
@@ -338,8 +338,9 @@ impl<F: PrimeField> WitnessComponent<F> for StdSum<F> {
         if self.mode.name == ModeName::Debug {
             let name = Self::MY_NAME;
             let max_values_to_print = self.mode.n_vals;
+            let print_to_file = self.mode.print_to_file;
             let debug_data = self.debug_data.as_ref().expect("Debug data missing");
-            print_debug_info(name, max_values_to_print, debug_data);
+            print_debug_info(name, max_values_to_print, print_to_file, debug_data);
         }
     }
 }

--- a/pil2-components/lib/std/rs/src/std_sum.rs
+++ b/pil2-components/lib/std/rs/src/std_sum.rs
@@ -226,15 +226,15 @@ impl<F: PrimeField> StdSum<F> {
                 };
 
                 let proves = match proves {
-                    p if p.is_zero() || p == -F::one() => {
+                    p if p.is_zero() || p == F::neg_one() => {
                         // If it's an assume, then negate its value
-                        if p == -F::one() {
+                        if p == F::neg_one() {
                             mul = -mul;
                         }
                         false
                     }
                     p if p.is_one() => true,
-                    _ => panic!("Proves hint must be either 0, 1, or -1"),
+                    _ => panic!("Proves hint must be either 0, 1, or -1 but has value {}", proves),
                 };
 
                 update_debug_data(

--- a/pil2-stark/src/starkpil/expressions_avx.hpp
+++ b/pil2-stark/src/starkpil/expressions_avx.hpp
@@ -278,7 +278,7 @@ public:
         }
     }
 
-    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize) override {
+    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize, bool compilationTime) override {
         uint64_t nOpenings = setupCtx.starkInfo.openingPoints.size();
         uint64_t ns = 2 + setupCtx.starkInfo.nStages + setupCtx.starkInfo.customCommits.size();
         bool domainExtended = domainSize == uint64_t(1 << setupCtx.starkInfo.starkStruct.nBitsExt) ? true : false;

--- a/pil2-stark/src/starkpil/expressions_avx512.hpp
+++ b/pil2-stark/src/starkpil/expressions_avx512.hpp
@@ -277,7 +277,7 @@ public:
         }
     }
 
-    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize) override {
+    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize, bool compilationTime) override {
         uint64_t nOpenings = setupCtx.starkInfo.openingPoints.size();
         uint64_t ns = 2 + setupCtx.starkInfo.nStages + setupCtx.starkInfo.customCommits.size();
         bool domainExtended = domainSize == uint64_t(1 << setupCtx.starkInfo.starkStruct.nBitsExt) ? true : false;

--- a/pil2-stark/src/starkpil/expressions_ctx.hpp
+++ b/pil2-stark/src/starkpil/expressions_ctx.hpp
@@ -72,11 +72,13 @@ public:
 
     virtual ~ExpressionsCtx() {};
     
-    virtual void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize) {};
+    virtual void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize, bool compilationTime = false) {};
  
-    void calculateExpression(StepsParams& params, Goldilocks::Element* dest, uint64_t expressionId, bool inverse = false) {
+    void calculateExpression(StepsParams& params, Goldilocks::Element* dest, uint64_t expressionId, bool inverse = false, bool compilation_time = false) {
         uint64_t domainSize;
-        if(expressionId == setupCtx.starkInfo.cExpId || expressionId == setupCtx.starkInfo.friExpId) {
+        if (compilation_time) {
+            domainSize = 1;
+        } else if(expressionId == setupCtx.starkInfo.cExpId || expressionId == setupCtx.starkInfo.friExpId) {
             setupCtx.expressionsBin.expressionsInfo[expressionId].destDim = 3;
             domainSize = 1 << setupCtx.starkInfo.starkStruct.nBitsExt;
         } else {
@@ -85,7 +87,7 @@ public:
         Dest destStruct(dest);
         destStruct.addParams(setupCtx.expressionsBin.expressionsInfo[expressionId], inverse);
         std::vector<Dest> dests = {destStruct};
-        calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, domainSize);
+        calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, domainSize, compilation_time);
     }
 };
 

--- a/pil2-stark/src/starkpil/expressions_pack.hpp
+++ b/pil2-stark/src/starkpil/expressions_pack.hpp
@@ -271,7 +271,7 @@ public:
         }
     }
 
-    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize) override {
+    void calculateExpressions(StepsParams& params, ParserArgs &parserArgs, std::vector<Dest> dests, uint64_t domainSize, bool compilation_time) override {
         uint64_t nOpenings = setupCtx.starkInfo.openingPoints.size();
         uint64_t ns = 2 + setupCtx.starkInfo.nStages + setupCtx.starkInfo.customCommits.size();
         bool domainExtended = domainSize == uint64_t(1 << setupCtx.starkInfo.starkStruct.nBitsExt) ? true : false;
@@ -280,11 +280,13 @@ public:
         setBufferTInfo(domainExtended, expId);
 
         Goldilocks::Element challenges[setupCtx.starkInfo.challengesMap.size()*FIELD_EXTENSION*nrowsPack];
-        for(uint64_t i = 0; i < setupCtx.starkInfo.challengesMap.size(); ++i) {
-            for(uint64_t j = 0; j < nrowsPack; ++j) {
-                challenges[(i*FIELD_EXTENSION)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION];
-                challenges[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION + 1];
-                challenges[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION + 2];
+        if(!compilation_time) {
+            for(uint64_t i = 0; i < setupCtx.starkInfo.challengesMap.size(); ++i) {
+                for(uint64_t j = 0; j < nrowsPack; ++j) {
+                    challenges[(i*FIELD_EXTENSION)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION];
+                    challenges[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION + 1];
+                    challenges[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.challenges[i * FIELD_EXTENSION + 2];
+                }
             }
         }
 
@@ -296,44 +298,52 @@ public:
         }
 
         Goldilocks::Element publics[setupCtx.starkInfo.nPublics*nrowsPack];
-        for(uint64_t i = 0; i < setupCtx.starkInfo.nPublics; ++i) {
-            for(uint64_t j = 0; j < nrowsPack; ++j) {
-                publics[i*nrowsPack + j] = params.publicInputs[i];
+        if(!compilation_time) {
+            for(uint64_t i = 0; i < setupCtx.starkInfo.nPublics; ++i) {
+                for(uint64_t j = 0; j < nrowsPack; ++j) {
+                    publics[i*nrowsPack + j] = params.publicInputs[i];
+                }
             }
         }
 
         Goldilocks::Element evals[setupCtx.starkInfo.evMap.size()*FIELD_EXTENSION*nrowsPack];
-        for(uint64_t i = 0; i < setupCtx.starkInfo.evMap.size(); ++i) {
-            for(uint64_t j = 0; j < nrowsPack; ++j) {
-                evals[(i*FIELD_EXTENSION)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION];
-                evals[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION + 1];
-                evals[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION + 2];
+        if(!compilation_time) {
+            for(uint64_t i = 0; i < setupCtx.starkInfo.evMap.size(); ++i) {
+                for(uint64_t j = 0; j < nrowsPack; ++j) {
+                    evals[(i*FIELD_EXTENSION)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION];
+                    evals[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION + 1];
+                    evals[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.evals[i * FIELD_EXTENSION + 2];
+                }
             }
         }
 
         Goldilocks::Element airgroupValues[setupCtx.starkInfo.airgroupValuesMap.size()*FIELD_EXTENSION*nrowsPack];
-        for(uint64_t i = 0; i < setupCtx.starkInfo.airgroupValuesMap.size(); ++i) {
-            for(uint64_t j = 0; j < nrowsPack; ++j) {
-                airgroupValues[(i*FIELD_EXTENSION)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION];
-                airgroupValues[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION + 1];
-                airgroupValues[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION + 2];
+        if(!compilation_time) {
+            for(uint64_t i = 0; i < setupCtx.starkInfo.airgroupValuesMap.size(); ++i) {
+                for(uint64_t j = 0; j < nrowsPack; ++j) {
+                    airgroupValues[(i*FIELD_EXTENSION)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION];
+                    airgroupValues[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION + 1];
+                    airgroupValues[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.airgroupValues[i * FIELD_EXTENSION + 2];
+                }
             }
         }
 
         Goldilocks::Element airValues[setupCtx.starkInfo.airValuesMap.size()*FIELD_EXTENSION*nrowsPack];
-        for(uint64_t i = 0; i < setupCtx.starkInfo.airValuesMap.size(); ++i) {
-            for(uint64_t j = 0; j < nrowsPack; ++j) {
-                airValues[(i*FIELD_EXTENSION)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION];
-                airValues[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION + 1];
-                airValues[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION + 2];
+        if(!compilation_time) {
+            for(uint64_t i = 0; i < setupCtx.starkInfo.airValuesMap.size(); ++i) {
+                for(uint64_t j = 0; j < nrowsPack; ++j) {
+                    airValues[(i*FIELD_EXTENSION)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION];
+                    airValues[(i*FIELD_EXTENSION + 1)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION + 1];
+                    airValues[(i*FIELD_EXTENSION + 2)*nrowsPack + j] = params.airValues[i * FIELD_EXTENSION + 2];
+                }
             }
-        }
+            }
 
-    #pragma omp parallel for
+    // #pragma omp parallel for
         for (uint64_t i = 0; i < domainSize; i+= nrowsPack) {
             Goldilocks::Element bufferT_[nOpenings*nCols*nrowsPack];
 
-            loadPolynomials(params, parserArgs, dests, bufferT_, i, domainSize);
+            if(!compilation_time) loadPolynomials(params, parserArgs, dests, bufferT_, i, domainSize);
 
             Goldilocks::Element **destVals = new Goldilocks::Element*[dests.size()];
 

--- a/pil2-stark/src/starkpil/gen_recursive_proof.hpp
+++ b/pil2-stark/src/starkpil/gen_recursive_proof.hpp
@@ -93,7 +93,7 @@ void *genRecursiveProof(SetupCtx& setupCtx, json& globalInfo, uint64_t airgroupI
     destStruct.addParams(setupCtx.expressionsBin.expressionsInfo[denFieldId], true);
     std::vector<Dest> dests = {destStruct};
 
-    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits));
+    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits), false);
 
     Goldilocks3::copy((Goldilocks3::Element *)&gprod[0], &Goldilocks3::one());
     for(uint64_t i = 1; i < N; ++i) {

--- a/pil2-stark/src/starkpil/starks.cpp
+++ b/pil2-stark/src/starkpil/starks.cpp
@@ -359,7 +359,7 @@ void Starks<ElementType>::calculateImPolsExpressions(uint64_t step, StepsParams 
     ExpressionsPack expressionsCtx(setupCtx);
 #endif
 
-    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits));
+    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsExpressions, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits), false);
 }
 
 template <typename ElementType>

--- a/pil2-stark/src/starkpil/verify_constraints.hpp
+++ b/pil2-stark/src/starkpil/verify_constraints.hpp
@@ -118,7 +118,7 @@ ConstraintsResults *verifyConstraints(SetupCtx& setupCtx, StepsParams &params) {
     ExpressionsPack expressionsCtx(setupCtx);
 #endif
 
-    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsConstraints, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits));
+    expressionsCtx.calculateExpressions(params, setupCtx.expressionsBin.expressionsBinArgsConstraints, dests, uint64_t(1 << setupCtx.starkInfo.starkStruct.nBits), false);
 
 #pragma omp parallel for
     for (uint64_t i = 0; i < setupCtx.expressionsBin.constraintsInfoDebug.size(); i++) {


### PR DESCRIPTION
Update: It includes PR #135.

This PR adds the processing of values thrown to the bus in a "global" manner, processing them once and only once when they are processed for a particular opid.

### Handling Global Values in Debug Data

* [`pil2-components/lib/std/rs/src/debug.rs`](diffhunk://#diff-fdf9a802b639236d024598935ba12a8d8225a8d4de56086a83423135736a80acR14): Added `direct_was_called` field to `SharedData` struct and updated `update_debug_data` function to handle global values, ensuring they are not processed multiple times.

### Updates to Rust Implementations

* [`pil2-components/lib/std/rs/src/std_prod.rs`](diffhunk://#diff-239948267de81643e5916c4ae58838aebb0159f790d1df7a06ffb26be8324f3aL109-R137): Updated `StdProd` implementation to include `is_global` handling in `update_bus` and `update_debug_data` calls.
* [`pil2-components/lib/std/rs/src/std_sum.rs`](diffhunk://#diff-7e5a426db5ea86c4fe8a13e1562636fa5a57389aa401f43af591aabdb45605daL111-R133): Updated `StdSum` implementation to include `is_global` handling in `update_bus` and `update_debug_data` calls.