### PR TITLE
feat: New Range Check API

### DIFF
--- a/examples/fibonacci-square/src/module.rs
+++ b/examples/fibonacci-square/src/module.rs
@@ -87,12 +87,12 @@ impl<F: PrimeField64> WitnessComponent<F> for Module<F> {
                 air_values.last_segment = F::from_bool(j == num_instances - 1);
 
                 x_mods.par_iter().for_each(|x_mod| {
-                    self.std_lib.range_check(range, (module - x_mod) as i64, 1);
+                    self.std_lib.range_check_one(range, module - x_mod);
                 });
 
                 // Trivial range check for the remaining rows
                 for _ in modules_slice.len()..trace.num_rows() {
-                    self.std_lib.range_check(range, module as i64, 1);
+                    self.std_lib.range_check_one(range, module);
                 }
 
                 let air_instance =

--- a/pil2-components/lib/std/pil/std_range_check.pil
+++ b/pil2-components/lib/std/pil/std_range_check.pil
@@ -411,7 +411,7 @@ function range_check_group(const expr expressions[], const int min, const int ma
 
     int opid;
     for (int i = 0; i < len; i++) {
-        opid =range_check(expressions[i], min, max, sels[i], predefined);
+        opid = range_check(expressions[i], min, max, sels[i], predefined);
     }
 
     return opid;
@@ -764,7 +764,6 @@ private function declare_u8_air() {
             U8Air(N: u8_air_n);
         }
     } else {
-        // TODO: Discuss if this makes sense
         // If the U8Air is needed more than once, we instantiate it in its own airgroup
         airgroup U8Air {
             if (U8_TABLE_VIRTUAL == 1) {
@@ -781,7 +780,7 @@ private function declare_u8_air() {
 private function declare_u16_air() {
     use proof.std.rc;
 
-    // Uupdate the number of U16 airgroups
+    // Update the number of U16 airgroups
     num_u16_airgroup++;
 
     // The U16 air is only needed once, so we wait for the last airgroup that uses it
@@ -789,7 +788,7 @@ private function declare_u16_air() {
         return;
     }
 
-    // save the airgroup id and air id of the table for latter use
+    // Save the airgroup id and air id of the table for latter use
     container proof.std.u16 {
         int airgroup_id = -1;
         int air_id = -1;

--- a/pil2-components/lib/std/rs/Cargo.toml
+++ b/pil2-components/lib/std/rs/Cargo.toml
@@ -24,4 +24,3 @@ serde_json.workspace = true
 
 [features]
 default = []
-verify-rc-values = []

--- a/pil2-components/lib/std/rs/src/range_check/specified_ranges.rs
+++ b/pil2-components/lib/std/rs/src/range_check/specified_ranges.rs
@@ -129,51 +129,22 @@ impl SpecifiedRanges {
         values.iter().map(|&v| Self::get_global_row(range_min, v)).collect()
     }
 
-    #[inline(always)]
-    pub fn update_input(&self, id: usize, value: i64, multiplicity: u64) {
+    /// Core update function: Updates multiplicities for value/multiplicity pairs
+    #[inline]
+    fn update(&self, table_offset: usize, range_min: i64, iter: impl Iterator<Item = (i64, u64)>) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
-        // Get the range for the given id
-        let range = &self.ranges[id];
-        let range_min = range.min;
+        for (value, multiplicity) in iter {
+            if multiplicity == 0 {
+                continue;
+            }
 
-        // Get the table offset
-        let table_offset = range.acc_height;
-
-        // Get the value offset
-        let val_offset = (value - range_min) as usize;
-
-        // Get the overall offset
-        let offset = table_offset + val_offset;
-
-        // Get the multiplicity index
-        let mul_idx = offset >> self.shift;
-
-        // Get the row index
-        let row_idx = offset & self.mask;
-
-        // Update the multiplicity
-        self.multiplicities[mul_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
-    }
-
-    pub fn update_inputs(&self, id: usize, values: Vec<u32>) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Get the range for the given id
-        let range = &self.ranges[id];
-        let range_min = range.min;
-        let table_offset = range.acc_height;
-
-        // Identify to which sub-range the value belongs
-        for (value, multiplicity) in values.iter().enumerate() {
             // Get the value offset
-            let val_offset = (value as i64 - range_min) as usize;
+            let val_offset = (value - range_min) as usize;
 
-            // Get the row offset
+            // Get the overall offset
             let offset = table_offset + val_offset;
 
             // Get the multiplicity index
@@ -183,8 +154,28 @@ impl SpecifiedRanges {
             let row_idx = offset & self.mask;
 
             // Update the multiplicity
-            self.multiplicities[mul_idx][row_idx].fetch_add(*multiplicity as u64, Ordering::Relaxed);
+            self.multiplicities[mul_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
         }
+    }
+
+    /// Update a single value with a multiplicity
+    pub fn update_value(&self, id: usize, value: i64, multiplicity: u64) {
+        let range = &self.ranges[id];
+        self.update(range.acc_height, range.min, std::iter::once((value, multiplicity)));
+    }
+
+    /// Update multiple values with corresponding multiplicities
+    pub fn update_values(&self, id: usize, values: &[i64], multiplicities: &[u64]) {
+        debug_assert!(!values.is_empty() && values.len() == multiplicities.len());
+        let range = &self.ranges[id];
+        self.update(range.acc_height, range.min, values.iter().copied().zip(multiplicities.iter().copied()));
+    }
+
+    /// Update multiple values with the same multiplicity
+    pub fn update_values_same_mul(&self, id: usize, values: &[i64], multiplicity: u64) {
+        debug_assert!(!values.is_empty());
+        let range = &self.ranges[id];
+        self.update(range.acc_height, range.min, values.iter().copied().map(|v| (v, multiplicity)));
     }
 
     pub fn airgroup_id(&self) -> usize {

--- a/pil2-components/lib/std/rs/src/range_check/std_range_check.rs
+++ b/pil2-components/lib/std/rs/src/range_check/std_range_check.rs
@@ -346,35 +346,37 @@ impl<F: PrimeField64> StdRangeCheck<F> {
         let range_item = &self.ranges[id];
 
         // Check that the value is contained within the range
-        #[cfg(all(debug_assertions, feature = "verify-rc-values"))]
-        check_value_in_range(range_item, value);
+        #[cfg(debug_assertions)]
+        Self::check_value_in_range(range_item, value);
 
         // Update the multiplicity of the corresponding AIR
         match range_item.rc_type {
             StdRangeType::U8Air => {
                 // Here, we can safely assume that value ∊ [0,2⁸-1]
                 // Therefore, we can safely cast value to u8
+                let value = value as u8;
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let row = U8Air::get_global_row(value as u8);
+                    let row = U8Air::get_global_row(value);
 
                     // Increment the virtual row
                     self.virtual_table.inc_virtual_row(range_item.virtual_id, row, multiplicity);
                 } else {
-                    self.u8air.as_ref().unwrap().update_input(value as u8, multiplicity);
+                    self.u8air.as_ref().unwrap().update_value(value, multiplicity);
                 }
             }
             StdRangeType::U16Air => {
                 // Here, we can safely assume that value ∊ [0,2¹⁶-1]
                 // Therefore, we can safely cast value to u16
+                let value = value as u16;
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let row = U16Air::get_global_row(value as u16);
+                    let row = U16Air::get_global_row(value);
 
                     // Increment the virtual row
                     self.virtual_table.inc_virtual_row(range_item.virtual_id, row, multiplicity);
                 } else {
-                    self.u16air.as_ref().unwrap().update_input(value as u16, multiplicity);
+                    self.u16air.as_ref().unwrap().update_value(value, multiplicity);
                 }
             }
             StdRangeType::U8AirDouble => {
@@ -385,14 +387,13 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                 let upper_value = (range_data.max - value) as u8;
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let rows = vec![U8Air::get_global_row(lower_value), U8Air::get_global_row(upper_value)];
+                    let rows = [U8Air::get_global_row(lower_value), U8Air::get_global_row(upper_value)];
 
                     // Increment the virtual row
                     self.virtual_table.inc_virtual_rows_same_mul(range_item.virtual_id, &rows, multiplicity);
                 } else {
                     let u8_air = self.u8air.as_ref().unwrap();
-                    u8_air.update_input(lower_value, multiplicity);
-                    u8_air.update_input(upper_value, multiplicity);
+                    u8_air.update_values_same_mul(&[lower_value, upper_value], multiplicity);
                 }
             }
             StdRangeType::U16AirDouble => {
@@ -403,14 +404,13 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                 let upper_value = (range_data.max - value) as u16;
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let rows = vec![U16Air::get_global_row(lower_value), U16Air::get_global_row(upper_value)];
+                    let rows = [U16Air::get_global_row(lower_value), U16Air::get_global_row(upper_value)];
 
                     // Increment the virtual rows
                     self.virtual_table.inc_virtual_rows_same_mul(range_item.virtual_id, &rows, multiplicity);
                 } else {
                     let u16_air = self.u16air.as_ref().unwrap();
-                    u16_air.update_input(lower_value, multiplicity);
-                    u16_air.update_input(upper_value, multiplicity);
+                    u16_air.update_values_same_mul(&[lower_value, upper_value], multiplicity);
                 }
             }
             StdRangeType::SpecifiedRanges => {
@@ -421,20 +421,25 @@ impl<F: PrimeField64> StdRangeCheck<F> {
                     // Increment the virtual rows
                     self.virtual_table.inc_virtual_row(range_item.virtual_id, row, multiplicity);
                 } else {
-                    self.specified_ranges_air.as_ref().unwrap().update_input(id, value, multiplicity);
+                    let specified_ranges_air = self.specified_ranges_air.as_ref().unwrap();
+                    specified_ranges_air.update_value(id, value, multiplicity);
                 }
             }
         }
     }
 
-    pub fn assign_values(&self, id: usize, values: Vec<u32>) {
+    pub fn assign_values(&self, id: usize, values: &[i64], multiplicities: &[u64]) {
         // Find the range with the given id
         let range_item = &self.ranges[id];
 
         // Check that the value is contained within the range
-        #[cfg(all(debug_assertions, feature = "verify-rc-values"))]
-        for (value, _) in values.iter().enumerate() {
-            check_value_in_range(range_item, value);
+        #[cfg(debug_assertions)]
+        {
+            assert_eq!(values.len(), multiplicities.len(), "Rows and multiplicities must have the same length");
+
+            for &value in values {
+                Self::check_value_in_range(range_item, value);
+            }
         }
 
         // Update the multiplicity of the corresponding AIR
@@ -442,54 +447,305 @@ impl<F: PrimeField64> StdRangeCheck<F> {
             StdRangeType::U8Air => {
                 // Here, we can safely assume that value ∊ [0,2⁸-1]
                 // Therefore, we can safely cast value to u8
+                let vals: Vec<u8> = values.iter().map(|&v| v as u8).collect();
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let vals: Vec<u8> = (0..values.len()).map(|v| v as u8).collect();
                     let rows = U8Air::get_global_rows(&vals);
 
                     // Increment the virtual rows
-                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, &values);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
                 } else {
-                    self.u8air.as_ref().unwrap().update_inputs(values);
+                    self.u8air.as_ref().unwrap().update_values(&vals, multiplicities);
                 }
             }
             StdRangeType::U16Air => {
                 // Here, we can safely assume that value ∊ [0,2¹⁶-1]
                 // Therefore, we can safely cast value to u16
+                let vals: Vec<u16> = values.iter().map(|&v| v as u16).collect();
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let vals: Vec<u16> = (0..values.len()).map(|v| v as u16).collect();
                     let rows = U16Air::get_global_rows(&vals);
 
                     // Increment the virtual rows
-                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, &values);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
                 } else {
-                    self.u16air.as_ref().unwrap().update_inputs(values);
+                    self.u16air.as_ref().unwrap().update_values(&vals, multiplicities);
+                }
+            }
+            StdRangeType::U8AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2⁸-1], min >= 0 and max <= 2⁸-1
+                // Therefore, we can safely cast value to u8
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u8> = values.iter().map(|&v| (v - range_data.min) as u8).collect();
+                let upper_vals: Vec<u8> = values.iter().map(|&v| (range_data.max - v) as u8).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U8Air::get_global_rows(&lower_vals);
+                    let upper_rows = U8Air::get_global_rows(&upper_vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &lower_rows, multiplicities);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &upper_rows, multiplicities);
+                } else {
+                    self.u8air.as_ref().unwrap().update_values(&lower_vals, multiplicities);
+                    self.u8air.as_ref().unwrap().update_values(&upper_vals, multiplicities);
+                }
+            }
+            StdRangeType::U16AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2¹⁶-1], min >= 0 and max <= 2¹⁶-1
+                // Therefore, we can safely cast value to u16
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u16> = values.iter().map(|&v| (v - range_data.min) as u16).collect();
+                let upper_vals: Vec<u16> = values.iter().map(|&v| (range_data.max - v) as u16).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U16Air::get_global_rows(&lower_vals);
+                    let upper_rows = U16Air::get_global_rows(&upper_vals);
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &lower_rows, multiplicities);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &upper_rows, multiplicities);
+                } else {
+                    self.u16air.as_ref().unwrap().update_values(&lower_vals, multiplicities);
+                    self.u16air.as_ref().unwrap().update_values(&upper_vals, multiplicities);
                 }
             }
             StdRangeType::SpecifiedRanges => {
                 if range_item.is_virtual {
                     // Get the rows corresponding to the values
-                    let vals: Vec<i64> = (0..values.len()).map(|v| v as i64).collect();
-                    let rows = SpecifiedRanges::get_global_rows(range_item.data.min, &vals);
+                    let rows = SpecifiedRanges::get_global_rows(range_item.data.min, values);
 
                     // Increment the virtual rows
-                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, &values);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
                 } else {
-                    self.specified_ranges_air.as_ref().unwrap().update_inputs(id, values);
+                    self.specified_ranges_air.as_ref().unwrap().update_values(id, values, multiplicities);
                 }
             }
