### PR TITLE
GPU kernel optimizations: cudaGraph, expression shared memory temps, fold/NTT fixes

### DIFF
--- a/pil2-stark/Makefile
+++ b/pil2-stark/Makefile
@@ -69,9 +69,13 @@ WITNESS_LIB := ./witness_lib
 CXX := g++
 AS := nasm
 ASFLAGS := -f elf64
+CUDA_GRAPH ?= 1
 NVCCFLAGS := -std=c++17 -Xcompiler -fPIC -Xcompiler -mavx2 -O3 $(CUDA_GENCODE_FLAGS) -DGL64_PARTIALLY_REDUCED -D__AVX2__ -D__USE_ASSEMBLY__ -D__ADX__ \
              -I./external/sppark/ff -I./external/sppark -I./external/sppark/util -I./external/sppark/ec -I./external/blst/src \
              -DFEATURE_BN254 --diag-suppress 114
+ifeq ($(CUDA_GRAPH), 1)
+    NVCCFLAGS += -DUSE_CUDA_GRAPH
+endif
 
 # Use the following flag to solve amxtileintrin.h incompatibility or use PROOFMAN_HOST_COMPILER_BIN variable to set the host compiler
 # NVCCFLAGS += --compiler-bindir=/usr/bin/g++-10

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -397,6 +397,14 @@ void free_device_buffers_gpu(void *d_buffers_)
 {
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
 
+    if (d_buffers->streamsData != nullptr) {
+        for (uint64_t i = 0; i < d_buffers->n_total_streams; i++) {
+            d_buffers->streamsData[i].free();
+        }
+        delete[] d_buffers->streamsData;
+        d_buffers->streamsData = nullptr;
+    }
+
     for (int i = 0; i < d_buffers->n_gpus; ++i) {
         cudaSetDevice(d_buffers->my_gpu_ids[i]);
         
@@ -430,13 +438,6 @@ void free_device_buffers_gpu(void *d_buffers_)
     free(d_buffers->pinned_buffer);
     free(d_buffers->pinned_buffer_extra);
     free(d_buffers->gpuMemoryBuffer);
-
-    if (d_buffers->streamsData != nullptr) {
-        for (uint64_t i = 0; i < d_buffers->n_total_streams; i++) {
-            d_buffers->streamsData[i].free();
-        }
-        delete[] d_buffers->streamsData;
-    }
 
     for (auto &outer_pair : d_buffers->air_instances) {
         for (auto &inner_pair : outer_pair.second) {

--- a/pil2-stark/src/goldilocks/src/data_layout.cuh
+++ b/pil2-stark/src/goldilocks/src/data_layout.cuh
@@ -43,6 +43,25 @@ __device__ __forceinline__ uint64_t getBufferOffset(
            + col_block * TILE_HEIGHT + row_block;
 }
 
+// Specialized getBufferOffset when row = chunkBase + threadIdx.x and chunkBase is
+// a multiple of TILE_HEIGHT. Saves the row / TILE_HEIGHT division and row % TILE_HEIGHT
+// modulo since row_block == threadIdx.x and blockX == chunkBase >> TILE_HEIGHT_LOG2.
+__device__ __forceinline__ uint64_t getBufferOffset_pack256(
+    uint64_t chunkBase,
+    uint64_t col,
+    uint64_t nRows,
+    uint64_t nCols
+) {
+    uint64_t blockY = col >> 2;
+    uint64_t blockX = chunkBase >> TILE_HEIGHT_LOG2;
+    uint64_t rem = nCols - (blockY << 2);
+    uint64_t nCols_block = rem < TILE_WIDTH ? rem : TILE_WIDTH;
+    uint64_t col_block = col & 3;
+
+    return (blockY << 2) * nRows + blockX * nCols_block * TILE_HEIGHT
+           + (col_block << TILE_HEIGHT_LOG2) + threadIdx.x;
+}
+
 // Row-major within tiles
 __device__ __forceinline__ uint64_t getBufferOffsetRowMajor(
     uint64_t row,

--- a/pil2-stark/src/goldilocks/src/gl64_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/gl64_tooling.cuh
@@ -304,7 +304,7 @@ struct StreamData{
     bool recursive;
 
     std::mutex mutex_stream_selection;
-    
+
     void initialize(uint64_t max_size_proof, uint32_t gpuId_, uint32_t localStreamId_, bool recursive_, uint64_t merkleTreeArity){
         uint64_t maxExps = 40000; // TODO: CALCULATE IT PROPERLY!
         cudaSetDevice(gpuId_);

--- a/pil2-stark/src/goldilocks/src/gl64_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/gl64_tooling.cuh
@@ -4,6 +4,10 @@
 #include <cstdint>
 #include <cassert>
 #include <atomic>
+#ifdef USE_CUDA_GRAPH
+#include <memory>
+#include "cuda_graph_cache.cuh"
+#endif
 #include "goldilocks_base_field.hpp"
 #ifndef __GOLDILOCKS_ENV__
 #include "gpu_timer.cuh"
@@ -303,6 +307,10 @@ struct StreamData{
         
     bool recursive;
 
+#ifdef USE_CUDA_GRAPH
+    std::unique_ptr<CudaGraphCache> graph_cache;
+#endif
+
     std::mutex mutex_stream_selection;
 
     void initialize(uint64_t max_size_proof, uint32_t gpuId_, uint32_t localStreamId_, bool recursive_, uint64_t merkleTreeArity){
@@ -327,6 +335,10 @@ struct StreamData{
         airgroupId = UINT64_MAX;
         airId = UINT64_MAX;
         arity = merkleTreeArity;
+
+    #ifdef USE_CUDA_GRAPH
+        graph_cache = std::make_unique<CudaGraphCache>();
+    #endif
 
         transcript = new TranscriptGL_GPU(merkleTreeArity,
                                     true,
@@ -362,6 +374,9 @@ struct StreamData{
 
     void free(){
         cudaSetDevice(gpuId);
+#ifdef USE_CUDA_GRAPH
+        graph_cache.reset();
+#endif
         cudaStreamDestroy(stream);
         cudaEventDestroy(end_event);
         cudaFreeHost(pinned_buffer_proof);

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
@@ -396,10 +396,19 @@ __global__ void nttDitButterflyKernel(gl64_t *data, gl64_t *twiddles, gl64_t* d_
                 uint32_t ggp = gbi & (ggs - 1);
                 factor = twiddles[ggp*((1 << maxLogDomainSize) >> (gs + 1))];
             }
-            for(int j=0; j<ncols_block; j++){
-                gl64_t odd_sub = tile[ j*BATCH_HEIGHT + index2] * factor;
-                tile[j*BATCH_HEIGHT +index2] = tile[j*BATCH_HEIGHT + index1] - odd_sub;
-                tile[j*BATCH_HEIGHT +index1] = tile[j*BATCH_HEIGHT + index1] + odd_sub;
+            if (ncols_block == BATCH_WIDTH) {
+                #pragma unroll
+                for(int j=0; j<BATCH_WIDTH; j++){
+                    gl64_t odd_sub = tile[ j*BATCH_HEIGHT + index2] * factor;
+                    tile[j*BATCH_HEIGHT +index2] = tile[j*BATCH_HEIGHT + index1] - odd_sub;
+                    tile[j*BATCH_HEIGHT +index1] = tile[j*BATCH_HEIGHT + index1] + odd_sub;
+                }
+            } else {
+                for(int j=0; j<ncols_block; j++){
+                    gl64_t odd_sub = tile[ j*BATCH_HEIGHT + index2] * factor;
+                    tile[j*BATCH_HEIGHT +index2] = tile[j*BATCH_HEIGHT + index1] - odd_sub;
+                    tile[j*BATCH_HEIGHT +index1] = tile[j*BATCH_HEIGHT + index1] + odd_sub;
+                }
             }
         }
         __syncthreads();

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
@@ -87,14 +87,12 @@ void nttDitLde( gl64_t *data, gl64_t **d_r_, gl64_t **d_fwd_twiddle_factors, gl6
 // Launch: <<<ceil(N/256), 256>>>
 __global__ void applyCosetShiftKernel(gl64_t *d_cmQ, gl64_t *d_q, gl64_t *d_S, Goldilocks::Element shiftIn, uint64_t N, uint64_t NExtended, uint64_t extendBits, uint64_t qDeg, uint64_t qDim)
 {
-    d_S[0] = gl64_t(uint64_t(1));
-    for(uint64_t i = 1; i < qDeg; ++i) {
-        d_S[i] = gl64_t(shiftIn.fe) * d_S[i - 1];
-    }
     int row = blockIdx.x * blockDim.x + threadIdx.x;
     if (row >= N)
         return;
 
+    // Compute S values inline per-thread in registers instead of via global memory
+    gl64_t s_val = gl64_t(uint64_t(1));
     for (uint64_t p = 0; p < qDeg; p++)
     {
         Goldilocks3GPU::Element src;
@@ -106,7 +104,7 @@ __global__ void applyCosetShiftKernel(gl64_t *d_cmQ, gl64_t *d_q, gl64_t *d_S, G
 
         Goldilocks3GPU::mul((Goldilocks3GPU::Element &)dst,
                             (Goldilocks3GPU::Element &)src,
-                            d_S[p]);
+                            s_val);
         d_cmQ[getBufferOffsetRowMajor(row, p * qDim, NExtended, qDeg * qDim)] = dst[0];
         d_cmQ[getBufferOffsetRowMajor(row, p * qDim + 1, NExtended, qDeg * qDim)] = dst[1];
         d_cmQ[getBufferOffsetRowMajor(row, p * qDim + 2, NExtended, qDeg * qDim)] = dst[2];
@@ -115,6 +113,7 @@ __global__ void applyCosetShiftKernel(gl64_t *d_cmQ, gl64_t *d_q, gl64_t *d_S, G
             d_cmQ[getBufferOffsetRowMajor(row + j * N, p * qDim + 1, NExtended, qDeg * qDim)] = gl64_t(uint64_t(0));
             d_cmQ[getBufferOffsetRowMajor(row + j * N, p * qDim + 2, NExtended, qDeg * qDim)] = gl64_t(uint64_t(0));
         }
+        s_val = gl64_t(shiftIn.fe) * s_val;
     }
 }
 

--- a/pil2-stark/src/starkpil/expressions_gpu.cu
+++ b/pil2-stark/src/starkpil/expressions_gpu.cu
@@ -328,8 +328,8 @@ __device__ __forceinline__ void load__(
     const int64_t stride = dExpsArgs->nextStridesExps[argOffset];
     const uint64_t logicalRow = isCyclic ? (r + stride) % domainSize : (r + stride);
 
-    // Use pack256 fast path when non-cyclic, stride==0, and blockDim==TILE_HEIGHT
-    const bool usePack256 = !isCyclic && stride == 0 && blockDim.x == TILE_HEIGHT;
+    // Use pack256 fast path when non-cyclic, stride==0, blockDim==TILE_HEIGHT, and TILE_WIDTH==4
+    const bool usePack256 = !isCyclic && stride == 0 && blockDim.x == TILE_HEIGHT && TILE_WIDTH == 4;
     const uint64_t chunkBase = row; // row is always blockDim.x-aligned
 
     // ConstPols
@@ -361,7 +361,7 @@ __device__ __forceinline__ void load__(
             out1 = nullptr;
             out2 = nullptr;
             return;
-        } else if (dim == 3 && (argIdx & 3) <= 1) {
+        } else if (dim == 3 && TILE_WIDTH == 4 && (argIdx & 3) <= 1) {
             // Same-tile fast path: all 3 extension columns in same tile
             // col_block values are argIdx&3, (argIdx+1)&3, (argIdx+2)&3 - all consecutive
             // Offsets differ by TILE_HEIGHT between consecutive columns in same tile

--- a/pil2-stark/src/starkpil/expressions_gpu.cu
+++ b/pil2-stark/src/starkpil/expressions_gpu.cu
@@ -173,7 +173,10 @@ void ExpressionsGPU::calculateExpressions_gpu(StepsParams *d_params, Dest dest, 
     dim3 nThreads_ = nthreads_;
     
     assert(bufferCommitSize  + 9  < 32);
-    size_t sharedMem = 32 * sizeof(Goldilocks::Element);
+    size_t ptrMem = 32 * sizeof(Goldilocks::Element);
+    size_t tmpMem = (h_expsArgs.maxTemp1Size + h_expsArgs.maxTemp3Size) * sizeof(Goldilocks::Element);
+    bool useTmpInShared = tmpMem <= 40960 && tmpMem > 0;
+    size_t sharedMem = useTmpInShared ? (ptrMem + tmpMem) : ptrMem;
 
     TimerStartCategoryGPU(timer, EXPRESSIONS);
     computeExpressions_<<<nBlocks_, nThreads_, sharedMem, stream>>>(d_params, d_deviceArgs, d_expsArgs, d_destParams, constraints);
@@ -258,10 +261,15 @@ void ExpressionsGPU::calculateExpressionsQ_gpu(StepsParams *d_params, Dest dest,
     dim3 nThreads_ = nthreads_;
     
     assert(bufferCommitSize  + 9  < 32);
-    size_t sharedMem = 32 * sizeof(Goldilocks::Element);
+    // Include temp buffers in dynamic shared memory if they fit in 40KB budget
+    size_t ptrMem = 32 * sizeof(Goldilocks::Element);
+    size_t tmpMem = (h_expsArgs.maxTemp1Size + h_expsArgs.maxTemp3Size) * sizeof(Goldilocks::Element);
+    bool useTmpInShared = tmpMem <= 40960 && tmpMem > 0;
+    size_t sharedMem = useTmpInShared ? (ptrMem + tmpMem) : ptrMem;
 
     TimerStartCategoryGPU(timer, EXPRESSIONS);
     computeExpression_<<<nBlocks_, nThreads_, sharedMem, stream>>>(d_params, d_deviceArgs, d_expsArgs, d_destParams);
+    CHECKCUDAERR(cudaGetLastError());
     TimerStopCategoryGPU(timer, EXPRESSIONS);
 }
 
@@ -320,14 +328,20 @@ __device__ __forceinline__ void load__(
     const int64_t stride = dExpsArgs->nextStridesExps[argOffset];
     const uint64_t logicalRow = isCyclic ? (r + stride) % domainSize : (r + stride);
 
+    // Use pack256 fast path when non-cyclic, stride==0, and blockDim==TILE_HEIGHT
+    const bool usePack256 = !isCyclic && stride == 0 && blockDim.x == TILE_HEIGHT;
+    const uint64_t chunkBase = row; // row is always blockDim.x-aligned
+
     // ConstPols
     if (type == 0) {
         const Goldilocks::Element* basePtr = dExpsArgs->domainExtended
             ? dParams->pConstPolsExtendedTreeAddress
             : dParams->pConstPolsAddress;
 
-        //const uint64_t pos = logicalRow * dArgs->mapSectionsN[0] + argIdx;
-        const uint64_t pos = getBufferOffset(logicalRow, argIdx, domainSize, dArgs->mapSectionsN[0]);
+        const uint64_t nCols0 = dArgs->mapSectionsN[0];
+        const uint64_t pos = usePack256
+            ? getBufferOffset_pack256(chunkBase, argIdx, domainSize, nCols0)
+            : getBufferOffset(logicalRow, argIdx, domainSize, nCols0);
         out0 = (gl64_t*)&basePtr[pos];
         out1 = nullptr;
         out2 = nullptr;
@@ -338,17 +352,32 @@ __device__ __forceinline__ void load__(
     if (type >= 1 && type <= 3) {
         const uint64_t offset = dExpsArgs->mapOffsetsExps[type];
         const uint64_t nCols = dArgs->mapSectionsN[type];
-        const uint64_t pos = getBufferOffset(logicalRow, argIdx, domainSize, nCols);
 
         if (type == 1 && !dExpsArgs->domainExtended) {
+            const uint64_t pos = usePack256
+                ? getBufferOffset_pack256(chunkBase, argIdx, domainSize, nCols)
+                : getBufferOffset(logicalRow, argIdx, domainSize, nCols);
             out0 = (gl64_t*)&dParams->trace[pos];
             out1 = nullptr;
             out2 = nullptr;
             return;
+        } else if (dim == 3 && (argIdx & 3) <= 1) {
+            // Same-tile fast path: all 3 extension columns in same tile
+            // col_block values are argIdx&3, (argIdx+1)&3, (argIdx+2)&3 - all consecutive
+            // Offsets differ by TILE_HEIGHT between consecutive columns in same tile
+            const uint64_t pos0 = usePack256
+                ? getBufferOffset_pack256(chunkBase, argIdx, domainSize, nCols)
+                : getBufferOffset(logicalRow, argIdx, domainSize, nCols);
+            out0 = (gl64_t*)&dParams->aux_trace[offset + pos0];
+            out1 = (gl64_t*)&dParams->aux_trace[offset + pos0 + TILE_HEIGHT];
+            out2 = (gl64_t*)&dParams->aux_trace[offset + pos0 + 2 * TILE_HEIGHT];
+            return;
         } else {
             #pragma unroll
             for (uint64_t d = 0; d < dim; d++) {
-                const uint64_t pos_ = getBufferOffset(logicalRow, argIdx+d, domainSize, nCols);
+                const uint64_t pos_ = usePack256
+                    ? getBufferOffset_pack256(chunkBase, argIdx+d, domainSize, nCols)
+                    : getBufferOffset(logicalRow, argIdx+d, domainSize, nCols);
                 if(d == 0) out0 = (gl64_t*)&dParams->aux_trace[offset + pos_];
                 if(d == 1) out1 = (gl64_t*)&dParams->aux_trace[offset + pos_];
                 if(d == 2) out2 = (gl64_t*)&dParams->aux_trace[offset + pos_];
@@ -592,10 +621,20 @@ __global__  void computeExpressions_(StepsParams *d_params, DeviceArguments *d_d
     uint32_t bufferCommitsSize = d_deviceArgs->bufferCommitSize;
     Goldilocks::Element **expressions_params = (Goldilocks::Element **)scratchpad;
 
+    // Use temp buffers in dynamic shared memory if launch allocated space for them
+    Goldilocks::Element *smem_after_ptrs_s = scratchpad + 32;
+    uint64_t tmpTotal_s = d_expsArgs->maxTemp1Size + d_expsArgs->maxTemp3Size;
+    bool useTmpSmem_s = tmpTotal_s > 0 && tmpTotal_s <= 5120;
+
     if (threadIdx.x == 0)
     {
-        expressions_params[bufferCommitsSize + 0] = (&d_params->aux_trace[d_expsArgs->offsetTmp1 + blockIdx.x * d_expsArgs->maxTemp1Size]);
-        expressions_params[bufferCommitsSize + 1] = (&d_params->aux_trace[d_expsArgs->offsetTmp3 + blockIdx.x * d_expsArgs->maxTemp3Size]);
+        if (useTmpSmem_s) {
+            expressions_params[bufferCommitsSize + 0] = smem_after_ptrs_s;
+            expressions_params[bufferCommitsSize + 1] = smem_after_ptrs_s + d_expsArgs->maxTemp1Size;
+        } else {
+            expressions_params[bufferCommitsSize + 0] = (&d_params->aux_trace[d_expsArgs->offsetTmp1 + blockIdx.x * d_expsArgs->maxTemp1Size]);
+            expressions_params[bufferCommitsSize + 1] = (&d_params->aux_trace[d_expsArgs->offsetTmp3 + blockIdx.x * d_expsArgs->maxTemp3Size]);
+        }
         expressions_params[bufferCommitsSize + 2] = d_params->publicInputs;
         expressions_params[bufferCommitsSize + 3] = constraints ? d_deviceArgs->numbersConstraints : d_deviceArgs->numbers;
         expressions_params[bufferCommitsSize + 4] = d_params->airValues;
@@ -689,6 +728,62 @@ __global__  void computeExpressions_(StepsParams *d_params, DeviceArguments *d_d
 }
 
 
+template<bool IsCyclic>
+__device__ __forceinline__ void computeExpression_chunk_(
+    StepsParams *d_params, DeviceArguments *d_deviceArgs, ExpsArguments *d_expsArgs,
+    DestParamsGPU *d_destParams, Goldilocks::Element **expressions_params,
+    uint32_t bufferCommitsSize, uint64_t i,
+    const uint8_t * __restrict__ ops, const uint16_t * __restrict__ args)
+{
+    gl64_t *a0, *a1, *a2, *b0, *b1, *b2;
+    gl64_t *res;
+
+    uint64_t i_args = 0;
+    uint64_t nOps = d_destParams[0].nOps;
+    for (uint64_t kk = 0; kk < nOps; ++kk)
+    {
+        switch (ops[kk])
+        {
+        case 0:
+        {
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 1, IsCyclic, a0, a1, a2);
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 1, IsCyclic, b0, b1, b2);
+            res = (gl64_t*)&expressions_params[bufferCommitsSize][args[i_args + 1] * blockDim.x];
+            op_gpu_p2(args[i_args], res, a0, b0);
+            i_args += 8;
+            break;
+        }
+        case 1:
+        {
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 3, IsCyclic, a0, a1, a2);
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 1, IsCyclic, b0, b1, b2);
+            res = (gl64_t*)&expressions_params[bufferCommitsSize + 1][args[i_args + 1] * blockDim.x];
+            op_31_gpu_p2(args[i_args], res, a0, a1, a2, b0);
+            i_args += 8;
+            break;
+        }
+        case 2:
+        {
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 3, IsCyclic, a0, a1, a2);
+            load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 3, IsCyclic, b0, b1, b2);
+            res = (gl64_t*)&expressions_params[bufferCommitsSize + 1][args[i_args + 1] * blockDim.x];
+            op_33_gpu_p2(args[i_args], res, a0, a1, a2, b0, b1, b2);
+            i_args += 8;
+            break;
+        }
+        default:
+        {
+            printf(" Wrong operation! %d \n", ops[kk]);
+        }
+        }
+    }
+    if (i_args != d_destParams[0].nArgs){
+        printf(" %lu consumed args - %lu expected args \n", i_args, d_destParams[0].nArgs);
+    }
+
+    storePolynomial__(d_expsArgs, (Goldilocks::Element *)res, i);
+}
+
 __global__  void computeExpression_(StepsParams *d_params, DeviceArguments *d_deviceArgs, ExpsArguments *d_expsArgs, DestParamsGPU *d_destParams)
 {
 
@@ -698,10 +793,27 @@ __global__  void computeExpression_(StepsParams *d_params, DeviceArguments *d_de
     uint32_t bufferCommitsSize = d_deviceArgs->bufferCommitSize;
     Goldilocks::Element **expressions_params = (Goldilocks::Element **)scratchpad;
 
+    // Static shared memory for ops/args staging
+    __shared__ uint8_t ops_staged[256];
+    __shared__ uint16_t args_staged[2048];
+
+    uint64_t nOps = d_destParams[0].nOps;
+    uint64_t nArgs = d_destParams[0].nArgs;
+
+    // Use temp buffers in dynamic shared memory if launch allocated space for them
+    Goldilocks::Element *smem_after_ptrs = scratchpad + 32;
+    uint64_t tmpTotal = d_expsArgs->maxTemp1Size + d_expsArgs->maxTemp3Size;
+    bool useTmpSmem = tmpTotal > 0 && tmpTotal <= 5120;
+
     if (threadIdx.x == 0)
     {
-        expressions_params[bufferCommitsSize + 0] = (&d_params->aux_trace[d_expsArgs->offsetTmp1 + blockIdx.x * d_expsArgs->maxTemp1Size]);
-        expressions_params[bufferCommitsSize + 1] = (&d_params->aux_trace[d_expsArgs->offsetTmp3 + blockIdx.x * d_expsArgs->maxTemp3Size]);
+        if (useTmpSmem) {
+            expressions_params[bufferCommitsSize + 0] = smem_after_ptrs;
+            expressions_params[bufferCommitsSize + 1] = smem_after_ptrs + d_expsArgs->maxTemp1Size;
+        } else {
+            expressions_params[bufferCommitsSize + 0] = (&d_params->aux_trace[d_expsArgs->offsetTmp1 + blockIdx.x * d_expsArgs->maxTemp1Size]);
+            expressions_params[bufferCommitsSize + 1] = (&d_params->aux_trace[d_expsArgs->offsetTmp3 + blockIdx.x * d_expsArgs->maxTemp3Size]);
+        }
         expressions_params[bufferCommitsSize + 2] = d_params->publicInputs;
         expressions_params[bufferCommitsSize + 3] = d_deviceArgs->numbers;
         expressions_params[bufferCommitsSize + 4] = d_params->airValues;
@@ -710,67 +822,27 @@ __global__  void computeExpression_(StepsParams *d_params, DeviceArguments *d_de
         expressions_params[bufferCommitsSize + 7] = d_params->challenges;
         expressions_params[bufferCommitsSize + 8] = d_params->evals;
     }
+    // Stage ops and args cooperatively
+    const uint8_t *g_ops = &d_deviceArgs->ops[d_destParams[0].opsOffset];
+    const uint16_t *g_args = &d_deviceArgs->args[d_destParams[0].argsOffset];
+    for (uint32_t t = threadIdx.x; t < nOps && t < 256; t += blockDim.x) ops_staged[t] = g_ops[t];
+    for (uint32_t t = threadIdx.x; t < nArgs && t < 2048; t += blockDim.x) args_staged[t] = g_args[t];
     __syncthreads();
+
+    const uint8_t *active_ops = (nOps <= 256) ? ops_staged : g_ops;
+    const uint16_t *active_args = (nArgs <= 2048) ? args_staged : g_args;
+
+    uint64_t k_min_chunk = d_expsArgs->k_min / blockDim.x;
+    uint64_t k_max_chunk = d_expsArgs->k_max / blockDim.x;
 
     while (chunk_idx < nchunks)
     {
         uint64_t i = chunk_idx * blockDim.x;
-        bool isCyclic = i < d_expsArgs->k_min || i >= d_expsArgs->k_max;
-        uint8_t *ops = &d_deviceArgs->ops[d_destParams[0].opsOffset];
-        uint16_t *args = &d_deviceArgs->args[d_destParams[0].argsOffset];
-        gl64_t *a0, *a1, *a2, *b0, *b1, *b2;
-        gl64_t *res;
-
-        uint64_t i_args = 0;
-        uint64_t nOps = d_destParams[0].nOps;
-        for (uint64_t kk = 0; kk < nOps; ++kk)
-
-        {
-
-            switch (ops[kk])
-            {
-            case 0:
-            {
-                // OPERATION WITH DEST: dim1 - SRC0: dim1 - SRC1: dim1
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 1, isCyclic, a0, a1, a2);
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 1, isCyclic, b0, b1, b2);
-                res = (gl64_t*)&expressions_params[bufferCommitsSize][args[i_args + 1] * blockDim.x];
-                op_gpu_p2(args[i_args], res, a0, b0);
-                i_args += 8;
-                break;
-            }
-            case 1:
-            {
-                // OPERATION WITH DEST: dim3 - SRC0: dim3 - SRC1: dim1
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 3, isCyclic, a0, a1, a2);
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 1, isCyclic, b0, b1, b2);
-                res = (gl64_t*)&expressions_params[bufferCommitsSize + 1][args[i_args + 1] * blockDim.x];
-                op_31_gpu_p2(args[i_args], res, a0, a1, a2, b0);
-                i_args += 8;
-                break;
-            }
-            case 2:
-            {
-                // OPERATION WITH DEST: dim3 - SRC0: dim3 - SRC1: dim3
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 2], args[i_args + 3], args[i_args + 4], i, 3, isCyclic, a0, a1, a2);
-                load__(d_deviceArgs, d_expsArgs, d_params, expressions_params, args[i_args + 5], args[i_args + 6], args[i_args + 7], i, 3, isCyclic, b0, b1, b2);
-                res = (gl64_t*)&expressions_params[bufferCommitsSize + 1][args[i_args + 1] * blockDim.x];
-                op_33_gpu_p2(args[i_args], res, a0, a1, a2, b0, b1, b2);
-                i_args += 8;
-                break;
-            }
-            default:
-            {
-                printf(" Wrong operation! %d \n", ops[kk]);
-            }
-            }
+        if (chunk_idx < k_min_chunk || chunk_idx >= k_max_chunk) {
+            computeExpression_chunk_<true>(d_params, d_deviceArgs, d_expsArgs, d_destParams, expressions_params, bufferCommitsSize, i, active_ops, active_args);
+        } else {
+            computeExpression_chunk_<false>(d_params, d_deviceArgs, d_expsArgs, d_destParams, expressions_params, bufferCommitsSize, i, active_ops, active_args);
         }
-        if (i_args !=  d_destParams[0].nArgs){
-            printf(" %lu consumed args - %lu expected args \n", i_args, d_destParams[0].nArgs);
-        }
-    
-
-        storePolynomial__(d_expsArgs, (Goldilocks::Element *)res, i);        
 
         chunk_idx += gridDim.x;
     }

--- a/pil2-stark/src/starkpil/expressions_gpu.cu
+++ b/pil2-stark/src/starkpil/expressions_gpu.cu
@@ -832,13 +832,16 @@ __global__  void computeExpression_(StepsParams *d_params, DeviceArguments *d_de
     const uint8_t *active_ops = (nOps <= 256) ? ops_staged : g_ops;
     const uint16_t *active_args = (nArgs <= 2048) ? args_staged : g_args;
 
+    // k_min and k_max are multiples of nRowsPack (== blockDim.x when nblocks_ > 1).
+    // Chunk-level dispatch avoids per-iteration branching for the ~99% non-cyclic interior.
+    // For single-block launches (nchunks == 1), use the safe cyclic path unconditionally.
     uint64_t k_min_chunk = d_expsArgs->k_min / blockDim.x;
     uint64_t k_max_chunk = d_expsArgs->k_max / blockDim.x;
 
     while (chunk_idx < nchunks)
     {
         uint64_t i = chunk_idx * blockDim.x;
-        if (chunk_idx < k_min_chunk || chunk_idx >= k_max_chunk) {
+        if (nchunks == 1 || chunk_idx < k_min_chunk || chunk_idx >= k_max_chunk) {
             computeExpression_chunk_<true>(d_params, d_deviceArgs, d_expsArgs, d_destParams, expressions_params, bufferCommitsSize, i, active_ops, active_args);
         } else {
             computeExpression_chunk_<false>(d_params, d_deviceArgs, d_expsArgs, d_destParams, expressions_params, bufferCommitsSize, i, active_ops, active_args);

--- a/pil2-stark/src/starkpil/expressions_gpu.cu
+++ b/pil2-stark/src/starkpil/expressions_gpu.cu
@@ -736,7 +736,7 @@ __device__ __forceinline__ void computeExpression_chunk_(
     const uint8_t * __restrict__ ops, const uint16_t * __restrict__ args)
 {
     gl64_t *a0, *a1, *a2, *b0, *b1, *b2;
-    gl64_t *res;
+    gl64_t *res = nullptr;
 
     uint64_t i_args = 0;
     uint64_t nOps = d_destParams[0].nOps;
@@ -781,7 +781,9 @@ __device__ __forceinline__ void computeExpression_chunk_(
         printf(" %lu consumed args - %lu expected args \n", i_args, d_destParams[0].nArgs);
     }
 
-    storePolynomial__(d_expsArgs, (Goldilocks::Element *)res, i);
+    if (res != nullptr) {
+        storePolynomial__(d_expsArgs, (Goldilocks::Element *)res, i);
+    }
 }
 
 __global__  void computeExpression_(StepsParams *d_params, DeviceArguments *d_deviceArgs, ExpsArguments *d_expsArgs, DestParamsGPU *d_destParams)

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -11,6 +11,7 @@
 #ifdef USE_CUDA_GRAPH
 #include "cuda_graph_cache.cuh"
 #include <vector>
+#include <memory>
 #endif
 #include <iomanip>
 
@@ -88,12 +89,14 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
 #ifdef USE_CUDA_GRAPH
     {
         static std::once_flag initFlag;
-        static std::vector<CudaGraphCache> cacheVec;
+        static std::vector<std::unique_ptr<CudaGraphCache>> cacheVec;
         std::call_once(initFlag, [&]() {
-            fprintf(stderr, "[cudaGraph] enabled (stream capture mode)\n");
+            zklog.debug("[cudaGraph] enabled (stream capture mode)");
             cacheVec.resize(d_buffers->n_total_streams);
+            for (auto& entry : cacheVec) entry = std::make_unique<CudaGraphCache>();
         });
-        cudagraph::current() = &cacheVec[stream_id];
+        assert(stream_id < cacheVec.size());
+        cudagraph::current() = cacheVec[stream_id].get();
         cudagraph::aggressive() = recursive;
     }
     cudaGetLastError();

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -10,6 +10,7 @@
 #include "gpu_timer.cuh"
 #ifdef USE_CUDA_GRAPH
 #include "cuda_graph_cache.cuh"
+#include <mutex>
 #endif
 #include <iomanip>
 
@@ -86,13 +87,16 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
 
 #ifdef USE_CUDA_GRAPH
     {
-        static bool printed = false;
-        if (!printed) {
+        static std::once_flag printFlag;
+        std::call_once(printFlag, []() {
             fprintf(stderr, "[cudaGraph] enabled (stream capture mode)\n");
-            printed = true;
-        }
+        });
+        static std::mutex cacheMapMutex;
         static std::unordered_map<uint32_t, CudaGraphCache> cacheMap;
-        cudagraph::current() = &cacheMap[stream_id];
+        {
+            std::lock_guard<std::mutex> lock(cacheMapMutex);
+            cudagraph::current() = &cacheMap[stream_id];
+        }
         cudagraph::aggressive() = recursive;
     }
     cudaGetLastError();
@@ -396,6 +400,8 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     TimerStartCategoryGPU(timer, GRINDING);
     Goldilocks::Element *d_input_hash_nonce = (Goldilocks::Element *)d_aux_trace + offsetInputHashNonce;
     CHECKCUDAERR(cudaMemcpyAsync(d_input_hash_nonce, d_challenge, FIELD_EXTENSION * sizeof(Goldilocks::Element), cudaMemcpyDeviceToDevice, stream));
+{
+    bool graphHandled = false;
 #ifdef USE_CUDA_GRAPH
     {
         CudaGraphCache *graphCache = cudagraph::current();
@@ -403,21 +409,20 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
             uint64_t key = CudaGraphCache::makeKey(0x4752494EULL ^ ctxId, setupCtx.starkInfo.starkStruct.powBits);
             if (graphCache->tryLaunch(key, stream)) {
-                goto skip_grinding;
-            }
-            if (graphCache->shouldCapture(key)) {
+                graphHandled = true;
+            } else if (graphCache->shouldCapture(key)) {
                 graphCache->beginCapture(key, stream);
                 Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
                 graphCache->endCaptureAndLaunch(stream);
-                goto skip_grinding;
+                graphHandled = true;
             }
         }
     }
 #endif
-    Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
-#ifdef USE_CUDA_GRAPH
-    skip_grinding:
-#endif
+    if (!graphHandled) {
+        Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
+    }
+}
     CHECKCUDAERR(cudaGetLastError());
     TimerStopCategoryGPU(timer, GRINDING);
 
@@ -426,6 +431,8 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     d_transcript_helper->put2(d_challenge, FIELD_EXTENSION, d_nonce, 1, stream);
     d_transcript_helper->getPermutations(friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, setupCtx.starkInfo.starkStruct.steps[0].nBits, stream);
 
+{
+    bool graphHandled = false;
 #ifdef USE_CUDA_GRAPH
     {
         CudaGraphCache *graphCache = cudagraph::current();
@@ -433,9 +440,8 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
             uint64_t key = CudaGraphCache::makeKey(0x515559ULL ^ ctxId, nTrees, setupCtx.starkInfo.starkStruct.nQueries, setupCtx.starkInfo.starkStruct.steps.size());
             if (graphCache->tryLaunch(key, stream)) {
-                goto skip_queries;
-            }
-            if (graphCache->shouldCapture(key)) {
+                graphHandled = true;
+            } else if (graphCache->shouldCapture(key)) {
                 graphCache->beginCapture(key, stream);
 
                 proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
@@ -444,18 +450,18 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
                 }
 
                 graphCache->endCaptureAndLaunch(stream);
-                goto skip_queries;
+                graphHandled = true;
             }
         }
     }
 #endif
-    proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
-    for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
-        proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
+    if (!graphHandled) {
+        proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
+        for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
+            proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
+        }
     }
-#ifdef USE_CUDA_GRAPH
-    skip_queries:
-#endif
+}
     TimerStopCategoryGPU(timer, FRI);
     TimerStopGPU(timer, STARK_STEP_FRI);
 

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -10,8 +10,6 @@
 #include "gpu_timer.cuh"
 #ifdef USE_CUDA_GRAPH
 #include "cuda_graph_cache.cuh"
-#include <vector>
-#include <memory>
 #endif
 #include <iomanip>
 
@@ -87,18 +85,8 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     TimerStartGPU(timer, STARK_STEP_0);
 
 #ifdef USE_CUDA_GRAPH
-    {
-        static std::once_flag initFlag;
-        static std::vector<std::unique_ptr<CudaGraphCache>> cacheVec;
-        std::call_once(initFlag, [&]() {
-            zklog.debug("[cudaGraph] enabled (stream capture mode)");
-            cacheVec.resize(d_buffers->n_total_streams);
-            for (auto& entry : cacheVec) entry = std::make_unique<CudaGraphCache>();
-        });
-        assert(stream_id < cacheVec.size());
-        cudagraph::current() = cacheVec[stream_id].get();
-        cudagraph::aggressive() = recursive;
-    }
+    cudagraph::current() = d_buffers->streamsData[stream_id].graph_cache.get();
+    cudagraph::aggressive() = recursive;
     cudaGetLastError();
 #endif
 
@@ -391,7 +379,25 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
         if (cudagraph::aggressive()) {
             CudaGraphCache *graphCache = cudagraph::current();
             if (graphCache && graphCache->isCapturing()) {
-                graphCache->endCaptureAndLaunch(stream);
+                if (!graphCache->endCaptureAndLaunch(stream)) {
+                    // Capture failed — work was recorded but not executed.
+                    // Re-execute this step's work directly.
+                    if (step > 0) {
+                        uint64_t prevBits = setupCtx.starkInfo.starkStruct.steps[step - 1].nBits;
+                        fold_inplace(step, friPol_offset, offset_helper, d_challenge, nBitsExt, prevBits, currentBits, d_aux_trace, timer, stream);
+                    }
+                    if (step < setupCtx.starkInfo.starkStruct.steps.size() - 1) {
+                        merkelizeFRI_inplace(setupCtx, h_params, step, d_friPol, starks.treesFRI[step], currentBits, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, d_transcript, timer, stream);
+                    } else {
+                        if(!setupCtx.starkInfo.starkStruct.hashCommits) {
+                            d_transcript->put((Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
+                        } else {
+                            calculateHash(d_transcript_helper, d_challenge, setupCtx, (Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
+                            d_transcript->put(d_challenge, HASH_SIZE, stream);
+                        }
+                    }
+                    d_transcript->getField((uint64_t *)d_challenge, stream);
+                }
             }
         }
 #endif
@@ -411,10 +417,12 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             if (graphCache->tryLaunch(key, stream)) {
                 graphHandled = true;
             } else if (graphCache->shouldCapture(key)) {
-                graphCache->beginCapture(key, stream);
-                Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
-                graphCache->endCaptureAndLaunch(stream);
-                graphHandled = true;
+                if (graphCache->beginCapture(key, stream)) {
+                    Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
+                    if (graphCache->endCaptureAndLaunch(stream)) {
+                        graphHandled = true;
+                    }
+                }
             }
         }
     }
@@ -442,15 +450,15 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             if (graphCache->tryLaunch(key, stream)) {
                 graphHandled = true;
             } else if (graphCache->shouldCapture(key)) {
-                graphCache->beginCapture(key, stream);
-
-                proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
-                for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
-                    proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
+                if (graphCache->beginCapture(key, stream)) {
+                    proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
+                    for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
+                        proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
+                    }
+                    if (graphCache->endCaptureAndLaunch(stream)) {
+                        graphHandled = true;
+                    }
                 }
-
-                graphCache->endCaptureAndLaunch(stream);
-                graphHandled = true;
             }
         }
     }

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -8,6 +8,9 @@
 #include "starks_gpu.cuh"
 #include "hints.cuh"
 #include "gpu_timer.cuh"
+#ifdef USE_CUDA_GRAPH
+#include "cuda_graph_cache.cuh"
+#endif
 #include <iomanip>
 
 // TOTO list: //rick
@@ -80,6 +83,20 @@ void calculateWitnessSTD_gpu(SetupCtx& setupCtx, StepsParams& h_params, StepsPar
 void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols, gl64_t *d_const_tree, char *constTreePath, uint32_t stream_id, uint64_t instance_id, DeviceCommitBuffers *d_buffers, AirInstanceInfo *air_instance_info, bool skipRecalculation, TimerGPU &timer, cudaStream_t stream, bool recursive = false, bool reuse_constants = false) {
     TimerStartGPU(timer, STARK_GPU_PROOF);
     TimerStartGPU(timer, STARK_STEP_0);
+
+#ifdef USE_CUDA_GRAPH
+    {
+        static bool printed = false;
+        if (!printed) {
+            fprintf(stderr, "[cudaGraph] enabled (stream capture mode)\n");
+            printed = true;
+        }
+        static std::unordered_map<uint32_t, CudaGraphCache> cacheMap;
+        cudagraph::current() = &cacheMap[stream_id];
+        cudagraph::aggressive() = recursive;
+    }
+    cudaGetLastError();
+#endif
 
     uint64_t countId = 0;
 
@@ -327,6 +344,26 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     for (uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size(); step++)
     {
         uint64_t currentBits = setupCtx.starkInfo.starkStruct.steps[step].nBits;
+
+#ifdef USE_CUDA_GRAPH
+        if (cudagraph::aggressive()) {
+            CudaGraphCache *graphCache = cudagraph::current();
+            if (graphCache) {
+                uint64_t prevBits = step > 0 ? setupCtx.starkInfo.starkStruct.steps[step - 1].nBits : 0;
+                uint64_t nextBits = step < setupCtx.starkInfo.starkStruct.steps.size() - 1 ? setupCtx.starkInfo.starkStruct.steps[step + 1].nBits : 0;
+                uint64_t arity = setupCtx.starkInfo.starkStruct.merkleTreeArity;
+                uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
+                uint64_t key = CudaGraphCache::makeKey(0x465249ULL ^ ctxId, step, nBitsExt, currentBits, prevBits, nextBits, arity);
+                if (graphCache->tryLaunch(key, stream)) {
+                    continue;
+                }
+                if (graphCache->shouldCapture(key)) {
+                    graphCache->beginCapture(key, stream);
+                }
+            }
+        }
+#endif
+
         if (step > 0) {
             uint64_t prevBits = setupCtx.starkInfo.starkStruct.steps[step - 1].nBits;
             fold_inplace(step, friPol_offset, offset_helper, d_challenge, nBitsExt, prevBits, currentBits, d_aux_trace, timer, stream);
@@ -345,25 +382,80 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             }
         }
         d_transcript->getField((uint64_t *)d_challenge, stream);
-    }   
+
+#ifdef USE_CUDA_GRAPH
+        if (cudagraph::aggressive()) {
+            CudaGraphCache *graphCache = cudagraph::current();
+            if (graphCache && graphCache->isCapturing()) {
+                graphCache->endCaptureAndLaunch(stream);
+            }
+        }
+#endif
+    }
 
     TimerStartCategoryGPU(timer, GRINDING);
     Goldilocks::Element *d_input_hash_nonce = (Goldilocks::Element *)d_aux_trace + offsetInputHashNonce;
     CHECKCUDAERR(cudaMemcpyAsync(d_input_hash_nonce, d_challenge, FIELD_EXTENSION * sizeof(Goldilocks::Element), cudaMemcpyDeviceToDevice, stream));
+#ifdef USE_CUDA_GRAPH
+    {
+        CudaGraphCache *graphCache = cudagraph::current();
+        if (graphCache) {
+            uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
+            uint64_t key = CudaGraphCache::makeKey(0x4752494EULL ^ ctxId, setupCtx.starkInfo.starkStruct.powBits);
+            if (graphCache->tryLaunch(key, stream)) {
+                goto skip_grinding;
+            }
+            if (graphCache->shouldCapture(key)) {
+                graphCache->beginCapture(key, stream);
+                Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
+                graphCache->endCaptureAndLaunch(stream);
+                goto skip_grinding;
+            }
+        }
+    }
+#endif
     Poseidon2GoldilocksGPUGrinding::grinding((uint64_t *)d_nonce, (uint64_t *)d_nonceBlocks, (uint64_t *)d_input_hash_nonce, setupCtx.starkInfo.starkStruct.powBits, stream);
+#ifdef USE_CUDA_GRAPH
+    skip_grinding:
+#endif
     CHECKCUDAERR(cudaGetLastError());
     TimerStopCategoryGPU(timer, GRINDING);
 
     TimerStartCategoryGPU(timer, FRI);
     d_transcript_helper->reset(stream);
-    d_transcript_helper->put(d_challenge, FIELD_EXTENSION, stream);
-    d_transcript_helper->put(d_nonce, 1, stream);
+    d_transcript_helper->put2(d_challenge, FIELD_EXTENSION, d_nonce, 1, stream);
     d_transcript_helper->getPermutations(friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, setupCtx.starkInfo.starkStruct.steps[0].nBits, stream);
 
+#ifdef USE_CUDA_GRAPH
+    {
+        CudaGraphCache *graphCache = cudagraph::current();
+        if (graphCache) {
+            uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
+            uint64_t key = CudaGraphCache::makeKey(0x515559ULL ^ ctxId, nTrees, setupCtx.starkInfo.starkStruct.nQueries, setupCtx.starkInfo.starkStruct.steps.size());
+            if (graphCache->tryLaunch(key, stream)) {
+                goto skip_queries;
+            }
+            if (graphCache->shouldCapture(key)) {
+                graphCache->beginCapture(key, stream);
+
+                proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
+                for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
+                    proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
+                }
+
+                graphCache->endCaptureAndLaunch(stream);
+                goto skip_queries;
+            }
+        }
+    }
+#endif
     proveQueries_inplace(setupCtx, d_queries_buff, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesGL, nTrees, d_aux_trace, d_const_tree, setupCtx.starkInfo.nStages, stream);
     for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) {
         proveFRIQueries_inplace(setupCtx, &d_queries_buff[(nTrees + step) * setupCtx.starkInfo.starkStruct.nQueries * setupCtx.starkInfo.maxProofBuffSize], step + 1, setupCtx.starkInfo.starkStruct.steps[step + 1].nBits, friQueries_gpu, setupCtx.starkInfo.starkStruct.nQueries, starks.treesFRI[step], stream);
     }
+#ifdef USE_CUDA_GRAPH
+    skip_queries:
+#endif
     TimerStopCategoryGPU(timer, FRI);
     TimerStopGPU(timer, STARK_STEP_FRI);
 

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -10,7 +10,7 @@
 #include "gpu_timer.cuh"
 #ifdef USE_CUDA_GRAPH
 #include "cuda_graph_cache.cuh"
-#include <mutex>
+#include <vector>
 #endif
 #include <iomanip>
 
@@ -87,16 +87,13 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
 
 #ifdef USE_CUDA_GRAPH
     {
-        static std::once_flag printFlag;
-        std::call_once(printFlag, []() {
+        static std::once_flag initFlag;
+        static std::vector<CudaGraphCache> cacheVec;
+        std::call_once(initFlag, [&]() {
             fprintf(stderr, "[cudaGraph] enabled (stream capture mode)\n");
+            cacheVec.resize(d_buffers->n_total_streams);
         });
-        static std::mutex cacheMapMutex;
-        static std::unordered_map<uint32_t, CudaGraphCache> cacheMap;
-        {
-            std::lock_guard<std::mutex> lock(cacheMapMutex);
-            cudagraph::current() = &cacheMap[stream_id];
-        }
+        cudagraph::current() = &cacheVec[stream_id];
         cudagraph::aggressive() = recursive;
     }
     cudaGetLastError();

--- a/pil2-stark/src/starkpil/stark_info.cpp
+++ b/pil2-stark/src/starkpil/stark_info.cpp
@@ -672,7 +672,7 @@ void StarkInfo::setMemoryExpressions(uint64_t nTmp1, uint64_t nTmp3) {
             nrowsPack = NROWS_PACK;
             maxNBlocks = omp_get_max_threads();
         } else {
-            nrowsPack = 512;
+            nrowsPack = 256;
             maxNBlocks = 512;
 
             uint64_t tmpsUsed = nTmp1 + (nTmp3 + 2) * FIELD_EXTENSION;

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -1,5 +1,8 @@
 #include "starks.hpp"
 #include "starks_gpu.cuh"
+#ifdef USE_CUDA_GRAPH
+#include "cuda_graph_cache.cuh"
+#endif
 #include "goldilocks_base_field.hpp"
 #include "goldilocks_cubic_extension.hpp"
 #include "goldilocks_cubic_extension.cuh"
@@ -212,7 +215,6 @@ void commitStage_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL **trees
 {
     if (step <= setupCtx.starkInfo.nStages)
     {
-    
         extendAndMerkelize_inplace(step, setupCtx, treesGL, d_trace, d_aux_trace, d_transcript, skipRecalculation, timer, stream);
     }
     else
@@ -236,6 +238,39 @@ void extendAndMerkelize_inplace(uint64_t step, SetupCtx& setupCtx, MerkleTreeGL*
     treesGL[step - 1]->setSource(dstGL + offset_dst);
     Goldilocks::Element *pNodes = dstGL + setupCtx.starkInfo.mapOffsets[make_pair("mt" + to_string(step), true)];
     treesGL[step - 1]->setNodes(pNodes);
+
+#ifdef USE_CUDA_GRAPH
+    CudaGraphCache *graphCache = cudagraph::current();
+    if (graphCache && !skipRecalculation && nCols > 0) {
+        uint64_t nBits = setupCtx.starkInfo.starkStruct.nBits;
+        uint64_t nBitsExt = setupCtx.starkInfo.starkStruct.nBitsExt;
+        uint64_t arity = setupCtx.starkInfo.starkStruct.merkleTreeArity;
+        uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
+        uint64_t key = CudaGraphCache::makeKey(0x4C4445ULL ^ ctxId, nBits, nBitsExt, nCols, arity, step);
+        if (graphCache->tryLaunch(key, stream)) {
+            if (d_transcript != nullptr) {
+                uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+            }
+            return;
+        }
+        if (graphCache->shouldCapture(key)) {
+            graphCache->beginCapture(key, stream);
+
+            NTTGoldilocksGPU ntt;
+            ntt.LDE(dst, offset_dst, src, offset_src, nBits, nBitsExt, nCols, timer, stream);
+            buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(dst + offset_dst), nCols, NExtended, stream);
+
+            graphCache->endCaptureAndLaunch(stream);
+
+            if (d_transcript != nullptr) {
+                uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+            }
+            return;
+        }
+    }
+#endif
 
     if(!skipRecalculation) {
         NTTGoldilocksGPU ntt;
@@ -285,7 +320,7 @@ void computeQ_MerkleTree_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL
     uint64_t qDim = setupCtx.starkInfo.qDim;
 
     Goldilocks::Element shiftIn = Goldilocks::exp(Goldilocks::inv(Goldilocks::shift()), N);
-     
+
     Goldilocks::Element* d_aux_traceGL = (Goldilocks::Element*) d_aux_trace;
 
     treesGL[step - 1]->setSource(d_aux_traceGL + offset_cmQ);
@@ -296,6 +331,38 @@ void computeQ_MerkleTree_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL
     {
         uint64_t offset_helper = setupCtx.starkInfo.mapOffsets[std::make_pair("extra_helper_fft", false)];
         NTTGoldilocksGPU nttExtended;
+
+#ifdef USE_CUDA_GRAPH
+        if (cudagraph::aggressive()) {
+            CudaGraphCache *graphCache = cudagraph::current();
+            if (graphCache) {
+                uint64_t nBits = setupCtx.starkInfo.starkStruct.nBits;
+                uint64_t nBitsExt = setupCtx.starkInfo.starkStruct.nBitsExt;
+                uint64_t arity = setupCtx.starkInfo.starkStruct.merkleTreeArity;
+                uint64_t ctxId = (uint64_t)(uintptr_t)&setupCtx;
+                uint64_t key = CudaGraphCache::makeKey(0x514D5400ULL ^ ctxId, nBits, nBitsExt, nCols, (qDeg << 32) | qDim, arity);
+                if (graphCache->tryLaunch(key, stream)) {
+                    uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                    if (d_transcript != nullptr) {
+                        d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+                    }
+                    return;
+                }
+                if (graphCache->shouldCapture(key)) {
+                    graphCache->beginCapture(key, stream);
+                    nttExtended.computeQ(offset_cmQ, offset_q, qDeg, qDim, shiftIn, nBits, nBitsExt, nCols, d_aux_trace, offset_helper, timer, stream);
+                    buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(d_aux_trace + offset_cmQ), nCols, NExtended, stream);
+                    graphCache->endCaptureAndLaunch(stream);
+                    uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                    if (d_transcript != nullptr) {
+                        d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+                    }
+                    return;
+                }
+            }
+        }
+#endif
+
         nttExtended.computeQ(offset_cmQ, offset_q, qDeg, qDim, shiftIn, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, d_aux_trace, offset_helper, timer, stream);
         TimerStartCategoryGPU(timer, MERKLE_TREE);
         buildMerkleTreeTilesGPU(setupCtx.starkInfo.starkStruct.merkleTreeArity, (uint64_t*)pNodes, (uint64_t*)(d_aux_trace + offset_cmQ), nCols, NExtended, stream);
@@ -610,7 +677,7 @@ __device__ void intt_tinny(gl64_t *data, uint32_t N, uint32_t logN, gl64_t *d_tw
     }
 }
 
-__global__ void fold(uint64_t step, gl64_t *friPol, gl64_t *d_challenge, gl64_t *d_ppar, Goldilocks::Element omega_inv, uint64_t shift_, uint64_t W_, uint64_t nBitsExt, uint64_t prevBits, uint64_t currentBits)
+__global__ void fold(uint64_t step, gl64_t *friPol, gl64_t *d_challenge, gl64_t *d_ppar, Goldilocks::Element omega_inv, uint64_t invShiftPow_, uint64_t invW_, uint64_t nBitsExt, uint64_t prevBits, uint64_t currentBits)
 {
 
     extern __shared__ gl64_t s_twiddles[];
@@ -634,15 +701,8 @@ __global__ void fold(uint64_t step, gl64_t *friPol, gl64_t *d_challenge, gl64_t 
     if (id < sizeFoldedPol)
     {
 
-        gl64_t shift(shift_);
-        gl64_t invShift = shift.reciprocal();
-        for (uint32_t j = 0; j < nBitsExt - prevBits; j++)
-        {
-            invShift *= invShift;
-        }
-
-        gl64_t W(W_);
-        gl64_t invW = W.reciprocal();
+        gl64_t invShift(invShiftPow_);
+        gl64_t invW(invW_);
         // Evaluate the sinv value for the id current component
         gl64_t sinv = invShift;
         gl64_t base = invW;
@@ -712,12 +772,20 @@ void fold_inplace(uint64_t step, uint64_t friPol_offset, uint64_t offset_helper,
     uint64_t sizeFoldedPol = 1 << currentBits;
 
     Goldilocks::Element omega_inv = omegas_inv_[prevBits - currentBits];
-    
+
+    // Precompute invShift^(2^(nBitsExt-prevBits)) on CPU to avoid redundant per-thread computation
+    Goldilocks::Element invShiftPow = Goldilocks::inv(Goldilocks::shift());
+    for (uint32_t j = 0; j < nBitsExt - prevBits; j++) {
+        Goldilocks::square(invShiftPow, invShiftPow);
+    }
+    // Precompute invW on CPU
+    Goldilocks::Element invW = Goldilocks::inv(Goldilocks::w(prevBits));
+
     dim3 nThreads(256);
-    dim3 nBlocks((sizeFoldedPol) + nThreads.x - 1 / nThreads.x);
+    dim3 nBlocks((sizeFoldedPol + nThreads.x - 1) / nThreads.x);
     size_t sharedMem = halfRatio * sizeof(gl64_t);
     TimerStartCategoryGPU(timer, FRI);
-    fold<<<nBlocks, nThreads, sharedMem, stream>>>(step, d_friPol, (gl64_t *)d_challenge, d_ppar, omega_inv, Goldilocks::shift().fe, Goldilocks::w(prevBits).fe, nBitsExt, prevBits, currentBits);
+    fold<<<nBlocks, nThreads, sharedMem, stream>>>(step, d_friPol, (gl64_t *)d_challenge, d_ppar, omega_inv, invShiftPow.fe, invW.fe, nBitsExt, prevBits, currentBits);
     TimerStopCategoryGPU(timer, FRI);
     CHECKCUDAERR(cudaGetLastError());
 }

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -215,6 +215,7 @@ void commitStage_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL **trees
 {
     if (step <= setupCtx.starkInfo.nStages)
     {
+    
         extendAndMerkelize_inplace(step, setupCtx, treesGL, d_trace, d_aux_trace, d_transcript, skipRecalculation, timer, stream);
     }
     else
@@ -255,19 +256,18 @@ void extendAndMerkelize_inplace(uint64_t step, SetupCtx& setupCtx, MerkleTreeGL*
             return;
         }
         if (graphCache->shouldCapture(key)) {
-            graphCache->beginCapture(key, stream);
-
-            NTTGoldilocksGPU ntt;
-            ntt.LDE(dst, offset_dst, src, offset_src, nBits, nBitsExt, nCols, timer, stream);
-            buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(dst + offset_dst), nCols, NExtended, stream);
-
-            graphCache->endCaptureAndLaunch(stream);
-
-            if (d_transcript != nullptr) {
-                uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
-                d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+            if (graphCache->beginCapture(key, stream)) {
+                NTTGoldilocksGPU ntt;
+                ntt.LDE(dst, offset_dst, src, offset_src, nBits, nBitsExt, nCols, timer, stream);
+                buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(dst + offset_dst), nCols, NExtended, stream);
+                if (graphCache->endCaptureAndLaunch(stream)) {
+                    if (d_transcript != nullptr) {
+                        uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                        d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+                    }
+                    return;
+                }
             }
-            return;
         }
     }
 #endif
@@ -320,7 +320,7 @@ void computeQ_MerkleTree_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL
     uint64_t qDim = setupCtx.starkInfo.qDim;
 
     Goldilocks::Element shiftIn = Goldilocks::exp(Goldilocks::inv(Goldilocks::shift()), N);
-
+     
     Goldilocks::Element* d_aux_traceGL = (Goldilocks::Element*) d_aux_trace;
 
     treesGL[step - 1]->setSource(d_aux_traceGL + offset_cmQ);
@@ -349,15 +349,17 @@ void computeQ_MerkleTree_inplace(uint64_t step, SetupCtx &setupCtx, MerkleTreeGL
                     return;
                 }
                 if (graphCache->shouldCapture(key)) {
-                    graphCache->beginCapture(key, stream);
-                    nttExtended.computeQ(offset_cmQ, offset_q, qDeg, qDim, shiftIn, nBits, nBitsExt, nCols, d_aux_trace, offset_helper, timer, stream);
-                    buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(d_aux_trace + offset_cmQ), nCols, NExtended, stream);
-                    graphCache->endCaptureAndLaunch(stream);
-                    uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
-                    if (d_transcript != nullptr) {
-                        d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+                    if (graphCache->beginCapture(key, stream)) {
+                        nttExtended.computeQ(offset_cmQ, offset_q, qDeg, qDim, shiftIn, nBits, nBitsExt, nCols, d_aux_trace, offset_helper, timer, stream);
+                        buildMerkleTreeTilesGPU(arity, (uint64_t*)pNodes, (uint64_t*)(d_aux_trace + offset_cmQ), nCols, NExtended, stream);
+                        if (graphCache->endCaptureAndLaunch(stream)) {
+                            uint64_t tree_size = treesGL[step - 1]->getNumNodes(NExtended);
+                            if (d_transcript != nullptr) {
+                                d_transcript->put(&pNodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+                            }
+                            return;
+                        }
                     }
-                    return;
                 }
             }
         }

--- a/pil2-stark/src/starkpil/transcript/transcriptGL.cu
+++ b/pil2-stark/src/starkpil/transcript/transcriptGL.cu
@@ -83,6 +83,31 @@ __global__ void _add(Goldilocks::Element* input, uint64_t size,  Goldilocks::Ele
     }
 }
 
+__global__ void _add2(Goldilocks::Element* input1, uint64_t size1, Goldilocks::Element* input2, uint64_t size2, Goldilocks::Element* state, Goldilocks::Element* pending, Goldilocks::Element* out, uint* pending_cursor, uint* out_cursor, uint32_t arity)
+{
+    uint32_t transcriptPendingSize = 4 * (arity - 1);
+    for (uint64_t i = 0; i < size1; i++)
+    {
+        pending[*pending_cursor] = input1[i];
+        (*pending_cursor) += 1;
+        *out_cursor = 0;
+        if (*pending_cursor == transcriptPendingSize)
+        {
+            _updateState(state, pending, out, pending_cursor, out_cursor, arity);
+        }
+    }
+    for (uint64_t i = 0; i < size2; i++)
+    {
+        pending[*pending_cursor] = input2[i];
+        (*pending_cursor) += 1;
+        *out_cursor = 0;
+        if (*pending_cursor == transcriptPendingSize)
+        {
+            _updateState(state, pending, out, pending_cursor, out_cursor, arity);
+        }
+    }
+}
+
 __global__ void _getField(uint64_t* output, Goldilocks::Element* state, Goldilocks::Element* pending, Goldilocks::Element* out, uint* pending_cursor, uint* out_cursor, uint32_t arity)
 {
     for (int i = 0; i < 3; i++)
@@ -193,6 +218,12 @@ void TranscriptGL_GPU::put(Goldilocks::Element *input, uint64_t size, cudaStream
 {
     size_t sharedMem = (arity*4) * sizeof(gl64_t); //used by poseidon2PermuteSmem
     _add<<<1,1, sharedMem, stream>>>(input, size, state, pending, out, pending_cursor, out_cursor,arity);
+}
+
+void TranscriptGL_GPU::put2(Goldilocks::Element *input1, uint64_t size1, Goldilocks::Element *input2, uint64_t size2, cudaStream_t stream)
+{
+    size_t sharedMem = (arity*4) * sizeof(gl64_t);
+    _add2<<<1,1, sharedMem, stream>>>(input1, size1, input2, size2, state, pending, out, pending_cursor, out_cursor, arity);
 }
 
 void TranscriptGL_GPU::getField(uint64_t* output, cudaStream_t stream)

--- a/pil2-stark/src/starkpil/transcript/transcriptGL.cuh
+++ b/pil2-stark/src/starkpil/transcript/transcriptGL.cuh
@@ -53,6 +53,7 @@ public:
     };
 
     void put(Goldilocks::Element *input, uint64_t size, cudaStream_t stream);
+    void put2(Goldilocks::Element *input1, uint64_t size1, Goldilocks::Element *input2, uint64_t size2, cudaStream_t stream);
     void getField(uint64_t *output, cudaStream_t stream);
     void getState(Goldilocks::Element* output, cudaStream_t stream);
     void getState(Goldilocks::Element* output, uint64_t nOutputs, cudaStream_t stream);

--- a/pil2-stark/src/utils/cuda_graph_cache.cuh
+++ b/pil2-stark/src/utils/cuda_graph_cache.cuh
@@ -1,0 +1,138 @@
+#ifndef CUDA_GRAPH_CACHE_CUH
+#define CUDA_GRAPH_CACHE_CUH
+
+#ifdef USE_CUDA_GRAPH
+
+#include <cuda_runtime.h>
+#include <unordered_map>
+#include <cstdint>
+#include <cstdio>
+
+class CudaGraphCache;
+
+namespace cudagraph {
+    inline CudaGraphCache*& current() {
+        static thread_local CudaGraphCache* ptr = nullptr;
+        return ptr;
+    }
+    inline bool& aggressive() {
+        static thread_local bool val = false;
+        return val;
+    }
+}
+
+class CudaGraphCache {
+    std::unordered_map<uint64_t, cudaGraphExec_t> cache_;
+    std::unordered_map<uint64_t, uint32_t> hitCount_;
+    uint64_t pending_key_ = 0;
+    bool capturing_ = false;
+
+    static constexpr uint32_t CAPTURE_THRESHOLD = 1000;
+
+    static void clearCudaError() {
+        cudaGetLastError();
+    }
+
+public:
+    CudaGraphCache() = default;
+
+    ~CudaGraphCache() { clear(); }
+
+    CudaGraphCache(const CudaGraphCache&) = delete;
+    CudaGraphCache& operator=(const CudaGraphCache&) = delete;
+
+    bool tryLaunch(uint64_t key, cudaStream_t stream) {
+        auto it = cache_.find(key);
+        if (it == cache_.end()) return false;
+        cudaError_t err = cudaGraphLaunch(it->second, stream);
+        if (err != cudaSuccess) {
+            clearCudaError();
+            cudaGraphExecDestroy(it->second);
+            cache_.erase(it);
+            return false;
+        }
+        return true;
+    }
+
+    bool shouldCapture(uint64_t key) {
+        return ++hitCount_[key] >= CAPTURE_THRESHOLD;
+    }
+
+    void beginCapture(uint64_t key, cudaStream_t stream) {
+        pending_key_ = key;
+        capturing_ = true;
+        cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
+        if (err != cudaSuccess) {
+            clearCudaError();
+            capturing_ = false;
+        }
+    }
+
+    bool endCaptureAndLaunch(cudaStream_t stream) {
+        if (!capturing_) return false;
+        capturing_ = false;
+
+        cudaGraph_t graph = nullptr;
+        cudaError_t err = cudaStreamEndCapture(stream, &graph);
+        if (err != cudaSuccess || graph == nullptr) {
+            clearCudaError();
+            if (graph) cudaGraphDestroy(graph);
+            return false;
+        }
+
+        cudaGraphExec_t exec = nullptr;
+#if CUDART_VERSION >= 12000
+        err = cudaGraphInstantiate(&exec, graph, 0);
+#else
+        err = cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0);
+#endif
+        if (err != cudaSuccess) {
+            clearCudaError();
+            cudaGraphDestroy(graph);
+            return false;
+        }
+
+        err = cudaGraphLaunch(exec, stream);
+        if (err != cudaSuccess) {
+            clearCudaError();
+            cudaGraphExecDestroy(exec);
+            cudaGraphDestroy(graph);
+            return false;
+        }
+
+        cache_[pending_key_] = exec;
+        cudaGraphDestroy(graph);
+        return true;
+    }
+
+    bool isCapturing() const { return capturing_; }
+
+    void clear() {
+        for (auto& kv : cache_) {
+            cudaGraphExecDestroy(kv.second);
+        }
+        cache_.clear();
+        hitCount_.clear();
+        capturing_ = false;
+        clearCudaError();
+    }
+
+    size_t size() const { return cache_.size(); }
+
+    static uint64_t makeKey(uint64_t a, uint64_t b = 0, uint64_t c = 0,
+                            uint64_t d = 0, uint64_t e = 0, uint64_t f = 0,
+                            uint64_t g = 0) {
+        uint64_t h = 0xcbf29ce484222325ULL;
+        const uint64_t prime = 0x100000001b3ULL;
+        auto mix = [&](uint64_t v) {
+            h ^= v;
+            h *= prime;
+        };
+        mix(a); mix(b); mix(c); mix(d); mix(e); mix(f); mix(g);
+        return h;
+    }
+};
+
+#endif // USE_CUDA_GRAPH
+
+#endif // CUDA_GRAPH_CACHE_CUH

--- a/pil2-stark/src/utils/cuda_graph_cache.cuh
+++ b/pil2-stark/src/utils/cuda_graph_cache.cuh
@@ -58,7 +58,7 @@ public:
         return ++hitCount_[key] >= CAPTURE_THRESHOLD;
     }
 
-    void beginCapture(uint64_t key, cudaStream_t stream) {
+    bool beginCapture(uint64_t key, cudaStream_t stream) {
         pending_key_ = key;
         capturing_ = true;
         cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
@@ -66,7 +66,9 @@ public:
             fprintf(stderr, "[cudaGraph] beginCapture failed: %s\n", cudaGetErrorString(err));
             clearCudaError();
             capturing_ = false;
+            return false;
         }
+        return true;
     }
 
     bool endCaptureAndLaunch(cudaStream_t stream) {

--- a/pil2-stark/src/utils/cuda_graph_cache.cuh
+++ b/pil2-stark/src/utils/cuda_graph_cache.cuh
@@ -63,6 +63,7 @@ public:
         capturing_ = true;
         cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
         if (err != cudaSuccess) {
+            fprintf(stderr, "[cudaGraph] beginCapture failed: %s\n", cudaGetErrorString(err));
             clearCudaError();
             capturing_ = false;
         }


### PR DESCRIPTION
## Summary

- Move expression evaluation intermediate temp buffers from global memory to dynamic shared memory (40KB budget), reducing access latency ~4x for the quotient polynomial and witness evaluation kernels
- Add cudaGraph stream capture infrastructure for LDE+Merkle, FRI fold, grinding, and query kernels (threshold conservatively set to 1000)
- Fix fold kernel block count bug (operator precedence), precompute invShift/invW on CPU
- Tune nRowsPack 512 -> 256 for better kernel occupancy
- Add NTT width-4 butterfly unroll, transcript batched put2() API, expression bytecode shared staging

## Benchmark (RTX 5090, sm_120)

| Test case | Baseline | After | Improvement |
|-----------|----------|-------|-------------|
| Small block (66 instances) | 26.116s | 25.020s | 4.2% |
| Large block (478 instances) | 116.796s | 109.079s | 6.6% |

Proofs verified on both test cases.

## Changed files

- `expressions_gpu.cu` — dynamic shared temp buffers, ops/args staging, pack256, interior/boundary split
- `starks_gpu.cu` — fold block count fix, invShift/invW precompute, applyS register optimization, cudaGraph capture
- `gen_proof.cuh` — cudaGraph capture for FRI/grinding/queries, put2() transcript call
- `ntt_goldilocks.cu` — width-4 butterfly unroll
- `transcriptGL.cu/cuh` — batched put2() API
- `cuda_graph_cache.cuh` — new file, per-stream graph cache
- `data_layout.cuh` — getBufferOffset_pack256
- `stark_info.cpp` — nRowsPack default 512 -> 256
- `Makefile` — CUDA_GENCODE_FLAGS, multi-location nvcc detection, DUSE_CUDA_GRAPH flag
- `gl64_tooling.cuh` — minor include cleanup

## Test plan

- [x] `make starks_lib_gpu` compiles cleanly (verified on CUDA 13.2, sm_120)
- [x] Run small block proof and verify
- [x] Run large block proof and verify