### PR TITLE
Print to file in debug mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"

--- a/cli/src/commands/prove.rs
+++ b/cli/src/commands/prove.rs
@@ -62,6 +62,9 @@ pub struct ProveCmd {
     #[clap(long)]
     pub print: Option<usize>,
 
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub print_to_file: bool,
+
     #[clap(long, action = clap::ArgAction::Append)]
     pub opids: Option<Vec<String>>,
 }
@@ -92,7 +95,8 @@ impl ProveCmd {
             });
 
             let n_values = self.print.unwrap_or(DEFAULT_PRINT_VALS);
-            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values)
+            let print_to_file = self.print_to_file;
+            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values, print_to_file)
         } else {
             self.debug.into()
         };

--- a/cli/src/commands/verify_constraints.rs
+++ b/cli/src/commands/verify_constraints.rs
@@ -50,6 +50,9 @@ pub struct VerifyConstraintsCmd {
     #[clap(long)]
     pub print: Option<usize>,
 
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub print_to_file: bool,
+
     #[clap(long, action = clap::ArgAction::Append)]
     pub opids: Option<Vec<String>>,
 }
@@ -74,7 +77,8 @@ impl VerifyConstraintsCmd {
             });
 
             let n_values = self.print.unwrap_or(DEFAULT_PRINT_VALS);
-            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values)
+            let print_to_file = self.print_to_file;
+            StdMode::new(proofman_common::ModeName::Debug, op_ids, n_values, print_to_file)
         } else {
             self.debug.into()
         };

--- a/common/src/std_mode.rs
+++ b/common/src/std_mode.rs
@@ -9,23 +9,24 @@ pub struct StdMode {
     pub name: ModeName,
     pub opids: Option<Vec<u64>>,
     pub n_vals: usize,
+    pub print_to_file: bool,
 }
 
 impl StdMode {
-    pub const fn new(name: ModeName, opids: Option<Vec<u64>>, n_vals: usize) -> Self {
+    pub const fn new(name: ModeName, opids: Option<Vec<u64>>, n_vals: usize, print_to_file: bool) -> Self {
         if n_vals == 0 {
             panic!("n_vals must be greater than 0");
         }
 
-        Self { name, opids, n_vals }
+        Self { name, opids, n_vals, print_to_file }
     }
 }
 
 impl From<u8> for StdMode {
     fn from(v: u8) -> Self {
         match v {
-            0 => StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS),
-            1 => StdMode::new(ModeName::Debug, None, DEFAULT_PRINT_VALS),
+            0 => StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS, false),
+            1 => StdMode::new(ModeName::Debug, None, DEFAULT_PRINT_VALS, false),
             _ => panic!("Invalid mode"),
         }
     }
@@ -33,7 +34,7 @@ impl From<u8> for StdMode {
 
 impl Default for StdMode {
     fn default() -> Self {
-        StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS)
+        StdMode::new(ModeName::Standard, None, DEFAULT_PRINT_VALS, false)
     }
 }
 

--- a/pil2-components/lib/std/rs/src/std_prod.rs
+++ b/pil2-components/lib/std/rs/src/std_prod.rs
@@ -320,8 +320,9 @@ impl<F: PrimeField> WitnessComponent<F> for StdProd<F> {
         if self.mode.name == ModeName::Debug {
             let name = Self::MY_NAME;
             let max_values_to_print = self.mode.n_vals;
+            let print_to_file = self.mode.print_to_file;
             let debug_data = self.debug_data.as_ref().expect("Debug data missing");
-            print_debug_info(name, max_values_to_print, debug_data);
+            print_debug_info(name, max_values_to_print, print_to_file, debug_data);
         }
     }
 }

--- a/pil2-components/lib/std/rs/src/std_sum.rs
+++ b/pil2-components/lib/std/rs/src/std_sum.rs
@@ -344,8 +344,9 @@ impl<F: PrimeField> WitnessComponent<F> for StdSum<F> {
         if self.mode.name == ModeName::Debug {
             let name = Self::MY_NAME;
             let max_values_to_print = self.mode.n_vals;
+            let print_to_file = self.mode.print_to_file;
             let debug_data = self.debug_data.as_ref().expect("Debug data missing");
-            print_debug_info(name, max_values_to_print, debug_data);
+            print_debug_info(name, max_values_to_print, print_to_file, debug_data);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a feature to optionally print debug information to a file instead of standard output.

Key changes include:

### Command Structures:
* Added a new boolean flag `print_to_file` to `ProveCmd` and `VerifyConstraintsCmd` structs to enable printing debug information to a file.

### Mode Initialization:
* Updated the `StdMode` struct and its constructor to include the `print_to_file` flag.
* Modified `StdMode::new` calls to accommodate the new `print_to_file` parameter.

### Debug Printing:
* Enhanced the `print_debug_info` function to handle writing to a file if the `print_to_file` flag is set, including creating the necessary directory and file.
* Updated calls to `print_debug_info` in `StdProd` and `StdSum` implementations to pass the `print_to_file` flag.

These changes ensure that debug information can be optionally redirected to a file, improving flexibility and usability in different debugging scenarios.