-            StdRangeType::U8AirDouble | StdRangeType::U16AirDouble => unreachable!(),
         }
     }
 
-    #[cfg(all(debug_assertions, feature = "verify-rc-values"))]
+    pub fn assign_values_same_mul(&self, id: usize, values: &[i64], multiplicity: u64) {
+        // Find the range with the given id
+        let range_item = &self.ranges[id];
+
+        // Check that all values are contained within the range
+        #[cfg(debug_assertions)]
+        {
+            for &value in values {
+                Self::check_value_in_range(range_item, value);
+            }
+        }
+
+        // Update the multiplicity of the corresponding AIR
+        match range_item.rc_type {
+            StdRangeType::U8Air => {
+                // Here, we can safely assume that value ∊ [0,2⁸-1]
+                // Therefore, we can safely cast value to u8
+                let vals: Vec<u8> = values.iter().map(|&v| v as u8).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = U8Air::get_global_rows(&vals);
+
+                    // Increment the virtual row
+                    self.virtual_table.inc_virtual_rows_same_mul(range_item.virtual_id, &rows, multiplicity);
+                } else {
+                    self.u8air.as_ref().unwrap().update_values_same_mul(&vals, multiplicity);
+                }
+            }
+            StdRangeType::U16Air => {
+                // Here, we can safely assume that value ∊ [0,2¹⁶-1]
+                // Therefore, we can safely cast value to u16
+                let vals: Vec<u16> = values.iter().map(|&v| v as u16).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = U16Air::get_global_rows(&vals);
+
+                    // Increment the virtual row
+                    self.virtual_table.inc_virtual_rows_same_mul(range_item.virtual_id, &rows, multiplicity);
+                } else {
+                    self.u16air.as_ref().unwrap().update_values_same_mul(&vals, multiplicity);
+                }
+            }
+            StdRangeType::U8AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2⁸-1], min >= 0 and max <= 2⁸-1
+                // Therefore, we can safely cast value to u8
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u8> = values.iter().map(|&v| (v - range_data.min) as u8).collect();
+                let upper_vals: Vec<u8> = values.iter().map(|&v| (range_data.max - v) as u8).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U8Air::get_global_rows(&lower_vals);
+                    let upper_rows = U8Air::get_global_rows(&upper_vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows_same_mul(
+                        range_item.virtual_id,
+                        &[lower_rows, upper_rows].concat(),
+                        multiplicity,
+                    );
+                } else {
+                    self.u8air
+                        .as_ref()
+                        .unwrap()
+                        .update_values_same_mul(&[lower_vals, upper_vals].concat(), multiplicity);
+                }
+            }
+            StdRangeType::U16AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2¹⁶-1], min >= 0 and max <= 2¹⁶-1
+                // Therefore, we can safely cast value to u16
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u16> = values.iter().map(|&v| (v - range_data.min) as u16).collect();
+                let upper_vals: Vec<u16> = values.iter().map(|&v| (range_data.max - v) as u16).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U16Air::get_global_rows(&lower_vals);
+                    let upper_rows = U16Air::get_global_rows(&upper_vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows_same_mul(
+                        range_item.virtual_id,
+                        &[lower_rows, upper_rows].concat(),
+                        multiplicity,
+                    );
+                } else {
+                    self.u16air
+                        .as_ref()
+                        .unwrap()
+                        .update_values_same_mul(&[lower_vals, upper_vals].concat(), multiplicity);
+                }
+            }
+            StdRangeType::SpecifiedRanges => {
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = SpecifiedRanges::get_global_rows(range_item.data.min, values);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows_same_mul(range_item.virtual_id, &rows, multiplicity);
+                } else {
+                    self.specified_ranges_air.as_ref().unwrap().update_values_same_mul(id, values, multiplicity);
+                }
+            }
+        }
+    }
+
+    pub fn assign_values_ranged(&self, id: usize, start: Option<i64>, multiplicities: &[u64]) {
+        // Find the range with the given id
+        let range_item = &self.ranges[id];
+
+        // Initialize the starting point
+        let start = start.unwrap_or(range_item.data.min);
+
+        // Check that the value is contained within the range
+        #[cfg(debug_assertions)]
+        {
+            // Check the given range [start, start + N] actually fits
+            let end = start + multiplicities.len() as i64 - 1;
+            let min = range_item.data.min;
+            let max = range_item.data.max;
+            if start < min {
+                panic!("Range check failed: Start value {} is less than the range minimum {}", start, min);
+            }
+            if end > max {
+                panic!(
+                    "Range check failed: End value {} (start {} + count {} - 1) exceeds the range maximum {}",
+                    end,
+                    start,
+                    multiplicities.len(),
+                    max
+                );
+            }
+        }
+
+        // Update the multiplicity of the corresponding AIR
+        match range_item.rc_type {
+            StdRangeType::U8Air => {
+                // Here, we can safely assume that value ∊ [0,2⁸-1]
+                // Therefore, we can safely cast value to u8
+                let vals: Vec<u8> = (0..multiplicities.len()).map(|v| (start as usize + v) as u8).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = U8Air::get_global_rows(&vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
+                } else {
+                    self.u8air.as_ref().unwrap().update_values(&vals, multiplicities);
+                }
+            }
+            StdRangeType::U16Air => {
+                // Here, we can safely assume that value ∊ [0,2¹⁶-1]
+                // Therefore, we can safely cast value to u16
+                let vals: Vec<u16> = (0..multiplicities.len()).map(|v| (start as usize + v) as u16).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = U16Air::get_global_rows(&vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
+                } else {
+                    self.u16air.as_ref().unwrap().update_values(&vals, multiplicities);
+                }
+            }
+            StdRangeType::U8AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2⁸-1], min >= 0 and max <= 2⁸-1
+                // Therefore, we can safely cast value to u8
+                let vals: Vec<i64> = (0..multiplicities.len()).map(|v| start + v as i64).collect();
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u8> = vals.iter().map(|&v| (v - range_data.min) as u8).collect();
+                let upper_vals: Vec<u8> = vals.iter().map(|&v| (range_data.max - v) as u8).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U8Air::get_global_rows(&lower_vals);
+                    let upper_rows = U8Air::get_global_rows(&upper_vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &lower_rows, multiplicities);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &upper_rows, multiplicities);
+                } else {
+                    self.u8air.as_ref().unwrap().update_values(&lower_vals, multiplicities);
+                    self.u8air.as_ref().unwrap().update_values(&upper_vals, multiplicities);
+                }
+            }
+            StdRangeType::U16AirDouble => {
+                // Here, we can safely assume that value ∊ [0,2¹⁶-1], min >= 0 and max <= 2¹⁶-1
+                // Therefore, we can safely cast value to u16
+                let vals: Vec<i64> = (0..multiplicities.len()).map(|v| start + v as i64).collect();
+                let range_data = &range_item.data;
+                let lower_vals: Vec<u16> = vals.iter().map(|&v| (v - range_data.min) as u16).collect();
+                let upper_vals: Vec<u16> = vals.iter().map(|&v| (range_data.max - v) as u16).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let lower_rows = U16Air::get_global_rows(&lower_vals);
+                    let upper_rows = U16Air::get_global_rows(&upper_vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &lower_rows, multiplicities);
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &upper_rows, multiplicities);
+                } else {
+                    self.u16air.as_ref().unwrap().update_values(&lower_vals, multiplicities);
+                    self.u16air.as_ref().unwrap().update_values(&upper_vals, multiplicities);
+                }
+            }
+            StdRangeType::SpecifiedRanges => {
+                let vals: Vec<i64> = (0..multiplicities.len()).map(|v| start + v as i64).collect();
+                if range_item.is_virtual {
+                    // Get the rows corresponding to the values
+                    let rows = SpecifiedRanges::get_global_rows(range_item.data.min, &vals);
+
+                    // Increment the virtual rows
+                    self.virtual_table.inc_virtual_rows(range_item.virtual_id, &rows, multiplicities);
+                } else {
+                    self.specified_ranges_air.as_ref().unwrap().update_values(id, &vals, multiplicities);
+                }
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
     fn check_value_in_range(range: &StdRange, value: i64) {
         let min = range.data.min;
         let max = range.data.max;
         if value < min || value > max {
-            log::error!("Value {} is not in the range [min,max] = [{},{}]", value, min, max);
-            panic!("Range check failed");
+            panic!("Range check failed: Value {} is not in the range [min,max] = [{},{}]", value, min, max);
         }
     }
 }

