### PR TITLE
Adding features to virtual tables 

### DIFF
--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -1,8 +1,6 @@
 require "std_constants.pil";
 require "std_lookup.pil";
 
-// TODO: Integrate the division table function here
-
 // TODO: Improve specified_ranges division, so that it does not create a new multiplicity
 // for each opid, but instead fills the N up until the end
 

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -3,6 +3,7 @@ require "std_lookup.pil";
 
 // TODO: Improve specified_ranges division, so that it does not create a new multiplicity
 // for each opid, but instead fills the N up until the end
+// Problem: I need to create an additional fixed because multiple OPIDS will coexist in the same slice
 
 /*
  * Module for performing selected range checks over expressions of any degree.
@@ -79,10 +80,6 @@ int MAX_SPECIFIED_BITS = -1; // -1 indicates that the bits is specified on deman
                              // and is set to be the maximum of all specified ranges
 
 function set_max_u8_bits(const int bits) {
-    if (U8_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_u8_bits() has no effect when the U8 table has been set virtual.");
-    }
-
     if (bits < 1 || bits > 8) {
         error(`The u8 bits should be between 1 and 8, got ${bits} instead`);
     }
@@ -91,10 +88,6 @@ function set_max_u8_bits(const int bits) {
 }
 
 function set_max_u16_bits(const int bits) {
-    if (U16_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_u16_bits() has no effect when the U16 table has been set virtual.");
-    }
-
     if (bits < 1 || bits > 16) {
         error(`The u16 bits should be between 1 and 16, got ${bits} instead`);
     }
@@ -103,10 +96,6 @@ function set_max_u16_bits(const int bits) {
 }
 
 function set_max_specified_bits(const int bits) {
-    if (SPECIFIED_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_specified_bits() has no effect when the specified table has been set virtual.");
-    }
-
     if (bits < 1) {
         error(`The specified bits should be greater than or equal to 1, got ${bits} instead`);
     }
@@ -115,20 +104,8 @@ function set_max_specified_bits(const int bits) {
 }
 
 function set_max_std_tables_bits(const int bits) {
-    if (U8_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_std_tables_bits() has no effect on the U8 table since it has been set virtual.");
-    }
-
-    if (U16_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_std_tables_bits() has no effect on the U16 table since it has been set virtual.");
-    }
-
-    if (SPECIFIED_TABLE_VIRTUAL == 1) {
-        println("[Warning] set_max_std_tables_bits() has no effect on the specified table since it has been set virtual.");
-    }
-
-    if (bits < 0) {
-        error(`The input bits should be greater than or equal to 0, got ${bits} instead`);
+    if (bits < 1) {
+        error(`The input bits should be greater than or equal to 1, got ${bits} instead`);
     }
 
     set_max_u8_bits(bits > 8 ? 8 : bits);

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -5,6 +5,10 @@ require "std_lookup.pil";
 // for each opid, but instead fills the N up until the end
 // Problem: I need to create an additional fixed because multiple OPIDS will coexist in the same slice
 
+
+// TODO: Function that isolates particular ranges, instead of parameter.
+// Everything is in a single table by default.
+
 /*
  * Module for performing selected range checks over expressions of any degree.
  * This module provides three independent user interfaces:
@@ -224,6 +228,9 @@ airtemplate SpecifiedRanges(const int N, const int opids[], const int opids_coun
     }
 }
 
+// airtemplate RangeCheckTable() {
+// }
+
 /**
  * Performs a range check on a expression within a specified range.
  *
@@ -252,6 +259,11 @@ function range_check(const expr expression, const int min, const int max, const 
         println(` -  U8: [0, ${MASK_8}]`);
         println(` - U16: [0, ${MASK_16}]`);
     }
+
+    // TODOOOO
+    // If the range already exists or it is included in an already existing range, reuse
+    // lookup_assumes(opid, [expression], sel, PIOP_NAME_RANGE_CHECK);
+
 
     // Define the range check assumes
     if (absorb) {

--- a/pil2-components/lib/std/pil/std_virtual_table.pil
+++ b/pil2-components/lib/std/pil/std_virtual_table.pil
@@ -1,6 +1,8 @@
 require "std_constants.pil";
 require "std_lookup.pil";
 
+// TODO: Add the possibility of different table sizes for the different virtual tables
+
 int MAX_VIRTUAL_BITS = -1; // -1 indicates that the bits is specified on demand
                            // and is set to be the maximum of all specified ranges
 
@@ -10,6 +12,18 @@ function set_max_virtual_bits(const int bits) {
     }
 
     MAX_VIRTUAL_BITS = bits;
+}
+
+int MAX_NUM_VIRTUAL_TABLES = 1; // Number of virtual tables
+
+function set_max_num_virtual_tables(const int num) {
+    if (num <= 0) {
+        error(`The input number of virtual tables should be greater than 0, got ${num} instead`);
+    } else if (num == 1) {
+        println("[Warning] The number of virtual tables is 1 by default. set_num_virtual_tables() has no effect.");
+    }
+
+    MAX_NUM_VIRTUAL_TABLES = num;
 }
 
 function collect_virtual_table(const int uid, const expr table[]) {
@@ -118,135 +132,184 @@ function pack_tables() {
         }
     }
 
-    int ordered_uids[vt.num_tables];
-    int ordered_acc_heights[vt.num_tables];
-    int ordered_acc_height = 0;
-    for (int i = 0; i < vt.num_tables; i++) {
-        const int idx = ordered_tables[i];
-        const int height = vt.heights[idx];
-        ordered_uids[i] = vt.uids[idx];
-        ordered_acc_heights[i] = ordered_acc_height;
-        ordered_acc_height += height;
-    }
-    @virtual_table_data{uids: ordered_uids, acc_heights: ordered_acc_heights};
-
-    int max_bits = 0;
+    // Compute the maximum and minimum bits for the table
+    int max_bits;
     if (MAX_VIRTUAL_BITS == -1) {
         // Take the bits that makes the total height fit
-        int num_rows = 1;
-        while (num_rows < vt.total_height) {
-            num_rows *= 2;
+        max_bits = 0;
+        while ((1 << max_bits) < vt.total_height) {
             max_bits++;
         }
     } else {
         // Use the specified bits
         max_bits = MAX_VIRTUAL_BITS;
     }
+    // TODO: For now we assume that min_bits == max_bits and therefore the height of the table to be 2**max_bits
+    //       We can remove this limitation in a future, when area computation gets more precise
     const int min_bits = max_bits;
 
-    // Proceed with the packing
-    // TODO: In the worst case N = 1, which creates a packing with total_height number of groups
-    //       This can be too much for array limit, so we limit the number of groups to ARRAY_SIZE
-    //       We can remove this limitation in a future if we consider more strategies for packing.
-    const int min_rows = 1 << min_bits;
-    const int min_groups = (vt.total_height + min_rows - 1) / min_rows;
-    if (min_groups > ARRAY_SIZE) {
-        error(`The number of bits=${min_bits} set in the virtual table generates too many groups=${min_groups} > max_groups=${ARRAY_SIZE}. Consider setting more virtual bits via set_max_virtual_bits()`);
+    // If the number of rows already fit the total height, then compute a single table
+    const int num_rows = 1 << max_bits;
+    if (num_rows >= vt.total_height) {
+        MAX_NUM_VIRTUAL_TABLES = 1;
     }
-    int min_area;
-    int bits_best_pack;
-    int uids_best_pack[ARRAY_SIZE][vt.num_tables];
-    int tables_best_pack[ARRAY_SIZE][vt.num_tables];
-    int widths_best_pack[ARRAY_SIZE];
-    int lens_best_pack[ARRAY_SIZE];
-    int num_groups_best_pack = 0;
-    // TODO: Try all heights from 2^min_bits to 2^max_bits and choose the best one
-    //       For this to be applied, the area formula needs to consider the prover costs
-    for (int i = min_bits; i <= max_bits; i++) {
-        // Compute the number of rows and the number of groups
-        const int num_rows = 1 << i;
-        const int num_groups = (vt.total_height + num_rows - 1) / num_rows;
 
-        // Compute the packing
-        int uids_pack[num_groups][vt.num_tables];
-        int tables_pack[num_groups][vt.num_tables];
-        int widths_pack[num_groups];
-        int lens_pack[num_groups];
-        int used_area[num_groups];
-        int available_height = num_rows;
-        int offset = 0;
-        for (int j = 0; j < vt.num_tables; j++) {
-            const int table_id = ordered_tables[j];
-            const int width = vt.widths[table_id];
-            int height = vt.heights[table_id];
+    // Divide the ordered tables by MAX_NUM_VIRTUAL_TABLES of approximately equal height
+    // Note: A table is never placed into two or more AIRs
+    int ordered_tables_air[MAX_NUM_VIRTUAL_TABLES][vt.num_tables];
+    int ordered_tables_air_height[MAX_NUM_VIRTUAL_TABLES];
+    int ordered_tables_air_len[MAX_NUM_VIRTUAL_TABLES];
+    for (int i = 0; i < MAX_NUM_VIRTUAL_TABLES; i++) {
+        ordered_tables_air_height[i] = 0;
+        ordered_tables_air_len[i] = 0;
+    }
 
-            while (height > 0) {
-                if (height <= available_height) {
-                    // It fits entirely
-                    available_height -= height;
-                    used_area[offset] += width * height;
-                    height = 0;
-                } else {
-                    // Only part fits, so cut and place what we can
-                    height -= available_height;
-                    used_area[offset] += width * available_height;
-                    available_height = 0;
+    const int max_height_by_vt = (vt.total_height + MAX_NUM_VIRTUAL_TABLES - 1) / MAX_NUM_VIRTUAL_TABLES;
+    int table_offset = 0;
+    int num_virtual_tables = MAX_NUM_VIRTUAL_TABLES;
+    for (int i = 0; i < MAX_NUM_VIRTUAL_TABLES; i++) {
+        if (table_offset >= vt.num_tables) {
+            num_virtual_tables = i;
+            break;
+        }
+
+        int col_offset = 0;
+        for (int j = table_offset; j < vt.num_tables; j++) {
+            const int idx = ordered_tables[j];
+            if ((col_offset > 0) && (ordered_tables_air_height[i] + vt.heights[idx] > max_height_by_vt)) {
+                break;
+            }
+
+            ordered_tables_air_height[i] += vt.heights[idx];
+            ordered_tables_air[i][col_offset] = idx;
+            ordered_tables_air_len[i]++;
+            col_offset++;
+        }
+
+        table_offset += col_offset;
+    }
+
+    for (int i = 0; i < num_virtual_tables; i++) {
+        const int total_height = ordered_tables_air_height[i];
+        const int num_tables = ordered_tables_air_len[i];
+
+        // Proceed with the packing
+        // TODO: In the worst case N = 1, which creates a packing with total_height number of groups
+        //       This can be too much for array limit, so we limit the number of groups to ARRAY_SIZE
+        //       We can remove this limitation in a future if we consider more strategies for packing.
+        const int min_rows = 1 << min_bits;
+        const int min_groups = (total_height + min_rows - 1) / min_rows;
+        if (min_groups > ARRAY_SIZE) {
+            error(`The number of bits=${min_bits} set in the virtual table generates too many groups=${min_groups} > max_groups=${ARRAY_SIZE}. Consider setting more virtual bits via set_max_virtual_bits()`);
+        }
+        int min_area;
+        int bits_best_pack;
+        int uids_best_pack[ARRAY_SIZE][num_tables];
+        int tables_best_pack[ARRAY_SIZE][num_tables];
+        int widths_best_pack[ARRAY_SIZE];
+        int lens_best_pack[ARRAY_SIZE];
+        int num_groups_best_pack = 0;
+        // TODO: Try all heights from 2^min_bits to 2^max_bits and choose the best one
+        //       For this to be applied, the area formula needs to consider the prover costs
+        for (int j = min_bits; j <= max_bits; j++) {
+            // Compute the number of rows and the number of groups
+            const int num_rows = 1 << j;
+            const int num_groups = (total_height + num_rows - 1) / num_rows;
+
+            // Compute the packing
+            int uids_pack[num_groups][num_tables];
+            int tables_pack[num_groups][num_tables];
+            int widths_pack[num_groups];
+            int lens_pack[num_groups];
+            int used_area[num_groups];
+            int available_height = num_rows;
+            int offset = 0;
+            for (int k = 0; k < num_tables; k++) {
+                const int table_id = ordered_tables_air[i][k];
+                const int width = vt.widths[table_id];
+                int height = vt.heights[table_id];
+
+                while (height > 0) {
+                    if (height <= available_height) {
+                        // It fits entirely
+                        available_height -= height;
+                        used_area[offset] += width * height;
+                        height = 0;
+                    } else {
+                        // Only part fits, so cut and place what we can
+                        height -= available_height;
+                        used_area[offset] += width * available_height;
+                        available_height = 0;
+                    }
+
+                    // Update the uids and the number of tables in the current group
+                    tables_pack[offset][lens_pack[offset]] = table_id;
+                    uids_pack[offset][lens_pack[offset]] = vt.uids[table_id];
+                    lens_pack[offset]++;
+
+                    if (available_height == 0) {
+                        // Close the current table
+                        widths_pack[offset] = width; // Since they are ordered by width,
+                                                    // the width representative is the last one that fits
+                        offset++;
+
+                        // Start a new table
+                        available_height = num_rows;
+                    }
                 }
+            }
 
-                // Update the uids and the number of tables in the current group
-                tables_pack[offset][lens_pack[offset]] = table_id;
-                uids_pack[offset][lens_pack[offset]] = vt.uids[table_id];
-                lens_pack[offset]++;
+            // If the last table is partially filled, we need to add a complete new table
+            if (available_height < num_rows) {
+                widths_pack[offset] = vt.widths[ordered_tables_air[i][num_tables - 1]];
+            }
 
-                if (available_height == 0) {
-                    // Close the current table
-                    widths_pack[offset] = width; // Since they are ordered by width,
-                                                 // the width representative is the last one that fits
-                    offset++;
+            // Compute the area of the packing
+            int wasted_area = 0;
+            int fixed_area = 0;
+            for (int k = 0; k < num_groups; k++) {
+                wasted_area += num_rows*widths_pack[k] - used_area[k];
+                fixed_area += (1 + widths_pack[k]);
+            }
+            const int witness_area = (num_groups + 3 + 3 * (num_groups / 2));
+            const int area = num_rows * (fixed_area + witness_area);
+            // println(`Height: 2^${j}, Wasted area: ${wasted_area}, Fixed area: ${num_rows*fixed_area}, Witness area: ${num_rows*witness_area}, Area: ${area}, #Groups: ${num_groups}`);
 
-                    // Start a new table
-                    available_height = num_rows;
+            if ((j == min_bits) || (area < min_area)) {
+                // If this is the first iteration or the area is smaller than the minimum found,
+                // update the minimum area and the chosen height
+                min_area = area;
+                bits_best_pack = j;
+                num_groups_best_pack = num_groups;
+                for (int k = 0; k < num_groups; k++) {
+                    widths_best_pack[k] = widths_pack[k];
+                    tables_best_pack[k] = tables_pack[k];
+                    uids_best_pack[k] = uids_pack[k];
+                    lens_best_pack[k] = lens_pack[k];
                 }
             }
         }
 
-        // If the last table is partially filled, we need to add a complete new table
-        if (available_height < num_rows) {
-            widths_pack[offset] = vt.widths[ordered_tables[vt.num_tables - 1]];
-        }
-
-        // Compute the area of the packing
-        int wasted_area = 0;
-        int fixed_area = 0;
-        for (int j = 0; j < num_groups; j++) {
-            wasted_area += num_rows*widths_pack[j] - used_area[j];
-            fixed_area += (1 + widths_pack[j]);
-        }
-        const int witness_area = (num_groups + 3 + 3 * (num_groups / 2));
-        const int area = num_rows * (fixed_area + witness_area);
-        // println(`Height: 2^${i}, Wasted area: ${wasted_area}, Fixed area: ${num_rows*fixed_area}, Witness area: ${num_rows*witness_area}, Area: ${area}, #Groups: ${num_groups}`);
-
-        if ((i == min_bits) || (area < min_area)) {
-            // If this is the first iteration or the area is smaller than the minimum found,
-            // update the minimum area and the chosen height
-            min_area = area;
-            bits_best_pack = i;
-            num_groups_best_pack = num_groups;
-            for (int j = 0; j < num_groups; j++) {
-                widths_best_pack[j] = widths_pack[j];
-                tables_best_pack[j] = tables_pack[j];
-                uids_best_pack[j] = uids_pack[j];
-                lens_best_pack[j] = lens_pack[j];
-            }
-        }
+        // Compute the length of the virtual table
+        const int num_rows = 1 << bits_best_pack;
+        VirtualTable(num_rows, uids_best_pack, tables_best_pack, widths_best_pack, lens_best_pack, num_groups_best_pack, i) alias `VirtualTable${i}`;
     }
-
-    // Compute the length of the virtual table
-    const int num_rows = 1 << bits_best_pack;
-    VirtualTable(num_rows, uids_best_pack, tables_best_pack, widths_best_pack, lens_best_pack, num_groups_best_pack);
 }
 
-airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][], const int widths[], const int lens[], const int num_groups) {    
+airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][], const int widths[], const int lens[], const int num_groups, const int air_idx) {       
+    // Issue information useful for hints
+    int ordered_uids[num_tables];
+    int ordered_acc_heights[num_tables];
+    int ordered_acc_height = 0;
+    for (int j = 0; j < num_tables; j++) {
+        const int idx = ordered_tables_air[i][j];
+        const int height = vt.heights[idx];
+        ordered_uids[j] = vt.uids[idx];
+        ordered_acc_heights[j] = ordered_acc_height;
+        ordered_acc_height += height;
+    }
+    @virtual_table_data{uids: ordered_uids, acc_heights: ordered_acc_heights, num_groups: num_groups};
+
     // Compute the number of fixed and witness columns
     int sum_widths = 0;
     for (int i = 0; i < num_groups; i++) {
@@ -258,8 +321,6 @@ airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][
     col fixed UID[num_groups];
     col fixed column[sum_widths];
     col witness multiplicity[num_groups];
-
-    @virtual_table_data{num_groups: num_groups};
 
     // Prove the groups
     int col_offset = 0;
@@ -322,13 +383,16 @@ airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][
 
     // save the airgroup id and air id of the table for latter use
     container proof.std.virtual_table {
-        int airgroup_id = AIRGROUP_ID;
-        int air_id = AIR_ID;
+        int airgroup_ids[num_virtual_tables];
+        int air_ids[num_virtual_tables];
     }
+    proof.std.virtual_table.airgroup_ids[air_idx] = AIRGROUP_ID;
+    proof.std.virtual_table.air_ids[air_idx] = AIR_ID;
+
     on final proof issue_virtual_table_data_global();
 }
 
 private function issue_virtual_table_data_global() {
     use proof.std.virtual_table;
-    @virtual_table_data_global{airgroup_id: airgroup_id, air_id: air_id};
+    @virtual_table_data_global{airgroup_ids: airgroup_ids, air_ids: air_ids};
 }

--- a/pil2-components/lib/std/pil/std_virtual_table.pil
+++ b/pil2-components/lib/std/pil/std_virtual_table.pil
@@ -26,6 +26,32 @@ function set_max_num_virtual_tables(const int num) {
     MAX_NUM_VIRTUAL_TABLES = num;
 }
 
+int isolated_uids[ARRAY_SIZE];
+int isolated_uids_len = 0;
+
+function set_virtual_table_isolated(const int uid) {
+    if (AIR_ID == -1) {
+        error(`set_virtual_table_isolated() can only be called inside an AIR. TABLE_ID: ${uid}`);
+    }
+
+    if (VIRTUAL == 0) {
+        error(`set_virtual_table_isolated() cannot by called from a non-virtual table. TABLE_ID: ${uid}, AIRGROUP_ID: ${AIRGROUP_ID}, AIR_ID: ${AIR_ID}`);
+    }
+
+    if (isolated_uids_len >= ARRAY_SIZE) {
+        error("Exceeded maximum number of isolated UIDs");
+    }
+
+    for (int i = 0; i < isolated_uids_len; i++) {
+        if (isolated_uids[i] == uid) {
+            error(`Table ${uid} is already set to be isolated`);
+        }
+    }
+
+    isolated_uids[isolated_uids_len] = uid;
+    isolated_uids_len++;
+}
+
 function collect_virtual_table(const int uid, const expr table[]) {
     // Check whether the inputs are valid
     const int w = length(table);
@@ -50,6 +76,7 @@ function collect_virtual_table(const int uid, const expr table[]) {
         int widths[ARRAY_SIZE];
         int heights[ARRAY_SIZE];
         int uids[ARRAY_SIZE];
+        int isolated[ARRAY_SIZE];
         int num_tables = 0;
         int total_height = 0;
     }
@@ -106,14 +133,67 @@ function collect_virtual_table(const int uid, const expr table[]) {
 function pack_tables() {
     use airgroup.std.virtual_table alias vt;
 
-    // Order the tables by width in ascending order and then by height in descending order
-    int ordered_tables[vt.num_tables];
-    for (int i = 0; i < vt.num_tables; i++) {
-        ordered_tables[i] = i;
+    // Mark isolated tables
+    for (int i = 0; i < isolated_uids_len; i++) {
+        const int uid = isolated_uids[i];
+        // Find the table with this uid and mark it as isolated
+        for (int j = 0; j < vt.num_tables; j++) {
+            if (vt.uids[j] == uid) {
+                vt.isolated[j] = 1;
+                break;
+            }
+        }
     }
 
-    for (int i = 0; i < vt.num_tables - 1; i++) {
-        for (int j = i + 1; j < vt.num_tables; j++) {
+    // Separate tables into isolated and non-isolated
+    int non_isolated_tables[vt.num_tables];
+    int isolated_tables[vt.num_tables];
+    int non_isolated_count = 0;
+    int isolated_count = 0;
+    int non_isolated_total_height = 0;
+    int isolated_total_height = 0;
+    for (int i = 0; i < vt.num_tables; i++) {
+        if (vt.isolated[i] == 1) {
+            isolated_tables[isolated_count] = i;
+            isolated_count++;
+            isolated_total_height += vt.heights[i];
+        } else {
+            non_isolated_tables[non_isolated_count] = i;
+            non_isolated_count++;
+            non_isolated_total_height += vt.heights[i];
+        }
+    }
+
+    // Compute the maximum and minimum bits for the non-isolated virtual tables
+    int max_bits;
+    if (MAX_VIRTUAL_BITS == -1) {
+        // Take the bits that makes the total height fit
+        max_bits = 0;
+        while ((1 << max_bits) < non_isolated_total_height) {
+            max_bits++;
+        }
+    } else {
+        // Use the specified bits
+        max_bits = MAX_VIRTUAL_BITS;
+    }
+    // TODO: For now we assume that min_bits == max_bits and therefore the height of the table to be 2**max_bits
+    //       We can remove this limitation in a future, when area computation gets more precise
+    const int min_bits = max_bits;
+
+    // If the number of rows already fit the total height, then compute a single table
+    const int num_rows = 1 << max_bits;
+    if (num_rows >= non_isolated_total_height) {
+        MAX_NUM_VIRTUAL_TABLES = 1;
+    }
+
+    // Order the tables by width in ascending order and then by height in descending order
+    int ordered_tables[non_isolated_count];
+    for (int i = 0; i < non_isolated_count; i++) {
+        ordered_tables[i] = non_isolated_tables[i];
+    }
+
+    for (int i = 0; i < non_isolated_count - 1; i++) {
+        for (int j = i + 1; j < non_isolated_count; j++) {
             const int idx_i = ordered_tables[i];
             const int idx_j = ordered_tables[j];
 
@@ -132,31 +212,9 @@ function pack_tables() {
         }
     }
 
-    // Compute the maximum and minimum bits for the table
-    int max_bits;
-    if (MAX_VIRTUAL_BITS == -1) {
-        // Take the bits that makes the total height fit
-        max_bits = 0;
-        while ((1 << max_bits) < vt.total_height) {
-            max_bits++;
-        }
-    } else {
-        // Use the specified bits
-        max_bits = MAX_VIRTUAL_BITS;
-    }
-    // TODO: For now we assume that min_bits == max_bits and therefore the height of the table to be 2**max_bits
-    //       We can remove this limitation in a future, when area computation gets more precise
-    const int min_bits = max_bits;
-
-    // If the number of rows already fit the total height, then compute a single table
-    const int num_rows = 1 << max_bits;
-    if (num_rows >= vt.total_height) {
-        MAX_NUM_VIRTUAL_TABLES = 1;
-    }
-
     // Divide the ordered tables by MAX_NUM_VIRTUAL_TABLES of approximately equal height
     // Note: A table is never placed into two or more AIRs
-    int ordered_tables_air[MAX_NUM_VIRTUAL_TABLES][vt.num_tables];
+    int ordered_tables_air[MAX_NUM_VIRTUAL_TABLES][non_isolated_count];
     int ordered_tables_air_height[MAX_NUM_VIRTUAL_TABLES];
     int ordered_tables_air_len[MAX_NUM_VIRTUAL_TABLES];
     for (int i = 0; i < MAX_NUM_VIRTUAL_TABLES; i++) {
@@ -164,17 +222,17 @@ function pack_tables() {
         ordered_tables_air_len[i] = 0;
     }
 
-    const int max_height_by_vt = (vt.total_height + MAX_NUM_VIRTUAL_TABLES - 1) / MAX_NUM_VIRTUAL_TABLES;
+    const int max_height_by_vt = (non_isolated_total_height + MAX_NUM_VIRTUAL_TABLES - 1) / MAX_NUM_VIRTUAL_TABLES;
     int table_offset = 0;
-    int num_virtual_tables = MAX_NUM_VIRTUAL_TABLES;
+    int num_non_isolated_virtual_tables = MAX_NUM_VIRTUAL_TABLES;
     for (int i = 0; i < MAX_NUM_VIRTUAL_TABLES; i++) {
-        if (table_offset >= vt.num_tables) {
-            num_virtual_tables = i;
+        if (table_offset >= non_isolated_count) {
+            num_non_isolated_virtual_tables = i;
             break;
         }
 
         int col_offset = 0;
-        for (int j = table_offset; j < vt.num_tables; j++) {
+        for (int j = table_offset; j < non_isolated_count; j++) {
             const int idx = ordered_tables[j];
             if ((col_offset > 0) && (ordered_tables_air_height[i] + vt.heights[idx] > max_height_by_vt)) {
                 break;
@@ -189,42 +247,85 @@ function pack_tables() {
         table_offset += col_offset;
     }
 
-    for (int i = 0; i < num_virtual_tables; i++) {
-        const int total_height = ordered_tables_air_height[i];
-        const int num_tables = ordered_tables_air_len[i];
+    const int num_virtual_tables = num_non_isolated_virtual_tables + isolated_count;
+    container proof.std.virtual_table {
+        int airgroup_ids[num_virtual_tables];
+        int air_ids[num_virtual_tables];
+    }
+
+    // Instantiate the isolated tables (each gets its own virtual table)
+    for (int i = 0; i < isolated_count; i++) {
+        const int table_idx = isolated_tables[i];
+        const int height = vt.heights[table_idx];
+        const int width = vt.widths[table_idx];
+        const int uid = vt.uids[table_idx];
+
+        // Compute required bits for this isolated table
+        int bits;
+        if (MAX_VIRTUAL_BITS == -1) {
+            bits = 0;
+            while ((1 << bits) < height) {
+                bits++;
+            }
+        } else {
+            bits = MAX_VIRTUAL_BITS;
+        }
+
+        const int num_rows = 1 << bits;
+        const int num_groups = (height + num_rows - 1) / num_rows;
+
+        // Create arrays for the VirtualTable template
+        int uids_pack[num_groups][1];
+        int tables_pack[num_groups][1];
+        int widths_pack[num_groups];
+        int lens_pack[num_groups];
+        for (int j = 0; j < num_groups; j++) {
+            uids_pack[j][0] = uid;
+            tables_pack[j][0] = table_idx;
+            widths_pack[j] = width;
+            lens_pack[j] = 1;
+        }
+
+        VirtualTable(num_rows, [table_idx], 1, height, uids_pack, tables_pack, widths_pack, lens_pack, num_groups, i, 1) alias `VirtualTable${i}`;
+    }
+
+    // Instantiate the non-isolated tables
+    for (int i = 0; i < num_non_isolated_virtual_tables; i++) {
+        const int total_height_air = ordered_tables_air_height[i];
+        const int num_tables_air = ordered_tables_air_len[i];
 
         // Proceed with the packing
-        // TODO: In the worst case N = 1, which creates a packing with total_height number of groups
+        // TODO: In the worst case N = 1, which creates a packing with total_height_air number of groups
         //       This can be too much for array limit, so we limit the number of groups to ARRAY_SIZE
         //       We can remove this limitation in a future if we consider more strategies for packing.
         const int min_rows = 1 << min_bits;
-        const int min_groups = (total_height + min_rows - 1) / min_rows;
-        if (min_groups > ARRAY_SIZE) {
-            error(`The number of bits=${min_bits} set in the virtual table generates too many groups=${min_groups} > max_groups=${ARRAY_SIZE}. Consider setting more virtual bits via set_max_virtual_bits()`);
+        const int max_num_groups = (total_height_air + min_rows - 1) / min_rows;
+        if (max_num_groups > ARRAY_SIZE) {
+            error(`The number of bits=${min_bits} set in the virtual table generates too many groups=${max_num_groups} > max_num_groups=${ARRAY_SIZE}. Consider setting more virtual bits via set_max_virtual_bits()`);
         }
         int min_area;
         int bits_best_pack;
-        int uids_best_pack[ARRAY_SIZE][num_tables];
-        int tables_best_pack[ARRAY_SIZE][num_tables];
-        int widths_best_pack[ARRAY_SIZE];
-        int lens_best_pack[ARRAY_SIZE];
-        int num_groups_best_pack = 0;
+        int uids_best_pack[max_num_groups][num_tables_air];
+        int tables_best_pack[max_num_groups][num_tables_air];
+        int widths_best_pack[max_num_groups];
+        int lens_best_pack[max_num_groups];
+        int num_groups_best_pack;
         // TODO: Try all heights from 2^min_bits to 2^max_bits and choose the best one
         //       For this to be applied, the area formula needs to consider the prover costs
         for (int j = min_bits; j <= max_bits; j++) {
             // Compute the number of rows and the number of groups
             const int num_rows = 1 << j;
-            const int num_groups = (total_height + num_rows - 1) / num_rows;
+            const int num_groups = (total_height_air + num_rows - 1) / num_rows;
 
             // Compute the packing
-            int uids_pack[num_groups][num_tables];
-            int tables_pack[num_groups][num_tables];
+            int uids_pack[num_groups][num_tables_air];
+            int tables_pack[num_groups][num_tables_air];
             int widths_pack[num_groups];
             int lens_pack[num_groups];
             int used_area[num_groups];
             int available_height = num_rows;
             int offset = 0;
-            for (int k = 0; k < num_tables; k++) {
+            for (int k = 0; k < num_tables_air; k++) {
                 const int table_id = ordered_tables_air[i][k];
                 const int width = vt.widths[table_id];
                 int height = vt.heights[table_id];
@@ -261,7 +362,7 @@ function pack_tables() {
 
             // If the last table is partially filled, we need to add a complete new table
             if (available_height < num_rows) {
-                widths_pack[offset] = vt.widths[ordered_tables_air[i][num_tables - 1]];
+                widths_pack[offset] = vt.widths[ordered_tables_air[i][num_tables_air - 1]];
             }
 
             // Compute the area of the packing
@@ -292,35 +393,42 @@ function pack_tables() {
 
         // Compute the length of the virtual table
         const int num_rows = 1 << bits_best_pack;
-        VirtualTable(num_rows, uids_best_pack, tables_best_pack, widths_best_pack, lens_best_pack, num_groups_best_pack, i) alias `VirtualTable${i}`;
+        const int air_idx = isolated_count + i;
+        VirtualTable(num_rows, ordered_tables_air[i], num_tables_air, total_height_air, uids_best_pack, tables_best_pack, widths_best_pack, lens_best_pack, num_groups_best_pack, air_idx, 0) alias `VirtualTable${air_idx}`;
     }
+
+    on final proof issue_virtual_table_data_global();
 }
 
-airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][], const int widths[], const int lens[], const int num_groups, const int air_idx) {       
-    // Issue information useful for hints
-    int ordered_uids[num_tables];
-    int ordered_acc_heights[num_tables];
-    int ordered_acc_height = 0;
-    for (int j = 0; j < num_tables; j++) {
-        const int idx = ordered_tables_air[i][j];
-        const int height = vt.heights[idx];
-        ordered_uids[j] = vt.uids[idx];
-        ordered_acc_heights[j] = ordered_acc_height;
-        ordered_acc_height += height;
-    }
-    @virtual_table_data{uids: ordered_uids, acc_heights: ordered_acc_heights, num_groups: num_groups};
-
+airtemplate VirtualTable(const int N, const int tables[], const int num_tables, const int total_height, const int uids[][], const int table_ids[][], const int widths[], const int lens[], const int num_groups, const int air_idx, const int isolated) {
     // Compute the number of fixed and witness columns
     int sum_widths = 0;
     for (int i = 0; i < num_groups; i++) {
         sum_widths += widths[i];
     }
 
-    // println(`Virtual table instantiated with N: 2^${log2(N)}, #Fixed: ${num_groups + sum_widths}, #Witness: ${num_groups}`);
-
     col fixed UID[num_groups];
     col fixed column[sum_widths];
     col witness multiplicity[num_groups];
+
+    // Issue hint information
+    int flatten_uids[num_tables];
+    int acc_heights[num_tables];
+    int acc_total_height = 0;
+    const string is_isolated = (isolated == 1) ? "isolated" : "non-isolated";
+    println(`VirtualTable${air_idx} [${is_isolated}] instantiated with: N=2^${log2(N)}, #Fixed=${num_groups + sum_widths}, #Witness=${num_groups}, Total Height=${total_height}, Total Divisions=${num_groups}.`);
+    println("Table composition:");
+    for (int i = 0; i < num_tables; i++) {
+        const int idx = tables[i];
+        const int uid = vt.uids[idx];
+        const int height = vt.heights[idx];
+        const int width = vt.widths[idx];
+        flatten_uids[i] = uid;
+        acc_heights[i] = acc_total_height;
+        acc_total_height += height;
+        println(`   - Table ${uid} with height=${height} and width=${width}`);
+    }
+    @virtual_table_data{uids: flatten_uids, acc_heights: acc_heights, num_muls: num_groups};
 
     // Prove the groups
     int col_offset = 0;
@@ -382,14 +490,8 @@ airtemplate VirtualTable(const int N, const int uids[][], const int table_ids[][
     }
 
     // save the airgroup id and air id of the table for latter use
-    container proof.std.virtual_table {
-        int airgroup_ids[num_virtual_tables];
-        int air_ids[num_virtual_tables];
-    }
     proof.std.virtual_table.airgroup_ids[air_idx] = AIRGROUP_ID;
     proof.std.virtual_table.air_ids[air_idx] = AIR_ID;
-
-    on final proof issue_virtual_table_data_global();
 }
 
 private function issue_virtual_table_data_global() {

--- a/pil2-components/lib/std/rs/src/range_check/std_range_check.rs
+++ b/pil2-components/lib/std/rs/src/range_check/std_range_check.rs
@@ -185,7 +185,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
             let is_virtual = hint_data.is_virtual;
             let virtual_id = if is_virtual {
                 // Get the virtual table ID
-                virtual_table.get_id(hint_data.opid as usize)
+                virtual_table.get_global_id_from_uid(hint_data.opid as usize)
             } else {
                 0
             };
@@ -300,7 +300,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let row = U8Air::get_global_row(value as u8);
 
                     // Increment the virtual row
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_row(
+                    self.virtual_table.inc_virtual_row(
                         range_item.virtual_id,
                         row,
                         multiplicity,
@@ -317,7 +317,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let row = U16Air::get_global_row(value as u16);
 
                     // Increment the virtual row
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_row(
+                    self.virtual_table.inc_virtual_row(
                         range_item.virtual_id,
                         row,
                         multiplicity,
@@ -337,7 +337,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let rows = vec![U8Air::get_global_row(lower_value), U8Air::get_global_row(upper_value)];
 
                     // Increment the virtual row
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_rows_same_mul(
+                    self.virtual_table.inc_virtual_rows_same_mul(
                         range_item.virtual_id,
                         &rows,
                         multiplicity,
@@ -359,7 +359,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let rows = vec![U16Air::get_global_row(lower_value), U16Air::get_global_row(upper_value)];
 
                     // Increment the virtual rows
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_rows_same_mul(
+                    self.virtual_table.inc_virtual_rows_same_mul(
                         range_item.virtual_id,
                         &rows,
                         multiplicity,
@@ -376,7 +376,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let row = SpecifiedRanges::get_global_row(range_item.data.min, value);
 
                     // Increment the virtual rows
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_row(
+                    self.virtual_table.inc_virtual_row(
                         range_item.virtual_id,
                         row,
                         multiplicity,
@@ -409,7 +409,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let rows = U8Air::get_global_rows(&vals);
 
                     // Increment the virtual rows
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_rows(
+                    self.virtual_table.inc_virtual_rows(
                         range_item.virtual_id,
                         &rows,
                         &values,
@@ -427,7 +427,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let rows = U16Air::get_global_rows(&vals);
 
                     // Increment the virtual rows
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_rows(
+                    self.virtual_table.inc_virtual_rows(
                         range_item.virtual_id,
                         &rows,
                         &values,
@@ -443,7 +443,7 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     let rows = SpecifiedRanges::get_global_rows(range_item.data.min, &vals);
 
                     // Increment the virtual rows
-                    self.virtual_table.virtual_table_air.as_ref().unwrap().inc_virtual_rows(
+                    self.virtual_table.inc_virtual_rows(
                         range_item.virtual_id,
                         &rows,
                         &values,

--- a/pil2-components/lib/std/rs/src/std.rs
+++ b/pil2-components/lib/std/rs/src/std.rs
@@ -6,7 +6,6 @@ use proofman_common::{ProofCtx, SetupCtx, StdMode};
 
 use crate::{StdProd, StdRangeCheck, StdSum, StdVirtualTable};
 
-
 pub struct Std<F: PrimeField64> {
     // STD mode
     pub mode: RwLock<StdMode>,
@@ -43,9 +42,9 @@ impl<F: PrimeField64> Std<F> {
         self.range_check.get_range_id(min, max, predefined)
     }
 
-    /// Gets the virtual table ID for a given ID
-    pub fn get_virtual_table_id(&self, id: usize) -> usize {
-        self.virtual_table.get_id(id)
+    /// Gets the virtual table ID for a given UID
+    pub fn get_virtual_table_id(&self, uid: usize) -> usize {
+        self.virtual_table.get_global_id_from_uid(uid)
     }
 
     pub fn range_check(&self, id: usize, val: i64, multiplicity: u64) {

--- a/pil2-components/lib/std/rs/src/std_virtual_table.rs
+++ b/pil2-components/lib/std/rs/src/std_virtual_table.rs
@@ -2,7 +2,7 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
-    },
+    }
 };
 use proofman_util::create_buffer_fast;
 use rayon::prelude::*;
@@ -14,11 +14,12 @@ use witness::WitnessComponent;
 use proofman_common::{AirInstance, BufferPool, ProofCtx, SetupCtx, TraceInfo};
 use proofman_hints::{get_hint_ids_by_name, HintFieldOptions};
 
-use crate::{get_global_hint_field_constant_as, get_hint_field_constant_a_as, get_hint_field_constant_as};
+use crate::{get_global_hint_field_constant_a_as, get_hint_field_constant_a_as, get_hint_field_constant_as};
 
 pub struct StdVirtualTable<F: PrimeField64> {
     _phantom: std::marker::PhantomData<F>,
-    pub virtual_table_air: Option<Arc<VirtualTableAir>>,
+    pub global_id_map: Vec<(usize, usize, usize)>, // global_idx -> (air_idx, uid, uid_idx)
+    pub virtual_table_airs: Option<Vec<Arc<VirtualTableAir>>>,
 }
 pub struct VirtualTableAir {
     airgroup_id: usize,
@@ -27,7 +28,7 @@ pub struct VirtualTableAir {
     mask: u64,
     num_rows: usize,
     num_cols: usize,
-    uids: Vec<(usize, u64)>, // (uid, acc_height)
+    acc_heights: Vec<u64>,
     multiplicities: Vec<Vec<AtomicU64>>,
     instance_id: AtomicU64,
     calculated: AtomicBool,
@@ -38,95 +39,116 @@ impl<F: PrimeField64> StdVirtualTable<F> {
         // Get relevant data from the global hint
         let virtual_table_global_hint = get_hint_ids_by_name(sctx.get_global_bin(), "virtual_table_data_global");
         if virtual_table_global_hint.is_empty() {
-            return Arc::new(Self { _phantom: std::marker::PhantomData, virtual_table_air: None });
+            return Arc::new(Self { 
+                _phantom: std::marker::PhantomData, 
+                global_id_map: Vec::new(),
+                virtual_table_airs: None,
+            });
         }
 
-        let airgroup_id = get_global_hint_field_constant_as(sctx, virtual_table_global_hint[0], "airgroup_id");
-        let air_id = get_global_hint_field_constant_as(sctx, virtual_table_global_hint[0], "air_id");
+        // Get the airgroup ids and air ids of the virtual tables
+        let airgroup_ids = get_global_hint_field_constant_a_as::<usize, F>(sctx, virtual_table_global_hint[0], "airgroup_ids");
+        let air_ids = get_global_hint_field_constant_a_as::<usize, F>(sctx, virtual_table_global_hint[0], "air_ids");
 
-        // Get the Virtual Table structure
-        let setup = sctx.get_setup(airgroup_id, air_id);
-        let hint_id = get_hint_ids_by_name(setup.p_setup.p_expressions_bin, "virtual_table_data")[0] as usize;
+        let num_virtual_tables = airgroup_ids.len();
+        let mut virtual_tables = Vec::with_capacity(num_virtual_tables);
+        let mut global_id_map = Vec::new();
+        let mut current_global_id = 0;
+        for i in 0..num_virtual_tables {
+            let airgroup_id = airgroup_ids[i];
+            let air_id = air_ids[i];
 
-        let hint_opt = HintFieldOptions::default();
-        let uids =
-            get_hint_field_constant_a_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "uids", hint_opt.clone());
-        let acc_heights =
-            get_hint_field_constant_a_as::<u64, F>(sctx, airgroup_id, air_id, hint_id, "acc_heights", hint_opt.clone());
+            // Get the Virtual Table structure
+            let setup = sctx.get_setup(airgroup_id, air_id);
+            let hint_id = get_hint_ids_by_name(setup.p_setup.p_expressions_bin, "virtual_table_data")[0] as usize;
 
-        // Map each uid to an ordered set of indexes
-        let num_uids = uids.len();
-        let mut idxs = vec![(0, 0); num_uids];
-        for i in 0..num_uids {
-            idxs[i] = (uids[i], acc_heights[i]);
+            let hint_opt = HintFieldOptions::default();
+            let uids =
+                get_hint_field_constant_a_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "uids", hint_opt.clone());
+            let acc_heights =
+                get_hint_field_constant_a_as::<u64, F>(sctx, airgroup_id, air_id, hint_id, "acc_heights", hint_opt.clone());
+            let num_groups =
+                get_hint_field_constant_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "num_groups", hint_opt.clone());
+
+            // Map each uid to an ordered set of indexes
+            let num_uids = uids.len();
+            for j in 0..num_uids {
+                // Update global ID mapping: global_idx -> (air_idx, uid, uid_idx)
+                global_id_map.insert(current_global_id, (i, uids[j], j));
+                current_global_id += 1;
+            }
+
+            let num_rows = pctx.global_info.airs[airgroup_id][air_id].num_rows;
+            let multiplicities = (0..num_groups as usize)
+                .into_par_iter()
+                .map(|_| (0..num_rows).into_par_iter().map(|_| AtomicU64::new(0)).collect())
+                .collect();
+
+            let virtual_table_air = VirtualTableAir {
+                airgroup_id,
+                air_id,
+                shift: num_rows.trailing_zeros() as u64,
+                mask: (num_rows - 1) as u64,
+                num_rows,
+                num_cols: num_groups as usize,
+                acc_heights,
+                multiplicities,
+                instance_id: AtomicU64::new(0),
+                calculated: AtomicBool::new(false),
+            };
+            virtual_tables.push(Arc::new(virtual_table_air));
         }
 
-        let hint_id = get_hint_ids_by_name(setup.p_setup.p_expressions_bin, "virtual_table_data")[1] as usize;
-        let num_groups =
-            get_hint_field_constant_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "num_groups", hint_opt.clone());
-        let num_rows = pctx.global_info.airs[airgroup_id][air_id].num_rows;
-        let multiplicities = (0..num_groups as usize)
-            .into_par_iter()
-            .map(|_| (0..num_rows).into_par_iter().map(|_| AtomicU64::new(0)).collect())
-            .collect();
-
-        let virtual_table_air = VirtualTableAir {
-            airgroup_id,
-            air_id,
-            shift: num_rows.trailing_zeros() as u64,
-            mask: (num_rows - 1) as u64,
-            num_rows,
-            num_cols: num_groups as usize,
-            uids: idxs,
-            multiplicities,
-            instance_id: AtomicU64::new(0),
-            calculated: AtomicBool::new(false),
-        };
-
-        Arc::new(Self { _phantom: std::marker::PhantomData, virtual_table_air: Some(Arc::new(virtual_table_air)) })
+        Arc::new(Self { 
+            _phantom: std::marker::PhantomData, 
+            global_id_map, 
+            virtual_table_airs: Some(virtual_tables),
+        })
     }
 
-    pub fn get_id(&self, id: usize) -> usize {
-        self.virtual_table_air.as_ref().unwrap().get_id(id)
+    /// Returns the global ID for a given UID.
+    pub fn get_global_id_from_uid(&self, uid: usize) -> usize {
+        self.global_id_map.iter()
+            .position(|&(_, u, _)| u == uid)
+            .unwrap_or_else(|| panic!("UID {uid} not found in the global ID map"))
     }
 
-    pub fn inc_virtual_row(&self, id: usize, row: u64, multiplicity: u64) {
-        self.virtual_table_air.as_ref().unwrap().inc_virtual_row(id, row, multiplicity);
+    pub fn inc_virtual_row(&self, global_id: usize, row: u64, multiplicity: u64) {
+        let (air_idx, _, uid_idx) = self.global_id_map[global_id];
+
+        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_row(uid_idx, row, multiplicity);
     }
 
-    pub fn inc_virtual_rows(&self, id: usize, rows: &[u64], multiplicities: &[u32]) {
-        self.virtual_table_air.as_ref().unwrap().inc_virtual_rows(id, rows, multiplicities);
+    pub fn inc_virtual_rows(&self, global_id: usize, rows: &[u64], multiplicities: &[u32]) {
+        let (air_idx, _, uid_idx) = self.global_id_map[global_id];
+
+        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows(uid_idx, rows, multiplicities);
     }
 
-    pub fn inc_virtual_rows_same_mul(&self, id: usize, rows: &[u64], multiplicity: u64) {
-        self.virtual_table_air.as_ref().unwrap().inc_virtual_rows_same_mul(id, rows, multiplicity);
+    pub fn inc_virtual_rows_same_mul(&self, global_id: usize, rows: &[u64], multiplicity: u64) {
+        let (air_idx, _, uid_idx) = self.global_id_map[global_id];
+
+        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows_same_mul(uid_idx, rows, multiplicity);
     }
 
-    pub fn inc_virtual_rows_ranged(&self, id: usize, ranged_values: &[u64]) {
-        self.virtual_table_air.as_ref().unwrap().inc_virtual_rows_ranged(id, ranged_values);
+    pub fn inc_virtual_rows_ranged(&self, global_id: usize, ranged_values: &[u64]) {
+        let (air_idx, _, uid_idx) = self.global_id_map[global_id];
+
+        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows_ranged(uid_idx, ranged_values);
     }
 }
 
 impl<F: PrimeField64> WitnessComponent<F> for StdVirtualTable<F> {}
 
 impl VirtualTableAir {
-    pub fn get_id(&self, id: usize) -> usize {
-        if let Some(pos) = self.uids.iter().position(|&(uid, _)| uid == id) {
-            pos
-        } else {
-            tracing::error!("ID {} not found in the virtual table", id);
-            panic!();
-        }
-    }
-
     /// Processes a slice of input data and updates the multiplicity table.
-    pub fn inc_virtual_row(&self, id: usize, row: u64, multiplicity: u64) {
+    pub fn inc_virtual_row(&self, idx: usize, row: u64, multiplicity: u64) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
         // Get the table offset
-        let table_offset = self.uids[id].1; // Acc height of the table
+        let table_offset = self.acc_heights[idx];
 
         // Get the offset
         let offset = table_offset + row;
@@ -141,13 +163,13 @@ impl VirtualTableAir {
         self.multiplicities[sub_table_idx as usize][row_idx as usize].fetch_add(multiplicity, Ordering::Relaxed);
     }
 
-    pub fn inc_virtual_rows(&self, id: usize, rows: &[u64], multiplicities: &[u32]) {
+    pub fn inc_virtual_rows(&self, idx: usize, rows: &[u64], multiplicities: &[u32]) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
         // Get the table offset
-        let table_offset = self.uids[id].1; // Acc height of the table
+        let table_offset = self.acc_heights[idx];
 
         for (&row, &multiplicity) in rows.iter().zip(multiplicities.iter()) {
             if multiplicity == 0 {
@@ -170,13 +192,13 @@ impl VirtualTableAir {
     }
 
     /// Processes a slice of input data and updates the multiplicity table.
-    pub fn inc_virtual_rows_same_mul(&self, id: usize, rows: &[u64], multiplicity: u64) {
+    pub fn inc_virtual_rows_same_mul(&self, idx: usize, rows: &[u64], multiplicity: u64) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
         // Get the table offset
-        let table_offset = self.uids[id].1; // Acc height of the table
+        let table_offset = self.acc_heights[idx];
 
         for row in rows.iter() {
             // Get the offset
@@ -193,13 +215,13 @@ impl VirtualTableAir {
         }
     }
 
-    pub fn inc_virtual_rows_ranged(&self, id: usize, ranged_values: &[u64]) {
+    pub fn inc_virtual_rows_ranged(&self, idx: usize, ranged_values: &[u64]) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
         // Get the table offset
-        let table_offset = self.uids[id].1; // Acc height of the table
+        let table_offset = self.acc_heights[idx];
 
         for (row, &multiplicity) in ranged_values.iter().enumerate() {
             if multiplicity == 0 {

--- a/pil2-components/lib/std/rs/src/std_virtual_table.rs
+++ b/pil2-components/lib/std/rs/src/std_virtual_table.rs
@@ -67,8 +67,8 @@ impl<F: PrimeField64> StdVirtualTable<F> {
                 get_hint_field_constant_a_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "uids", hint_opt.clone());
             let acc_heights =
                 get_hint_field_constant_a_as::<u64, F>(sctx, airgroup_id, air_id, hint_id, "acc_heights", hint_opt.clone());
-            let num_groups =
-                get_hint_field_constant_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "num_groups", hint_opt.clone());
+            let num_muls =
+                get_hint_field_constant_as::<usize, F>(sctx, airgroup_id, air_id, hint_id, "num_muls", hint_opt.clone());
 
             // Map each uid to an ordered set of indexes
             let num_uids = uids.len();
@@ -79,7 +79,7 @@ impl<F: PrimeField64> StdVirtualTable<F> {
             }
 
             let num_rows = pctx.global_info.airs[airgroup_id][air_id].num_rows;
-            let multiplicities = (0..num_groups as usize)
+            let multiplicities = (0..num_muls as usize)
                 .into_par_iter()
                 .map(|_| (0..num_rows).into_par_iter().map(|_| AtomicU64::new(0)).collect())
                 .collect();
@@ -90,7 +90,7 @@ impl<F: PrimeField64> StdVirtualTable<F> {
                 shift: num_rows.trailing_zeros() as u64,
                 mask: (num_rows - 1) as u64,
                 num_rows,
-                num_cols: num_groups as usize,
+                num_cols: num_muls as usize,
                 acc_heights,
                 multiplicities,
                 instance_id: AtomicU64::new(0),

--- a/pil2-components/test/std/virtual_tables/rs/src/component9.rs
+++ b/pil2-components/test/std/virtual_tables/rs/src/component9.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use witness::{define_wc_with_std, execute, WitnessComponent};
+use proofman_common::{BufferPool, FromTrace, AirInstance, ProofCtx, SetupCtx};
+
+use fields::PrimeField64;
+use rand::{
+    distr::{Distribution, StandardUniform},
+    rngs::StdRng,
+    Rng, SeedableRng,
+};
+
+use crate::{Component9Trace, Table9};
+
+define_wc_with_std!(Component9, "Component9");
+
+impl<F: PrimeField64> WitnessComponent<F> for Component9<F>
+where
+    StandardUniform: Distribution<F>,
+{
+    execute!(Component9Trace, 1);
+
+    fn calculate_witness(
+        &self,
+        stage: u32,
+        pctx: Arc<ProofCtx<F>>,
+        _sctx: Arc<SetupCtx<F>>,
+        instance_ids: &[usize],
+        _n_cores: usize,
+        buffer_pool: &dyn BufferPool<F>,
+    ) {
+        if stage == 1 {
+            let mut rng = StdRng::seed_from_u64(self.seed.load(Ordering::Relaxed));
+
+            let mut trace = Component9Trace::new_from_vec(buffer_pool.take_buffer());
+            let num_rows = trace.num_rows();
+
+            tracing::debug!("··· Starting witness computation stage {}", 1);
+
+            // Get the virtual table ID
+            let id = self.std_lib.get_virtual_table_id(9);
+
+            // Assumes
+            let t = trace[0].a.len();
+            for i in 0..num_rows {
+                let val = rng.random_range(0..num_rows) as u64;
+                for j in 0..t {
+                    trace[i].a[j] = F::from_u64(val);
+                }
+
+                // Get the row
+                let row = Table9::calculate_table_row(val);
+
+                // Update the virtual table rows
+                self.std_lib.inc_virtual_row(id, row, 1);
+            }
+
+            let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));
+            pctx.add_air_instance(air_instance, instance_ids[0]);
+        }
+    }
+}

--- a/pil2-components/test/std/virtual_tables/rs/src/lib.rs
+++ b/pil2-components/test/std/virtual_tables/rs/src/lib.rs
@@ -6,6 +6,7 @@ mod component5;
 mod component6;
 // mod component7; // TODO
 mod component8;
+mod component9;
 mod pil_helpers;
 mod table1;
 mod table2;
@@ -15,6 +16,7 @@ mod table5;
 mod table6;
 // mod table7; // TODO
 mod table8;
+mod table9;
 mod virtual_tables_lib;
 
 pub use component1::*;
@@ -25,6 +27,7 @@ pub use component5::*;
 pub use component6::*;
 // pub use component7::*;
 pub use component8::*;
+pub use component9::*;
 pub use pil_helpers::*;
 pub use table1::*;
 pub use table2::*;
@@ -34,4 +37,5 @@ pub use table5::*;
 pub use table6::*;
 // pub use table7::*;
 pub use table8::*;
+pub use table9::*;
 pub use virtual_tables_lib::*;

--- a/pil2-components/test/std/virtual_tables/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/std/virtual_tables/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use rayon::prelude::*;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "768dd13bfff3a05a37e5db62af22481eafe009ccc981e0d9b25f3024ea112dce";
+pub const PILOUT_HASH: &str = "d8c460714dbad0684c6b91c775d20e560dabbc758b6887354c1e75ca7af98c46";
 
 //AIRGROUP CONSTANTS
 
@@ -42,7 +42,13 @@ pub const TABLE_7_AIR_IDS: &[usize] = &[7];
 
 pub const COMPONENT_8_AIR_IDS: &[usize] = &[8];
 
-pub const VIRTUAL_TABLE_AIR_IDS: &[usize] = &[9];
+pub const COMPONENT_9_AIR_IDS: &[usize] = &[9];
+
+pub const VIRTUAL_TABLE_0_AIR_IDS: &[usize] = &[10];
+
+pub const VIRTUAL_TABLE_1_AIR_IDS: &[usize] = &[11];
+
+pub const VIRTUAL_TABLE_2_AIR_IDS: &[usize] = &[12];
 
   
 trace!(Component1Fixed<F> {
@@ -117,13 +123,37 @@ trace!(Component8Trace<F> {
  a: [F; 3],
 },  0, 8, 1024 );
 
-trace!(VirtualTableFixed<F> {
- UID: [F; 3], column: [F; 8], __L1__: F,
-},  0, 9, 32768 );
+trace!(Component9Fixed<F> {
+ __L1__: F,
+},  0, 9, 1048576 );
 
-trace!(VirtualTableTrace<F> {
- multiplicity: [F; 3],
-},  0, 9, 32768 );
+trace!(Component9Trace<F> {
+ a: [F; 4],
+},  0, 9, 1048576 );
+
+trace!(VirtualTable0Fixed<F> {
+ UID: [F; 32], column: [F; 128], __L1__: F,
+},  0, 10, 32768 );
+
+trace!(VirtualTable0Trace<F> {
+ multiplicity: [F; 32],
+},  0, 10, 32768 );
+
+trace!(VirtualTable1Fixed<F> {
+ UID: [F; 2], column: [F; 2], __L1__: F,
+},  0, 11, 32768 );
+
+trace!(VirtualTable1Trace<F> {
+ multiplicity: [F; 2],
+},  0, 11, 32768 );
+
+trace!(VirtualTable2Fixed<F> {
+ UID: [F; 1], column: [F; 6], __L1__: F,
+},  0, 12, 32768 );
+
+trace!(VirtualTable2Trace<F> {
+ multiplicity: [F; 1],
+},  0, 12, 32768 );
 
 values!(Component1AirGroupValues<F> {
  gsum_result: FieldExtension<F>,
@@ -161,6 +191,18 @@ values!(Component8AirGroupValues<F> {
  gsum_result: FieldExtension<F>,
 });
 
-values!(VirtualTableAirGroupValues<F> {
+values!(Component9AirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(VirtualTable0AirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(VirtualTable1AirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(VirtualTable2AirGroupValues<F> {
  gsum_result: FieldExtension<F>,
 });

--- a/pil2-components/test/std/virtual_tables/rs/src/table9.rs
+++ b/pil2-components/test/std/virtual_tables/rs/src/table9.rs
@@ -1,0 +1,9 @@
+pub struct Table9;
+
+impl Table9 {
+    const N: u64 = 1_048_576; // 2**20
+
+    pub fn calculate_table_row(val: u64) -> u64 {
+        (Self::N - 1) - val
+    }
+}

--- a/pil2-components/test/std/virtual_tables/rs/src/virtual_tables_lib.rs
+++ b/pil2-components/test/std/virtual_tables/rs/src/virtual_tables_lib.rs
@@ -10,7 +10,7 @@ use rand::{
 
 use crate::{
     Component1, Component2, Component3, Component4, Component5, Component6, /*Component7, Table7*/
