### PR TITLE
fix build with newer gcc

### DIFF
--- a/pil2-stark/src/rapidsnark/polynomial/cpolynomial.c.hpp
+++ b/pil2-stark/src/rapidsnark/polynomial/cpolynomial.c.hpp
@@ -3,6 +3,8 @@
 
 #include "cpolynomial.hpp"
 
+#include <cmath>
+
 using namespace CPlusPlusLogging;
 
 template<typename Engine>

--- a/pil2-stark/src/rapidsnark/polynomial/polynomial.c.hpp
+++ b/pil2-stark/src/rapidsnark/polynomial/polynomial.c.hpp
@@ -554,7 +554,7 @@ void Polynomial<Engine>::divZh(u_int64_t domainSize, int extension) {
         E.fr.neg(this->coef[i], this->coef[i]);
     }
 
-    int nThreads = pow(2, floor(log2(omp_get_max_threads())));
+    int nThreads = pow(2, floor(log2(double(omp_get_max_threads()))));
     uint64_t nElementsThread = domainSize / nThreads;
 
     assert(domainSize == nElementsThread * nThreads);
@@ -608,7 +608,7 @@ void Polynomial<Engine>::divByZerofier(u_int64_t n, FrElement beta) {
         }
     }
 
-    int nThreads = pow(2, floor(log2(omp_get_max_threads())));
+    int nThreads = pow(2, floor(log2(double(omp_get_max_threads()))));
     nThreads = std::min(n, (u_int64_t)nThreads);
 
     uint64_t nElementsThread = n / nThreads;