--- a/pil2-components/lib/std/rs/src/range_check/u16air.rs
+++ b/pil2-components/lib/std/rs/src/range_check/u16air.rs
@@ -72,31 +72,20 @@ impl U16Air {
         values.iter().map(|&v| Self::get_global_row(v)).collect()
     }
 
-    #[inline(always)]
-    pub fn update_input(&self, value: u16, multiplicity: u64) {
+    /// Core update function: Updates multiplicities for value/multiplicity pairs
+    #[inline]
+    fn update(&self, iter: impl Iterator<Item = (u16, u64)>) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
-        // Identify to which sub-range the value belongs
-        let range_idx = (value as usize) >> self.shift;
-
-        // Get the row index
-        let row_idx = (value as usize) & self.mask;
-
-        // Update the multiplicity
-        self.multiplicities[range_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
-    }
-
-    pub fn update_inputs(&self, values: Vec<u32>) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        for (value, multiplicity) in values.iter().enumerate() {
-            if *multiplicity == 0 {
+        for (value, multiplicity) in iter {
+            if multiplicity == 0 {
                 continue;
             }
+
+            // Convert the value to usize for bitwise operations
+            let value = value as usize;
 
             // Identify to which sub-range the value belongs
             let range_idx = value >> self.shift;
@@ -105,8 +94,24 @@ impl U16Air {
             let row_idx = value & self.mask;
 
             // Update the multiplicity
-            self.multiplicities[range_idx][row_idx].fetch_add(*multiplicity as u64, Ordering::Relaxed);
+            self.multiplicities[range_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
         }
+    }
+
+    /// Update a single value with a multiplicity
+    pub fn update_value(&self, value: u16, multiplicity: u64) {
+        self.update(std::iter::once((value, multiplicity)));
+    }
+
+    /// Update multiple values with corresponding multiplicities
+    pub fn update_values(&self, values: &[u16], multiplicities: &[u64]) {
+        debug_assert_eq!(values.len(), multiplicities.len());
+        self.update(values.iter().copied().zip(multiplicities.iter().copied()));
+    }
+
+    /// Update multiple values with the same multiplicity
+    pub fn update_values_same_mul(&self, values: &[u16], multiplicity: u64) {
+        self.update(values.iter().copied().map(|v| (v, multiplicity)));
     }
 
     pub fn airgroup_id(&self) -> usize {

--- a/pil2-components/lib/std/rs/src/range_check/u8air.rs
+++ b/pil2-components/lib/std/rs/src/range_check/u8air.rs
@@ -71,31 +71,20 @@ impl U8Air {
         values.iter().map(|&v| Self::get_global_row(v)).collect()
     }
 
-    #[inline(always)]
-    pub fn update_input(&self, value: u8, multiplicity: u64) {
+    /// Core update function: Updates multiplicities for value/multiplicity pairs
+    #[inline]
+    fn update(&self, iter: impl Iterator<Item = (u8, u64)>) {
         if self.calculated.load(Ordering::Relaxed) {
             return;
         }
 
-        // Identify to which sub-range the value belongs
-        let range_idx = (value as usize) >> self.shift;
-
-        // Get the row index
-        let row_idx = (value as usize) & self.mask;
-
-        // Update the multiplicity
-        self.multiplicities[range_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
-    }
-
-    pub fn update_inputs(&self, values: Vec<u32>) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        for (value, multiplicity) in values.iter().enumerate() {
-            if *multiplicity == 0 {
+        for (value, multiplicity) in iter {
+            if multiplicity == 0 {
                 continue;
             }
+
+            // Convert value to usize for bitwise operations
+            let value = value as usize;
 
             // Identify to which sub-range the value belongs
             let range_idx = value >> self.shift;
@@ -104,8 +93,24 @@ impl U8Air {
             let row_idx = value & self.mask;
 
             // Update the multiplicity
-            self.multiplicities[range_idx][row_idx].fetch_add(*multiplicity as u64, Ordering::Relaxed);
+            self.multiplicities[range_idx][row_idx].fetch_add(multiplicity, Ordering::Relaxed);
         }
+    }
+
+    /// Update a single value with a multiplicity
+    pub fn update_value(&self, value: u8, multiplicity: u64) {
+        self.update(std::iter::once((value, multiplicity)));
+    }
+
+    /// Update multiple values with corresponding multiplicities
+    pub fn update_values(&self, values: &[u8], multiplicities: &[u64]) {
+        debug_assert_eq!(values.len(), multiplicities.len());
+        self.update(values.iter().copied().zip(multiplicities.iter().copied()));
+    }
+
+    /// Update multiple values with the same multiplicity
+    pub fn update_values_same_mul(&self, values: &[u8], multiplicity: u64) {
+        self.update(values.iter().copied().map(|v| (v, multiplicity)));
     }
 
     pub fn airgroup_id(&self) -> usize {

--- a/pil2-components/lib/std/rs/src/std.rs
+++ b/pil2-components/lib/std/rs/src/std.rs
@@ -157,16 +157,19 @@ impl<F: PrimeField64> Std<F> {
         Ok(id)
     }
 
+    /// Increments the multiplicity `mul` of a given row `row` in the virtual table with id `id`
     pub fn inc_virtual_row<M: RCMultiplicity>(&self, id: usize, row: M, mul: M) {
         let id = self.unwrap_virtual_table_id(id);
         self.virtual_table.inc_virtual_row(id, row.to_u64(), mul.to_u64());
     }
 
+    /// Increments the multiplicity of a given row `row` by 1
     pub fn inc_virtual_row_one<M: RCMultiplicity>(&self, id: usize, row: M) {
         let id = self.unwrap_virtual_table_id(id);
         self.virtual_table.inc_virtual_row(id, row.to_u64(), 1);
     }
 
+    /// Increments the multiplicities for multiple row/multiplicity pairs in the virtual table with id `id`
     pub fn inc_virtual_row_batch<M: RCMultiplicity>(&self, id: usize, rows: &[M], muls: &[M]) {
         let id = self.unwrap_virtual_table_id(id);
         let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
@@ -174,18 +177,22 @@ impl<F: PrimeField64> Std<F> {
         self.virtual_table.inc_virtual_rows(id, &rows, &muls);
     }
 
+    /// Increments the multiplicity by 1 for each row in `rows`
     pub fn inc_virtual_row_batch_one<M: RCMultiplicity>(&self, id: usize, rows: &[M]) {
         let id = self.unwrap_virtual_table_id(id);
         let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
         self.virtual_table.inc_virtual_rows_same_mul(id, &rows, 1);
     }
 
+    /// Increments the multiplicities for multiple rows with the same multiplicity in the virtual table with id `id`
     pub fn inc_virtual_rows_same_mul<M: RCMultiplicity>(&self, id: usize, rows: &[M], mul: M) {
         let id = self.unwrap_virtual_table_id(id);
         let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
         self.virtual_table.inc_virtual_rows_same_mul(id, &rows, mul.to_u64());
     }
 
+    /// Increments the multiplicities of a list of rows `[start, start + N]` in the virtual table with id `id`.
+    /// If `start` is `None`, then it is set to be 0
     pub fn inc_virtual_rows_ranged<M: RCMultiplicity>(&self, id: usize, start: Option<u64>, muls: &[M]) {
         let id = self.unwrap_virtual_table_id(id);
         let start = start.map(|s| s.to_u64());

--- a/pil2-components/lib/std/rs/src/std.rs
+++ b/pil2-components/lib/std/rs/src/std.rs
@@ -6,6 +6,47 @@ use proofman_common::{ProofCtx, ProofmanResult, SetupCtx, StdMode};
 
 use crate::{StdProd, StdRangeCheck, StdSum, StdVirtualTable};
 
+/// Trait for types that can be used as range check values
+pub trait RCValue: Copy {
+    fn to_i64(self) -> i64;
+}
+
+macro_rules! impl_range_value {
+    ($($t:ty),*) => {
+        $(impl RCValue for $t {
+            #[inline(always)]
+            fn to_i64(self) -> i64 { self as i64 }
+        })*
+    };
+}
+
+impl_range_value!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
+
+/// Trait for types that can be used as multiplicities
+pub trait RCMultiplicity: Copy {
+    fn to_u64(self) -> u64;
+}
+
+macro_rules! impl_multiplicity {
+    ($($t:ty),*) => {
+        $(impl RCMultiplicity for $t {
+            #[inline(always)]
+            fn to_u64(self) -> u64 { self as u64 }
+        })*
+    };
+}
+
+impl_multiplicity!(u16, u32, u64, usize);
+
+/// Marker bit to distinguish range check IDs from virtual table IDs
+/// This assumes that we will never have more than 2^62 range checks or virtual tables
+#[cfg(debug_assertions)]
+const RANGE_CHECK_MARKER: usize = 1 << 63;
+#[cfg(debug_assertions)]
+const VIRTUAL_TABLE_MARKER: usize = 1 << 62;
+#[cfg(debug_assertions)]
+const ID_MASK: usize = !(RANGE_CHECK_MARKER | VIRTUAL_TABLE_MARKER);
+
 pub struct Std<F: PrimeField64> {
     // STD mode
     pub mode: RwLock<StdMode>,
@@ -31,41 +72,142 @@ impl<F: PrimeField64> Std<F> {
         Ok(Arc::new(Self { mode, prod_bus, sum_bus, range_check, virtual_table }))
     }
 
+    // ==================== Range Check API ====================
+
     /// Gets the range id for a given range subject to the range check
-    pub fn get_range_id(&self, min: i64, max: i64, predefined: Option<bool>) -> ProofmanResult<usize> {
-        self.range_check.get_range_id(min, max, predefined)
+    pub fn get_range_id<V: RCValue>(&self, min: V, max: V, predefined: Option<bool>) -> ProofmanResult<usize> {
+        let id = self.range_check.get_range_id(min.to_i64(), max.to_i64(), predefined)?;
+
+        #[cfg(debug_assertions)]
+        let id = id | RANGE_CHECK_MARKER;
+
+        Ok(id)
     }
+
+    /// Increments the multiplicity `mul` of a given value `val` in the range check with id `id`
+    pub fn range_check<V: RCValue, M: RCMultiplicity>(&self, id: usize, val: V, mul: M) {
+        let id = self.unwrap_range_check_id(id);
+        self.range_check.assign_value(id, val.to_i64(), mul.to_u64());
+    }
+
+    /// Increments the multiplicity of a given value `val` by 1
+    pub fn range_check_one<V: RCValue>(&self, id: usize, val: V) {
+        let id = self.unwrap_range_check_id(id);
+        self.range_check.assign_value(id, val.to_i64(), 1);
+    }
+
+    /// Increments the multiplicities for multiple value/multiplicity pairs in the range check with id `id`
+    pub fn range_check_batch<V: RCValue, M: RCMultiplicity>(&self, id: usize, vals: &[V], muls: &[M]) {
+        let id = self.unwrap_range_check_id(id);
+        let vals: Vec<i64> = vals.iter().map(|&v| v.to_i64()).collect();
+        let muls: Vec<u64> = muls.iter().map(|&m| m.to_u64()).collect();
+        self.range_check.assign_values(id, &vals, &muls);
+    }
+
+    /// Increments the multiplicity by 1 for each value in `vals`
+    pub fn range_check_batch_one<V: RCValue>(&self, id: usize, vals: &[V]) {
+        let id = self.unwrap_range_check_id(id);
+        let vals: Vec<i64> = vals.iter().map(|&v| v.to_i64()).collect();
+        self.range_check.assign_values_same_mul(id, &vals, 1);
+    }
+
+    /// Increments the multiplicities for multiple values with the same multiplicity in the range check with id `id`
+    pub fn range_checks_same_mul<V: RCValue, M: RCMultiplicity>(&self, id: usize, vals: &[V], mul: M) {
+        let id = self.unwrap_range_check_id(id);
+        let vals: Vec<i64> = vals.iter().map(|&v| v.to_i64()).collect();
+        self.range_check.assign_values_same_mul(id, &vals, mul.to_u64());
+    }
+
+    /// Increments the multiplicities of a list of values `[start, start + N]` in the range check with id `id`.
+    /// If `start` is `None`, then it is set to be the minimum of the range
+    pub fn range_check_ranged<M: RCMultiplicity>(&self, id: usize, start: Option<i64>, muls: &[M]) {
+        let id = self.unwrap_range_check_id(id);
+        let start = start.map(|s| s.to_i64());
+        let muls: Vec<u64> = muls.iter().map(|&m| m.to_u64()).collect();
+        self.range_check.assign_values_ranged(id, start, &muls)
+    }
+
+    #[inline(always)]
+    fn unwrap_range_check_id(&self, id: usize) -> usize {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                (id & RANGE_CHECK_MARKER) != 0,
+                "Invalid range check ID: {}. Expected an ID from get_range_id().",
+                id & ID_MASK
+            );
+            id & ID_MASK
+        }
+
+        #[cfg(not(debug_assertions))]
+        {
+            id
+        }
+    }
+
+    // ==================== Virtual Table API ====================
 
     /// Gets the virtual table ID for a given ID
     pub fn get_virtual_table_id(&self, id: usize) -> ProofmanResult<usize> {
-        self.virtual_table.get_global_id(id)
+        let id = self.virtual_table.get_global_id(id)?;
+
+        #[cfg(debug_assertions)]
+        let id = id | VIRTUAL_TABLE_MARKER;
+
+        Ok(id)
     }
 
-    pub fn range_check(&self, id: usize, val: i64, multiplicity: u64) {
-        self.range_check.assign_value(id, val, multiplicity);
+    pub fn inc_virtual_row<M: RCMultiplicity>(&self, id: usize, row: M, mul: M) {
+        let id = self.unwrap_virtual_table_id(id);
+        self.virtual_table.inc_virtual_row(id, row.to_u64(), mul.to_u64());
     }
 
-    pub fn range_checks(&self, id: usize, values: Vec<u32>) {
-        self.range_check.assign_values(id, values)
+    pub fn inc_virtual_row_one<M: RCMultiplicity>(&self, id: usize, row: M) {
+        let id = self.unwrap_virtual_table_id(id);
+        self.virtual_table.inc_virtual_row(id, row.to_u64(), 1);
     }
 
-    pub fn inc_virtual_row(&self, id: usize, row: u64, multiplicity: u64) {
-        self.virtual_table.inc_virtual_row(id, row, multiplicity);
+    pub fn inc_virtual_row_batch<M: RCMultiplicity>(&self, id: usize, rows: &[M], muls: &[M]) {
+        let id = self.unwrap_virtual_table_id(id);
+        let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
+        let muls: Vec<u64> = muls.iter().map(|&m| m.to_u64()).collect();
+        self.virtual_table.inc_virtual_rows(id, &rows, &muls);
     }
 
-    pub fn inc_virtual_rows(&self, id: usize, rows: &[u64], multiplicities: &[u32]) {
-        #[cfg(all(debug_assertions, feature = "verify-rc-values"))]
-        assert_eq!(rows.len(), multiplicities.len(), "Rows and multiplicities must have the same length");
-
-        self.virtual_table.inc_virtual_rows(id, rows, multiplicities);
+    pub fn inc_virtual_row_batch_one<M: RCMultiplicity>(&self, id: usize, rows: &[M]) {
+        let id = self.unwrap_virtual_table_id(id);
+        let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
+        self.virtual_table.inc_virtual_rows_same_mul(id, &rows, 1);
     }
 
-    pub fn inc_virtual_rows_same_mul(&self, id: usize, rows: &[u64], multiplicity: u64) {
-        self.virtual_table.inc_virtual_rows_same_mul(id, rows, multiplicity);
+    pub fn inc_virtual_rows_same_mul<M: RCMultiplicity>(&self, id: usize, rows: &[M], mul: M) {
+        let id = self.unwrap_virtual_table_id(id);
+        let rows: Vec<u64> = rows.iter().map(|&r| r.to_u64()).collect();
+        self.virtual_table.inc_virtual_rows_same_mul(id, &rows, mul.to_u64());
     }
 
-    /// Processes a range [0, N] of values and increments the virtual table rows accordingly
-    pub fn inc_virtual_rows_ranged(&self, id: usize, ranged_values: &[u64]) {
-        self.virtual_table.inc_virtual_rows_ranged(id, ranged_values);
+    pub fn inc_virtual_rows_ranged<M: RCMultiplicity>(&self, id: usize, start: Option<u64>, muls: &[M]) {
+        let id = self.unwrap_virtual_table_id(id);
+        let start = start.map(|s| s.to_u64());
+        let muls: Vec<u64> = muls.iter().map(|&m| m.to_u64()).collect();
+        self.virtual_table.inc_virtual_rows_ranged(id, start, &muls);
+    }
+
+    #[inline(always)]
+    fn unwrap_virtual_table_id(&self, id: usize) -> usize {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                (id & VIRTUAL_TABLE_MARKER) != 0,
+                "Invalid virtual table ID: {}. Expected an ID from get_virtual_table_id()",
+                id & ID_MASK
+            );
+            id & ID_MASK
+        }
+
+        #[cfg(not(debug_assertions))]
+        {
+            id
+        }
     }
 }

--- a/pil2-components/lib/std/rs/src/std_virtual_table.rs
+++ b/pil2-components/lib/std/rs/src/std_virtual_table.rs
@@ -150,7 +150,8 @@ impl<F: PrimeField64> StdVirtualTable<F> {
         self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_row(uid_idx, row, multiplicity);
     }
 
-    pub fn inc_virtual_rows(&self, global_id: usize, rows: &[u64], multiplicities: &[u32]) {
+    pub fn inc_virtual_rows(&self, global_id: usize, rows: &[u64], multiplicities: &[u64]) {
+        debug_assert!(!rows.is_empty() && rows.len() == multiplicities.len());
         let (air_idx, uid_idx) = self.indices_by_global_id[global_id];
         self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows(uid_idx, rows, multiplicities);
     }
@@ -160,9 +161,15 @@ impl<F: PrimeField64> StdVirtualTable<F> {
         self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows_same_mul(uid_idx, rows, multiplicity);
     }
 
-    pub fn inc_virtual_rows_ranged(&self, global_id: usize, ranged_values: &[u64]) {
+    pub fn inc_virtual_rows_ranged(&self, global_id: usize, start: Option<u64>, multiplicities: &[u64]) {
+        // If start is None, set it to 0
+        let start = start.unwrap_or(0);
+
+        // Generate the rows
+        let rows: Vec<u64> = (0..multiplicities.len()).map(|v| (start as usize + v) as u64).collect();
+
         let (air_idx, uid_idx) = self.indices_by_global_id[global_id];
-        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows_ranged(uid_idx, ranged_values);
+        self.virtual_table_airs.as_ref().unwrap()[air_idx].inc_virtual_rows(uid_idx, &rows, multiplicities);
     }
 }
 
@@ -189,105 +196,44 @@ impl VirtualTableAir {
         }
     }
 
-    /// Processes a slice of input data and updates the multiplicity table.
+    /// Core update function: Updates multiplicities for row/multiplicity pairs
+    fn update(&self, table_offset: u64, iter: impl Iterator<Item = (u64, u64)>) {
+        if self.calculated.load(Ordering::Relaxed) {
+            return;
+        }
+
+        for (row, multiplicity) in iter {
+            if multiplicity == 0 {
+                continue;
+            }
+
+            // Get the offset
+            let offset = table_offset + row;
+
+            // Map it to the appropriate multiplicity
+            let sub_table_idx = offset >> self.shift;
+
+            // Get the row index
+            let row_idx = offset & self.mask;
+
+            // Update the multiplicity
+            self.multiplicities[sub_table_idx as usize][row_idx as usize].fetch_add(multiplicity, Ordering::Relaxed);
+        }
+    }
+
     pub fn inc_virtual_row(&self, id: usize, row: u64, multiplicity: u64) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Get the table offset
-        let table_offset = self.table_ids[id].1; // Acc height of the table
-
-        // Get the offset
-        let offset = table_offset + row;
-
-        // Map it to the appropriate multiplicity
-        let sub_table_idx = offset >> self.shift;
-
-        // Get the row index
-        let row_idx = offset & self.mask;
-
-        // Update the multiplicity
-        self.multiplicities[sub_table_idx as usize][row_idx as usize].fetch_add(multiplicity, Ordering::Relaxed);
+        let table_offset = self.table_ids[id].1;
+        self.update(table_offset, std::iter::once((row, multiplicity)));
     }
 
-    pub fn inc_virtual_rows(&self, id: usize, rows: &[u64], multiplicities: &[u32]) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Get the table offset
-        let table_offset = self.table_ids[id].1; // Acc height of the table
-
-        for (&row, &multiplicity) in rows.iter().zip(multiplicities.iter()) {
-            if multiplicity == 0 {
-                continue;
-            }
-
-            // Get the offset
-            let offset = table_offset + row;
-
-            // Map it to the appropriate multiplicity
-            let sub_table_idx = offset >> self.shift;
-
-            // Get the row index
-            let row_idx = offset & self.mask;
-
-            // Update the multiplicity
-            self.multiplicities[sub_table_idx as usize][row_idx as usize]
-                .fetch_add(multiplicity as u64, Ordering::Relaxed);
-        }
+    pub fn inc_virtual_rows(&self, id: usize, rows: &[u64], multiplicities: &[u64]) {
+        let table_offset = self.table_ids[id].1;
+        self.update(table_offset, rows.iter().copied().zip(multiplicities.iter().copied()));
     }
 
-    /// Processes a slice of input data and updates the multiplicity table.
     pub fn inc_virtual_rows_same_mul(&self, id: usize, rows: &[u64], multiplicity: u64) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Get the table offset
-        let table_offset = self.table_ids[id].1; // Acc height of the table
-
-        for row in rows.iter() {
-            // Get the offset
-            let offset = table_offset + row;
-
-            // Map it to the appropriate multiplicity
-            let sub_table_idx = offset >> self.shift;
-
-            // Get the row index
-            let row_idx = offset & self.mask;
-
-            // Update the multiplicity
-            self.multiplicities[sub_table_idx as usize][row_idx as usize].fetch_add(multiplicity, Ordering::Relaxed);
-        }
-    }
-
-    pub fn inc_virtual_rows_ranged(&self, id: usize, ranged_values: &[u64]) {
-        if self.calculated.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Get the table offset
-        let table_offset = self.table_ids[id].1; // Acc height of the table
-
-        for (row, &multiplicity) in ranged_values.iter().enumerate() {
-            if multiplicity == 0 {
-                continue;
-            }
-
-            // Get the offset
-            let offset = table_offset + row as u64;
-
-            // Map it to the appropriate multiplicity
-            let sub_table_idx = offset >> self.shift;
-
-            // Get the row index
-            let row_idx = offset & self.mask;
-
-            // Update the multiplicity
-            self.multiplicities[sub_table_idx as usize][row_idx as usize].fetch_add(multiplicity, Ordering::Relaxed);
-        }
+        let table_offset = self.table_ids[id].1;
+        self.update(table_offset, rows.iter().copied().map(|r| (r, multiplicity)));
     }
 }
 

--- a/pil2-components/test/range_check/rs/src/multi_range_check1.rs
+++ b/pil2-components/test/range_check/rs/src/multi_range_check1.rs
@@ -62,12 +62,12 @@ impl<F: PrimeField64> WitnessComponent<F> for MultiRangeCheck1<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].a[0] = F::from_u16(val);
 
-                        self.std_lib.range_check(range1, val as i64, 1);
+                        self.std_lib.range_check_one(range1, val);
                     } else {
                         let val = rng.random_range(0..=(1 << 8) - 1);
                         trace[i].a[0] = F::from_u16(val);
 
-                        self.std_lib.range_check(range2, val as i64, 1);
+                        self.std_lib.range_check_one(range2, val);
                     }
                 }
 
@@ -76,12 +76,12 @@ impl<F: PrimeField64> WitnessComponent<F> for MultiRangeCheck1<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].a[1] = F::from_u16(val);
 
-                        self.std_lib.range_check(range1, val as i64, 1);
+                        self.std_lib.range_check_one(range1, val);
                     } else {
                         let val = rng.random_range(0..=(1 << 6) - 1);
                         trace[i].a[1] = F::from_u16(val);
 
-                        self.std_lib.range_check(range3, val as i64, 1);
+                        self.std_lib.range_check_one(range3, val);
                     }
                 }
 
@@ -90,12 +90,12 @@ impl<F: PrimeField64> WitnessComponent<F> for MultiRangeCheck1<F> {
                         let val = rng.random_range((1 << 5)..=(1 << 8) - 1);
                         trace[i].a[2] = F::from_u16(val);
 
-                        self.std_lib.range_check(range4, val as i64, 1);
+                        self.std_lib.range_check_one(range4, val);
                     } else {
                         let val = rng.random_range((1 << 8)..=(1 << 9) - 1);
                         trace[i].a[2] = F::from_u16(val);
 
-                        self.std_lib.range_check(range5, val as i64, 1);
+                        self.std_lib.range_check_one(range5, val);
                     }
                 }
             }

--- a/pil2-components/test/range_check/rs/src/multi_range_check2.rs
+++ b/pil2-components/test/range_check/rs/src/multi_range_check2.rs
@@ -55,12 +55,12 @@ impl<F: PrimeField64> WitnessComponent<F> for MultiRangeCheck2<F> {
                         let val = rng.random_range((1 << 5)..=(1 << 8) - 1);
                         trace[i].a[0] = F::from_u16(val);
 
-                        self.std_lib.range_check(range1, val as i64, 1);
+                        self.std_lib.range_check_one(range1, val);
                     } else {
                         let val = rng.random_range((1 << 8)..=(1 << 9) - 1);
                         trace[i].a[0] = F::from_u16(val);
 
-                        self.std_lib.range_check(range2, val as i64, 1);
+                        self.std_lib.range_check_one(range2, val);
                     }
                 }
 
@@ -69,12 +69,12 @@ impl<F: PrimeField64> WitnessComponent<F> for MultiRangeCheck2<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].a[1] = F::from_u16(val);
 
-                        self.std_lib.range_check(range3, val as i64, 1);
+                        self.std_lib.range_check_one(range3, val);
                     } else {
                         let val = rng.random_range(0..=(1 << 4) - 1);
                         trace[i].a[1] = F::from_u16(val);
 
-                        self.std_lib.range_check(range4, val as i64, 1);
+                        self.std_lib.range_check_one(range4, val);
                     }
                 }
             }