-    Component8,
+    Component8, Component9
 };
 use proofman::register_std;
 
@@ -35,6 +35,7 @@ where
         // let table7 = Table7::new();
         // let component7 = Component7::new(table7.clone());
         let component8 = Component8::new(std.clone());
+        let component9 = Component9::new(std.clone());
         component1.set_seed(seed);
         component2.set_seed(seed);
         component3.set_seed(seed);
@@ -43,6 +44,7 @@ where
         component6.set_seed(seed);
         // component7.set_seed(seed);
         component8.set_seed(seed);
+        component9.set_seed(seed);
 
         wcm.register_component(component1);
         wcm.register_component(component2);
@@ -53,5 +55,6 @@ where
         // wcm.register_component(table7);
         // wcm.register_component(component7);
         wcm.register_component(component8);
+        wcm.register_component(component9);
     }
 }

--- a/pil2-components/test/std/virtual_tables/virtual_tables.pil
+++ b/pil2-components/test/std/virtual_tables/virtual_tables.pil
@@ -56,7 +56,8 @@ airtemplate TablePadded(const int N, const int opid) {
 
 airgroup VirtualTables {
     set_range_check_tables_virtual(); // Enable virtual tables for range checks
-    set_max_virtual_bits(15); // Set the maximum bits for virtual tables
+    set_max_virtual_bits(16); // Set the maximum bits for virtual tables
+    set_max_num_virtual_tables(3); // Set the maximum number of virtual tables
 
     // Virtual tables
     Component(N: 2**5, t: 5, opid: 1) alias Component1;

--- a/pil2-components/test/std/virtual_tables/virtual_tables.pil
+++ b/pil2-components/test/std/virtual_tables/virtual_tables.pil
@@ -26,14 +26,16 @@ airtemplate ComponentRC(const int N, const int t, const int opid) {
 
 airtemplate Table(const int N, const int t, const int opid) {
     col fixed A[t];
-    for (int i = 0; i < N; i++) {
-        for (int j = 0; j < t; j++) {
-            A[j][i] = (N - 1) - i;
-        }
+    for (int i = 0; i < t; i++) {
+        A[i] = [(N-1)..0...]; // [(N-1)..0];
     }
 
     col witness multiplicity;
     lookup_proves(opid, A, mul: multiplicity);
+
+    if (VIRTUAL == 1 && opid == 9) {
+        set_virtual_table_isolated(opid); // Set this table as virtually isolated
+    }
 }
 
 airtemplate TablePadded(const int N, const int opid) {
@@ -56,7 +58,7 @@ airtemplate TablePadded(const int N, const int opid) {
 
 airgroup VirtualTables {
     set_range_check_tables_virtual(); // Enable virtual tables for range checks
-    set_max_virtual_bits(16); // Set the maximum bits for virtual tables
+    set_max_virtual_bits(15); // Set the maximum bits for virtual tables
     set_max_num_virtual_tables(3); // Set the maximum number of virtual tables
 
     // Virtual tables
@@ -85,4 +87,8 @@ airgroup VirtualTables {
     // Non power-of-two virtual tables
     Component(N: 2**10, t: 3, opid: 8) alias Component8;
     virtual TablePadded(N: 48, opid: 8) alias Table8;
+
+    // Big table
+    Component(N: 2**20, t: 4, opid: 9) alias Component9;
+    virtual Table(N: 2**20, t: 4, opid: 9) alias Table9;
 }

--- a/proofman/src/utils.rs
+++ b/proofman/src/utils.rs
@@ -634,8 +634,10 @@ pub fn register_std<F: PrimeField64>(wcm: &WitnessManager<F>, std: &Std<F>) {
     }
 
     wcm.register_component_std(std.virtual_table.clone());
-    if std.virtual_table.virtual_table_air.is_some() {
-        wcm.register_component_std(std.virtual_table.virtual_table_air.clone().unwrap());
+    if std.virtual_table.virtual_table_airs.is_some() {
+        for air in std.virtual_table.virtual_table_airs.clone().unwrap() {
+            wcm.register_component_std(air);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the following features to virtual tables:
1. It can now be set a maximum number of virtual tables:
    ```
    airgroup VirtualTables {
      set_max_num_virtual_tables(3);
    }
    ``` 
    the std takes this number and tries to get closer to it, taking less tables if results fit better.
2. It can now be set a virtual table as isolated, so that a virtual table is created to itself alone:
    ```
    airtemplate Table {
     ...

      if (VIRTUAL == 1) {
        set_virtual_table_isolated(opid);
      }
    }
    ``` 