### PR DESCRIPTION
  In file included from src/rapidsnark/polynomial/polynomial.hpp:109,
                   from src/rapidsnark/polynomial/cpolynomial.hpp:4,
                   from src/rapidsnark/polynomial/cpolynomial.c.hpp:4,
                   from src/rapidsnark/fflonk_setup.hpp:12,
                   from src/rapidsnark/fflonk_setup.cpp:1:
  src/rapidsnark/polynomial/polynomial.c.hpp: In member function 'void Polynomial<Engine>::divZh(u_int64_t, int)':
  src/rapidsnark/polynomial/polynomial.c.hpp:557:37: error: call of overloaded 'log2(int)' is ambiguous
    557 |     int nThreads = pow(2, floor(log2(omp_get_max_threads())));
        |                                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~
  In file included from ./src/ffiasm/multiexp.c.hpp:3,
                   from ./src/ffiasm/multiexp.hpp:49,
                   from ./src/ffiasm/curve.hpp:4,
                   from ./src/ffiasm/alt_bn128.hpp:7,
                   from src/rapidsnark/fflonk_setup.hpp:4:
  ./src/ffiasm/misc.hpp:7:10: note: candidate: 'uint32_t log2(uint32_t)'
      7 | uint32_t log2 (uint32_t value);
        |          ^~~~
  In file included from /usr/include/features.h:524,
                   from /usr/include/bits/libc-header-start.h:33,
                   from /usr/include/stdint.h:26,
                   from ./src/ffiasm/fq.hpp:4,
                   from ./src/ffiasm/alt_bn128.hpp:4:
  /usr/include/bits/mathcalls.h:170:17: note: candidate: 'double log2(double)'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        |                 ^~~~
  /usr/include/sys/cdefs.h:131:25: note: in definition of macro '__CONCAT'
    131 | #define __CONCAT(x,y)   x ## y
        |                         ^
  /usr/include/bits/mathcalls-macros.h:39:15: note: in expansion of macro '__MATH_PRECNAME'
     39 |   extern type __MATH_PRECNAME(function,suffix) args __THROW
        |               ^~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:41:3: note: in expansion of macro '__MATHDECL_1_IMPL'
     41 |   __MATHDECL_1_IMPL(type, function, suffix, args)
        |   ^~~~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:32:3: note: in expansion of macro '__MATHDECL_1'
     32 |   __MATHDECL_1(type, function,suffix, args); \
        |   ^~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:30:3: note: in expansion of macro '__MATHDECL'
     30 |   __MATHDECL (_Mdouble_,function,suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:23:3: note: in expansion of macro '__MATHCALL'
     23 |   __MATHCALL (function, suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls.h:170:1: note: in expansion of macro '__MATHCALL_VEC'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        | ^~~~~~~~~~~~~~
  src/rapidsnark/polynomial/polynomial.c.hpp: In member function 'void Polynomial<Engine>::divByZerofier(u_int64_t, FrElement)':
  src/rapidsnark/polynomial/polynomial.c.hpp:611:37: error: call of overloaded 'log2(int)' is ambiguous
    611 |     int nThreads = pow(2, floor(log2(omp_get_max_threads())));
        |                                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~
  ./src/ffiasm/misc.hpp:7:10: note: candidate: 'uint32_t log2(uint32_t)'
      7 | uint32_t log2 (uint32_t value);
        |          ^~~~
  /usr/include/bits/mathcalls.h:170:17: note: candidate: 'double log2(double)'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        |                 ^~~~
  /usr/include/sys/cdefs.h:131:25: note: in definition of macro '__CONCAT'
    131 | #define __CONCAT(x,y)   x ## y
        |                         ^
  /usr/include/bits/mathcalls-macros.h:39:15: note: in expansion of macro '__MATH_PRECNAME'
     39 |   extern type __MATH_PRECNAME(function,suffix) args __THROW
        |               ^~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:41:3: note: in expansion of macro '__MATHDECL_1_IMPL'
     41 |   __MATHDECL_1_IMPL(type, function, suffix, args)
        |   ^~~~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:32:3: note: in expansion of macro '__MATHDECL_1'
     32 |   __MATHDECL_1(type, function,suffix, args); \
        |   ^~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:30:3: note: in expansion of macro '__MATHDECL'
     30 |   __MATHDECL (_Mdouble_,function,suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:23:3: note: in expansion of macro '__MATHCALL'
     23 |   __MATHCALL (function, suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls.h:170:1: note: in expansion of macro '__MATHCALL_VEC'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        | ^~~~~~~~~~~~~~
  src/rapidsnark/polynomial/cpolynomial.c.hpp: In member function 'Polynomial<Engine>* CPolynomial<Engine>::getPolynomial(FrElement*) const':
  src/rapidsnark/polynomial/cpolynomial.c.hpp:51:35: error: 'pow' is not a member of 'std'; did you mean 'pow'?
     51 |     u_int64_t lengthBuffer = std::pow(2, ((u_int64_t)log2(maxDegree - 1)) + 1);
        |                                   ^~~
  /usr/include/bits/mathcalls.h:177:17: note: 'pow' declared here
    177 | __MATHCALL_VEC (pow,, (_Mdouble_ __x, _Mdouble_ __y));
        |                 ^~~
  /usr/include/sys/cdefs.h:131:25: note: in definition of macro '__CONCAT'
    131 | #define __CONCAT(x,y)   x ## y
        |                         ^
  /usr/include/bits/mathcalls-macros.h:39:15: note: in expansion of macro '__MATH_PRECNAME'
     39 |   extern type __MATH_PRECNAME(function,suffix) args __THROW
        |               ^~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:41:3: note: in expansion of macro '__MATHDECL_1_IMPL'
     41 |   __MATHDECL_1_IMPL(type, function, suffix, args)
        |   ^~~~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:32:3: note: in expansion of macro '__MATHDECL_1'
     32 |   __MATHDECL_1(type, function,suffix, args); \
        |   ^~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:30:3: note: in expansion of macro '__MATHDECL'
     30 |   __MATHDECL (_Mdouble_,function,suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:23:3: note: in expansion of macro '__MATHCALL'
     23 |   __MATHCALL (function, suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls.h:177:1: note: in expansion of macro '__MATHCALL_VEC'
    177 | __MATHCALL_VEC (pow,, (_Mdouble_ __x, _Mdouble_ __y));
        | ^~~~~~~~~~~~~~
  src/rapidsnark/polynomial/cpolynomial.c.hpp:51:58: error: call of overloaded 'log2(u_int64_t)' is ambiguous
     51 |     u_int64_t lengthBuffer = std::pow(2, ((u_int64_t)log2(maxDegree - 1)) + 1);
        |                                                      ~~~~^~~~~~~~~~~~~~~
  ./src/ffiasm/misc.hpp:7:10: note: candidate: 'uint32_t log2(uint32_t)'
      7 | uint32_t log2 (uint32_t value);
        |          ^~~~
  /usr/include/bits/mathcalls.h:170:17: note: candidate: 'double log2(double)'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        |                 ^~~~
  /usr/include/sys/cdefs.h:131:25: note: in definition of macro '__CONCAT'
    131 | #define __CONCAT(x,y)   x ## y
        |                         ^
  /usr/include/bits/mathcalls-macros.h:39:15: note: in expansion of macro '__MATH_PRECNAME'
     39 |   extern type __MATH_PRECNAME(function,suffix) args __THROW
        |               ^~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:41:3: note: in expansion of macro '__MATHDECL_1_IMPL'
     41 |   __MATHDECL_1_IMPL(type, function, suffix, args)
        |   ^~~~~~~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:32:3: note: in expansion of macro '__MATHDECL_1'
     32 |   __MATHDECL_1(type, function,suffix, args); \
        |   ^~~~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:30:3: note: in expansion of macro '__MATHDECL'
     30 |   __MATHDECL (_Mdouble_,function,suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls-macros.h:23:3: note: in expansion of macro '__MATHCALL'
     23 |   __MATHCALL (function, suffix, args)
        |   ^~~~~~~~~~
  /usr/include/bits/mathcalls.h:170:1: note: in expansion of macro '__MATHCALL_VEC'
    170 | __MATHCALL_VEC (log2,, (_Mdouble_ __x));
        | ^~~~~~~~~~~~~~
  make: *** [Makefile:193: build/./src/rapidsnark/fflonk_setup.cpp.o] Error 1
  make: *** Waiting for unfinished jobs....