--- a/pil2-components/test/range_check/rs/src/range_check1.rs
+++ b/pil2-components/test/range_check/rs/src/range_check1.rs
@@ -58,8 +58,8 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck1<F> {
                     trace[i].a1 = F::from_u16(val1);
                     trace[i].a3 = F::from_u32(val2);
 
-                    self.std_lib.range_check(range1, val1 as i64, 1);
-                    self.std_lib.range_check(range3, val2 as i64, 1);
+                    self.std_lib.range_check_one(range1, val1);
+                    self.std_lib.range_check_one(range3, val2);
                 }
 
                 if selected2 {
@@ -68,15 +68,15 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck1<F> {
                     trace[i].a2 = F::from_u8(val1);
                     trace[i].a4 = F::from_u16(val2);
 
-                    self.std_lib.range_check(range2, val1 as i64, 1);
-                    self.std_lib.range_check(range4, val2 as i64, 1);
+                    self.std_lib.range_check_one(range2, val1);
+                    self.std_lib.range_check_one(range4, val2);
                 }
 
                 if selected3 {
                     let val = rng.random_range(0..=(1 << 8) - 1);
                     trace[i].a5 = F::from_u16(val);
 
-                    self.std_lib.range_check(range1, val as i64, 1);
+                    self.std_lib.range_check_one(range1, val);
                 }
             }
 

