### PR TITLE
Make verifier no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,19 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,17 +60,17 @@ env_logger = "0.11"
 bytes = "1.7"
 prost = "0.13"
 rand = "0.9"
-num-bigint = "0.4"
+num-bigint = { version = "0.4", default-features = false }
 prost-build = "0.13"
 num-traits = "0.2"
 crossbeam-channel = "0.5.15"
 rayon = "1"
-serde = { version = "1.0.130", features = ["derive"] }
-bytemuck = "1.23.1"
+serde = { version = "1.0.130", default-features = false, features = ["derive"] }
+bytemuck = { version = "1.23.1", default-features = false }
 serde_json = "1.0.68"
 serde_arrays = "0.2"
 colored = "3"
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false }
 libloading = "0.8.7"
 sysinfo = "0.35.1"
 blake3 = "1.3.1"

--- a/fields/src/extended_field.rs
+++ b/fields/src/extended_field.rs
@@ -1,9 +1,9 @@
 use crate::Field;
 use core::array;
-use std::fmt::{Display, Formatter, Result};
+use core::fmt::{Display, Formatter, Result};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::ops::{Index, IndexMut};
+use core::ops::{Index, IndexMut};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct CubicExtensionField<F: Display> {

--- a/fields/src/field.rs
+++ b/fields/src/field.rs
@@ -1,7 +1,7 @@
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::ops::DivAssign;
+use core::ops::DivAssign;
 
 use num_bigint::BigUint;
 use serde::Serialize;

--- a/fields/src/fri.rs
+++ b/fields/src/fri.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 use crate::{CubicExtensionField, Field, Goldilocks};
 
 const OMEGAS_INV: [u64; 33] = [

--- a/fields/src/goldilocks.rs
+++ b/fields/src/goldilocks.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::ops::DivAssign;
+use core::ops::DivAssign;
 
 use num_bigint::BigUint;
 

--- a/fields/src/goldilocks_quintic_extension.rs
+++ b/fields/src/goldilocks_quintic_extension.rs
@@ -1,8 +1,8 @@
-use std::{
-    array,
+use core::{
     fmt::{Display, Formatter, Result},
-    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::array;
 use serde::{Deserialize, Serialize};
 
 use crate::{PrimeField64, Field, ExtensionField, Goldilocks};

--- a/fields/src/lib.rs
+++ b/fields/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 mod goldilocks;
 mod integers;
 mod goldilocks_quintic_extension;

--- a/fields/src/poseidon2.rs
+++ b/fields/src/poseidon2.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 use crate::PrimeField64;
 
 pub const HALF_ROUNDS: usize = 4;

--- a/fields/src/transcript.rs
+++ b/fields/src/transcript.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 use crate::{poseidon2_hash, Field, Goldilocks, PrimeField64};
 
 #[derive(Default)]

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -16,5 +16,6 @@ bytemuck.workspace = true
 zstd.workspace = true
 
 [features]
-default = ["verify"]
+default = ["verify", "std"]
 verify = ["fields/verify"]
+std = []

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod verifier;
 mod vadcop_final_verifier;
 

--- a/verifier/src/verifier.rs
+++ b/verifier/src/verifier.rs
@@ -1,5 +1,7 @@
 use fields::{intt_tiny, verify_fold, verify_mt, CubicExtensionField, Field, Goldilocks, Transcript};
 use bytemuck::cast_slice;
+extern crate alloc;
+use alloc::{vec, vec::Vec, string::String};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
The main goal of this PR is to make the dependency of the verifier on `libstd` optional. This allows integrating the verifier with projects requiring `no_std`.

Concretely, this PR introduces the `std` feature (enabled by default) for the verifier crate.
When compiled as `no_std`, the verifier only supports uncompressed proofs.