--- a/pil2-components/test/range_check/rs/src/range_check2.rs
+++ b/pil2-components/test/range_check/rs/src/range_check2.rs
@@ -43,9 +43,9 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck2<F> {
                 trace[i].b2 = F::from_u16(val2);
                 trace[i].b3 = F::from_u16(val3);
 
-                self.std_lib.range_check(range1, val1 as i64, 1);
-                self.std_lib.range_check(range2, val2 as i64, 1);
-                self.std_lib.range_check(range3, val3 as i64, 1);
+                self.std_lib.range_check_one(range1, val1);
+                self.std_lib.range_check_one(range2, val2);
+                self.std_lib.range_check_one(range3, val3);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/range_check/rs/src/range_check3.rs
+++ b/pil2-components/test/range_check/rs/src/range_check3.rs
@@ -39,8 +39,8 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck3<F> {
                 trace[i].c1 = F::from_u16(val1);
                 trace[i].c2 = F::from_u16(val2);
 
-                self.std_lib.range_check(range1, val1 as i64, 1);
-                self.std_lib.range_check(range2, val2 as i64, 1);
+                self.std_lib.range_check_one(range1, val1);
+                self.std_lib.range_check_one(range2, val2);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/range_check/rs/src/range_check4.rs
+++ b/pil2-components/test/range_check/rs/src/range_check4.rs
@@ -63,9 +63,9 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck4<F> {
                         F::from_u8(val3 as u8)
                     };
 
-                    self.std_lib.range_check(range1, val1 as i64, 1);
-                    self.std_lib.range_check(range6, val2 as i64, 1);
-                    self.std_lib.range_check(range7, val3 as i64, 1);
+                    self.std_lib.range_check_one(range1, val1);
+                    self.std_lib.range_check_one(range6, val2);
+                    self.std_lib.range_check_one(range7, val3);
                 }
                 if selected2 {
                     trace[i].a5 = F::ZERO;
@@ -80,10 +80,10 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck4<F> {
                     trace[i].a3 = F::from_u16(val3);
                     trace[i].a4 = F::from_u32(val4);
 
-                    self.std_lib.range_check(range2, val1 as i64, 1);
-                    self.std_lib.range_check(range3, val2 as i64, 1);
-                    self.std_lib.range_check(range4, val3 as i64, 1);
-                    self.std_lib.range_check(range5, val4 as i64, 1);
+                    self.std_lib.range_check_one(range2, val1);
+                    self.std_lib.range_check_one(range3, val2);
+                    self.std_lib.range_check_one(range4, val3);
+                    self.std_lib.range_check_one(range5, val4);
                 }
 
                 if !selected1 && !selected2 {
@@ -97,11 +97,11 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheck4<F> {
 
                 let val7: i16 = rng.random_range(-(1 << 7) + 1..=-50);
                 trace[i].a7 = F::from_u64((val7 as i128 + F::ORDER_U64 as i128) as u64);
-                self.std_lib.range_check(range8, val7 as i64, 1);
+                self.std_lib.range_check_one(range8, val7);
 
                 let val8: i16 = rng.random_range(-(1 << 8) + 1..=-127);
                 trace[i].a8 = F::from_u64((val8 as i128 + F::ORDER_U64 as i128) as u64);
-                self.std_lib.range_check(range9, val8 as i64, 1);
+                self.std_lib.range_check_one(range9, val8);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/range_check/rs/src/range_check_dynamic1.rs
+++ b/pil2-components/test/range_check/rs/src/range_check_dynamic1.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic1<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].colu = F::from_u16(val);
 
-                        self.std_lib.range_check(range7, val as i64, 1);
+                        self.std_lib.range_check_one(range7, val);
                     }
                     1 => {
                         trace[i].sel_7 = F::ZERO;
@@ -58,7 +58,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic1<F> {
                         let val = rng.random_range(0..=(1 << 8) - 1);
                         trace[i].colu = F::from_u16(val);
 
-                        self.std_lib.range_check(range8, val as i64, 1);
+                        self.std_lib.range_check_one(range8, val);
                     }
                     2 => {
                         trace[i].sel_7 = F::ZERO;
@@ -68,7 +68,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic1<F> {
                         let val = rng.random_range(0..=(1 << 16) - 1);
                         trace[i].colu = F::from_u32(val);
 
-                        self.std_lib.range_check(range16, val as i64, 1);
+                        self.std_lib.range_check_one(range16, val);
                     }
                     3 => {
                         trace[i].sel_7 = F::ZERO;
@@ -78,7 +78,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic1<F> {
                         let val = rng.random_range(0..=(1 << 17) - 1);
                         trace[i].colu = F::from_u32(val);
 
-                        self.std_lib.range_check(range17, val as i64, 1);
+                        self.std_lib.range_check_one(range17, val);
                     }
                     _ => return Err(ProofmanError::StdError("Invalid range".to_string())),
                 }

--- a/pil2-components/test/range_check/rs/src/range_check_dynamic2.rs
+++ b/pil2-components/test/range_check/rs/src/range_check_dynamic2.rs
@@ -50,7 +50,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic2<F> {
                         let val = rng.random_range(5225..=29023);
                         trace[i].colu = F::from_u16(val);
 
-                        self.std_lib.range_check(range1, val as i64, 1);
+                        self.std_lib.range_check_one(range1, val);
                     }
                     1 => {
                         trace[i].sel_1 = F::ZERO;
@@ -61,7 +61,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic2<F> {
                         let colu_val = rng.random_range(-8719..=-7269);
                         trace[i].colu = F::from_u64((colu_val as i128 + F::ORDER_U64 as i128) as u64);
 
-                        self.std_lib.range_check(range2, colu_val as i64, 1);
+                        self.std_lib.range_check_one(range2, colu_val);
                     }
                     2 => {
                         trace[i].sel_1 = F::ZERO;
@@ -76,7 +76,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic2<F> {
                             F::from_u8(colu_val as u8)
                         };
 
-                        self.std_lib.range_check(range3, colu_val as i64, 1);
+                        self.std_lib.range_check_one(range3, colu_val);
                     }
                     3 => {
                         trace[i].sel_1 = F::ZERO;
@@ -87,7 +87,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic2<F> {
                         let val = rng.random_range(0..=(1 << 8) - 1);
                         trace[i].colu = F::from_u32(val);
 
-                        self.std_lib.range_check(range4, val as i64, 1);
+                        self.std_lib.range_check_one(range4, val);
                     }
                     4 => {
                         trace[i].sel_1 = F::ZERO;
@@ -98,7 +98,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckDynamic2<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].colu = F::from_u32(val);
 
-                        self.std_lib.range_check(range5, val as i64, 1);
+                        self.std_lib.range_check_one(range5, val);
                     }
                     _ => return Err(ProofmanError::StdError("Invalid range".to_string())),
                 }

--- a/pil2-components/test/range_check/rs/src/range_check_mix.rs
+++ b/pil2-components/test/range_check/rs/src/range_check_mix.rs
@@ -48,11 +48,11 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                 // First interface
                 let val0 = rng.random_range(0..=(1 << 8) - 1);
                 trace[i].a[0] = F::from_u16(val0);
-                self.std_lib.range_check(range1, val0 as i64, 1);
+                self.std_lib.range_check_one(range1, val0);
 
                 let val1 = rng.random_range(50..=(1 << 7) - 1);
                 trace[i].a[1] = F::from_u8(val1);
-                self.std_lib.range_check(range2, val1 as i64, 1);
+                self.std_lib.range_check_one(range2, val1);
 
                 let val2: i8 = rng.random_range(-1..=(1 << 3));
                 trace[i].a[2] = if val2 < 0 {
@@ -60,11 +60,11 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                 } else {
                     F::from_u8(val2 as u8)
                 };
-                self.std_lib.range_check(range3, val2 as i64, 1);
+                self.std_lib.range_check_one(range3, val2);
 
                 let val3: i16 = rng.random_range(-(1 << 7) + 1..=-50);
                 trace[i].a[3] = F::from_u64((val3 as i128 + F::ORDER_U64 as i128) as u64);
-                self.std_lib.range_check(range4, val3 as i64, 1);
+                self.std_lib.range_check_one(range4, val3);
 
                 // Second interface
                 let range_selector1 = rng.random_bool(0.5);
@@ -77,24 +77,24 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                     let val = rng.random_range(0..=(1 << 7) - 1);
                     trace[i].b[0] = F::from_u16(val);
 
-                    self.std_lib.range_check(range5, val as i64, 1);
+                    self.std_lib.range_check_one(range5, val);
                 } else {
                     let val = rng.random_range(0..=(1 << 4) - 1);
                     trace[i].b[0] = F::from_u16(val);
 
-                    self.std_lib.range_check(range6, val as i64, 1);
+                    self.std_lib.range_check_one(range6, val);
                 }
 
                 if range_selector2 {
                     let val = rng.random_range((1 << 5)..=(1 << 8) - 1);
                     trace[i].b[1] = F::from_u16(val);
 
-                    self.std_lib.range_check(range7, val as i64, 1);
+                    self.std_lib.range_check_one(range7, val);
                 } else {
                     let val = rng.random_range((1 << 8)..=(1 << 9) - 1);
                     trace[i].b[1] = F::from_u16(val);
 
-                    self.std_lib.range_check(range8, val as i64, 1);
+                    self.std_lib.range_check_one(range8, val);
                 }
 
                 // Third interface
@@ -108,7 +108,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                         let val = rng.random_range(5225..=29023);
                         trace[i].c[0] = F::from_u32(val);
 
-                        self.std_lib.range_check(range9, val as i64, 1);
+                        self.std_lib.range_check_one(range9, val);
                     }
                     1 => {
                         trace[i].range_sel[2] = F::ZERO;
@@ -121,7 +121,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                             F::from_u8(colu_val as u8)
                         };
 
-                        self.std_lib.range_check(range11, colu_val as i64, 1);
+                        self.std_lib.range_check_one(range11, colu_val);
                     }
                     2 => {
                         trace[i].range_sel[2] = F::ZERO;
@@ -130,7 +130,7 @@ impl<F: PrimeField64> WitnessComponent<F> for RangeCheckMix<F> {
                         let val = rng.random_range(0..=(1 << 7) - 1);
                         trace[i].c[0] = F::from_u32(val);
 
-                        self.std_lib.range_check(range5, val as i64, 1);
+                        self.std_lib.range_check_one(range5, val);
                     }
                     _ => return Err(ProofmanError::StdError("Invalid range".to_string())),
                 }

--- a/pil2-components/test/simple/rs/src/simple_left.rs
+++ b/pil2-components/test/simple/rs/src/simple_left.rs
@@ -67,66 +67,66 @@ impl<F: PrimeField64> WitnessComponent<F> for SimpleLeft<F> {
                         if i == 0 {
                             let val = 0;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 1 {
                             let val = 1 << 4;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 2 {
                             let val = (1 << 8) - 1;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         }
                     } else if j == 5 {
                         if i == 0 {
                             let val = -(1 << 7);
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 1 {
                             let val = -(1 << 2);
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 2 {
                             let val = -1;
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         }
                     } else if j == 6 {
                         if i == 0 {
                             let val = -(1 << 7) - 1;
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 1 {
                             let val = -(1 << 2);
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 2 {
                             let val = -1;
                             trace[i].k[j] = F::from_u64((val as i128 + F::ORDER_U64 as i128) as u64);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 3 {
                             let val = 0;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 4 {
                             let val = (1 << 7) - 1;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         } else if i == 5 {
                             let val = 10;
                             trace[i].k[j] = F::from_u32(val);
-                            self.std_lib.range_check(range[j], val as i64, 1);
+                            self.std_lib.range_check_one(range[j], val);
                             continue;
                         }
                     }
@@ -136,7 +136,7 @@ impl<F: PrimeField64> WitnessComponent<F> for SimpleLeft<F> {
                     } else {
                         F::from_u32(val[j] as u32)
                     };
-                    self.std_lib.range_check(range[j], val[j] as i64, 1);
+                    self.std_lib.range_check_one(range[j], val[j]);
                 }
             }
 

--- a/pil2-components/test/virtual_tables/rs/src/component1.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component1.rs
@@ -45,10 +45,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component1<F> {
                 let row = Table1::calculate_table_row(val);
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
-
-                // TODO?
-                // self.std_lib.inc_virtual_row_one(id, row);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component2.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component2.rs
@@ -60,7 +60,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component2<F> {
                 }
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component3.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component3.rs
@@ -45,7 +45,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component3<F> {
                 let row = Table3::calculate_table_row(val);
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component4.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component4.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component4<F> {
 
                 // Update the virtual table rows
                 let row = Table4::calculate_table_row(val);
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
 
                 let val1 = rng.random_range(5..=(1 << 8) - 1);
                 let val2 = rng.random_range(0..=(1 << 16) - 1);
@@ -58,9 +58,9 @@ impl<F: PrimeField64> WitnessComponent<F> for Component4<F> {
                 trace[i].b[2] = F::from_u64(val3);
 
                 // Perform the range checks
-                self.std_lib.range_check(range1, val1 as i64, 1);
-                self.std_lib.range_check(range2, val2 as i64, 1);
-                self.std_lib.range_check(range3, val3 as i64, 1);
+                self.std_lib.range_check_one(range1, val1);
+                self.std_lib.range_check_one(range2, val2);
+                self.std_lib.range_check_one(range3, val3);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component5.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component5.rs
@@ -45,7 +45,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component5<F> {
                 let row = Table5::calculate_table_row(val);
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component6.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component6.rs
@@ -45,7 +45,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component6<F> {
                 let row = Table6::calculate_table_row(val);
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/component8.rs
+++ b/pil2-components/test/virtual_tables/rs/src/component8.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField64> WitnessComponent<F> for Component8<F> {
                 let row = Table8::calculate_table_row(val1, val2, val3);
 
                 // Update the virtual table rows
-                self.std_lib.inc_virtual_row(id, row, 1);
+                self.std_lib.inc_virtual_row_one(id, row);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/virtual_tables/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/virtual_tables/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "67dd1981d5c9700396d72e676c98f3ccdfbe2687709c8bdc055fdaa5afbf8c77";
+pub const PILOUT_HASH: &str = "1596b54cb3f8fe66bb3af0058600b8f0b7b83a06448a95949a07db2f4a668e80";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -164,15 +164,15 @@ trace_row!(SpecifiedRangesTraceRow<F> {
 pub type SpecifiedRangesTrace<F> = GenericTrace<SpecifiedRangesTraceRow<F>, 64, 0, 9>;
 
 trace_row!(VirtualTableVirtualTables0FixedRow<F> {
- UID: [F; 5], column: [F; 14], __L1__: F,
+ UID: [F; 3], column: [F; 10], __L1__: F,
 });
-pub type VirtualTableVirtualTables0Fixed<F> = GenericTrace<VirtualTableVirtualTables0FixedRow<F>, 256, 0, 10>;
+pub type VirtualTableVirtualTables0Fixed<F> = GenericTrace<VirtualTableVirtualTables0FixedRow<F>, 512, 0, 10>;
 
 trace_row!(VirtualTableVirtualTables0TraceRow<F> {
- multiplicity:[F; 5],
+ multiplicity:[F; 3],
 });
 
-pub type VirtualTableVirtualTables0Trace<F> = GenericTrace<VirtualTableVirtualTables0TraceRow<F>, 256, 0, 10>;
+pub type VirtualTableVirtualTables0Trace<F> = GenericTrace<VirtualTableVirtualTables0TraceRow<F>, 512, 0, 10>;
 
 trace_row!(VirtualTableVirtualTables1FixedRow<F> {
  UID: [F; 5], column: [F; 17], __L1__: F,
@@ -186,15 +186,15 @@ trace_row!(VirtualTableVirtualTables1TraceRow<F> {
 pub type VirtualTableVirtualTables1Trace<F> = GenericTrace<VirtualTableVirtualTables1TraceRow<F>, 8192, 0, 11>;
 
 trace_row!(VirtualTableVirtualTables2FixedRow<F> {
- UID: [F; 9], column: [F; 11], __L1__: F,
+ UID: [F; 5], column: [F; 7], __L1__: F,
 });
-pub type VirtualTableVirtualTables2Fixed<F> = GenericTrace<VirtualTableVirtualTables2FixedRow<F>, 8192, 0, 12>;
+pub type VirtualTableVirtualTables2Fixed<F> = GenericTrace<VirtualTableVirtualTables2FixedRow<F>, 16384, 0, 12>;
 
 trace_row!(VirtualTableVirtualTables2TraceRow<F> {
- multiplicity:[F; 9],
+ multiplicity:[F; 5],
 });
 
-pub type VirtualTableVirtualTables2Trace<F> = GenericTrace<VirtualTableVirtualTables2TraceRow<F>, 8192, 0, 12>;
+pub type VirtualTableVirtualTables2Trace<F> = GenericTrace<VirtualTableVirtualTables2TraceRow<F>, 16384, 0, 12>;
 
 values!(Component1AirGroupValues<F> {
  gsum_result: FieldExtension<F>,


### PR DESCRIPTION
> Supersedes #394.

The range check API was refactored as follows:
```rust
    // ==================== Range Check API ====================

    /// Gets the range id for a given range subject to the range check
    pub fn get_range_id<V: RCValue>(&self, min: V, max: V, predefined: Option<bool>) -> ProofmanResult<usize>

    /// Increments the multiplicity `mul` of a given value `val` in the range check with id `id`
    pub fn range_check<V: RCValue, M: RCMultiplicity>(&self, id: usize, val: V, mul: M)

    /// Increments the multiplicity of a given value `val` by 1
    pub fn range_check_one<V: RCValue>(&self, id: usize, val: V)

    /// Increments the multiplicities for multiple value/multiplicity pairs in the range check with id `id`
    pub fn range_check_batch<V: RCValue, M: RCMultiplicity>(&self, id: usize, vals: &[V], muls: &[M])

    /// Increments the multiplicity by 1 for each value in `vals`
    pub fn range_check_batch_one<V: RCValue>(&self, id: usize, vals: &[V])

    /// Increments the multiplicities for multiple values with the same multiplicity in the range check with id `id`
    pub fn range_checks_same_mul<V: RCValue, M: RCMultiplicity>(&self, id: usize, vals: &[V], mul: M)

    /// Increments the multiplicities of a list of values `[start, start + N]` in the range check with id `id`.
    /// If `start` is `None`, then it is set to be the minimum of the range
    pub fn range_check_ranged<M: RCMultiplicity>(&self, id: usize, start: Option<i64>, muls: &[M])

    // ==================== Virtual Table API ====================

    /// Gets the virtual table ID for a given ID
    pub fn get_virtual_table_id(&self, id: usize) -> ProofmanResult<usize>

    /// Increments the multiplicity `mul` of a given row `row` in the virtual table with id `id`
    pub fn inc_virtual_row<M: RCMultiplicity>(&self, id: usize, row: M, mul: M)

    /// Increments the multiplicity of a given row `row` by 1
    pub fn inc_virtual_row_one<M: RCMultiplicity>(&self, id: usize, row: M)

    /// Increments the multiplicities for multiple row/multiplicity pairs in the virtual table with id `id`
    pub fn inc_virtual_row_batch<M: RCMultiplicity>(&self, id: usize, rows: &[M], muls: &[M])

    /// Increments the multiplicity by 1 for each row in `rows`
    pub fn inc_virtual_row_batch_one<M: RCMultiplicity>(&self, id: usize, rows: &[M])

    /// Increments the multiplicities for multiple rows with the same multiplicity in the virtual table with id `id`
    pub fn inc_virtual_rows_same_mul<M: RCMultiplicity>(&self, id: usize, rows: &[M], mul: M)

    /// Increments the multiplicities of a list of rows `[start, start + N]` in the virtual table with id `id`.
    /// If `start` is `None`, then it is set to be 0
    pub fn inc_virtual_rows_ranged<M: RCMultiplicity>(&self, id: usize, start: Option<u64>, muls: &[M])
```