### PR TITLE
fix(pil2-components): debug-mode bus checking for free PIOPs

### DIFF
--- a/pil2-components/lib/std/rs/src/common.rs
+++ b/pil2-components/lib/std/rs/src/common.rs
@@ -10,6 +10,19 @@ use proofman_hints::{
 pub const STD_MODE_DEFAULT: usize = 0;
 pub const STD_MODE_ONE_INSTANCE: usize = 1;
 
+/// PIOP types on the sum/product bus. They must concide with their value in `std_sum.pil`.
+pub const PIOP_TYPE_ASSUMES: u64 = 0;
+pub const PIOP_TYPE_PROVES: u64 = 1;
+pub const PIOP_TYPE_FREE: u64 = 2;
+
+/// Largest field value treated as a positive (prove) multiplicity under the canonical-half sign
+/// convention used for free PIOPs: values in `[1, (p-1)/2]` are positive, while values strictly
+/// greater (the upper half of the field) are interpreted as negative (assume) counts.
+#[inline]
+pub fn max_positive_multiplicity<F: PrimeField64>() -> u64 {
+    (F::ORDER_U64 - 1) / 2
+}
+
 pub trait AirComponent<F: PrimeField64> {
     fn new(
         pctx: &ProofCtx<F>,

--- a/pil2-components/lib/std/rs/src/debug.rs
+++ b/pil2-components/lib/std/rs/src/debug.rs
@@ -11,7 +11,7 @@ use proofman_common::SetupCtx;
 
 use colored::Colorize;
 use fields::PrimeField64;
-use proofman_common::{ProofCtx, ProofmanError, ProofmanResult};
+use proofman_common::{ProofCtx, ProofmanResult};
 use proofman_hints::{
     get_hint_ids_by_name, format_hint_field_output_vec, HintFieldOutput, HintFieldValue, HintFieldValuesVec,
     HintFieldOptions,
@@ -148,13 +148,9 @@ pub fn update_global_debug_data<F: PrimeField64>(
     if is_proves {
         bus_val.shared_data.num_proves += times;
     } else {
-        if times != 1 {
-            return Err(ProofmanError::StdError(format!(
-                "The selector value is invalid: expected 1, but received {times:?}."
-            )));
-        }
         bus_val.shared_data.num_assumes += times;
     }
+
     Ok(())
 }
 

--- a/pil2-components/lib/std/rs/src/debug_common.rs
+++ b/pil2-components/lib/std/rs/src/debug_common.rs
@@ -14,8 +14,9 @@ use proofman_hints::{
 use crate::{
     check_invalid_opids, get_global_hint_field, get_global_hint_field_constant_as, get_hint_field_constant_as,
     get_hint_field_constant_as_string, get_hint_field_constant_a_as_string, get_hint_field_constant_as_field,
-    get_row_field_value, print_debug_info, update_debug_data, update_debug_data_fast, DebugData, DebugDataFast,
-    DebugDataFastGlobal, DebugDataInfo, HintMetadata, hash_vals, normalize_vals,
+    get_row_field_value, max_positive_multiplicity, print_debug_info, update_debug_data, update_debug_data_fast,
+    DebugData, DebugDataFast, DebugDataFastGlobal, DebugDataInfo, HintMetadata, hash_vals, normalize_vals,
+    PIOP_TYPE_ASSUMES, PIOP_TYPE_FREE, PIOP_TYPE_PROVES,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -39,7 +40,7 @@ pub fn extract_global_hint_fields<F: PrimeField64>(
             let airgroup_id =
                 get_global_hint_field_constant_as::<usize, F>(sctx, debug_data_hints[1 + i], "airgroup_id")?;
             let type_piop = get_global_hint_field_constant_as::<u64, F>(sctx, debug_data_hints[1 + i], "type_piop")?;
-            if ![0, 1, 2].contains(&type_piop) {
+            if ![PIOP_TYPE_ASSUMES, PIOP_TYPE_PROVES, PIOP_TYPE_FREE].contains(&type_piop) {
                 return Err(ProofmanError::StdError(format!("Invalid type_piop: {type_piop}")));
             }
 
@@ -61,19 +62,22 @@ pub fn extract_global_hint_fields<F: PrimeField64>(
                 continue;
             }
 
-            // If the type_piop is free and the num_reps is minus_one, simply flip the num_reps
-            if type_piop == 2 {
-                if num_reps == F::NEG_ONE {
-                    num_reps = -num_reps;
-                } else if num_reps != F::ONE {
-                    return Err(ProofmanError::StdError(format!(
-                        "The number of repetitions in a free piop can only be {{-1, 0, 1}}, received: {num_reps}"
-                    )));
+            // Determine whether this is a prove or an assume
+            let is_proves = match type_piop {
+                PIOP_TYPE_ASSUMES => false,
+                PIOP_TYPE_PROVES => true,
+                PIOP_TYPE_FREE => {
+                    if num_reps.as_canonical_u64() > max_positive_multiplicity::<F>() {
+                        num_reps = -num_reps;
+                        false
+                    } else {
+                        true
+                    }
                 }
-            }
+                _ => unreachable!(),
+            };
 
             let expressions = get_hint_field_gc_a(pctx, sctx, debug_data_hints[1 + i], "expressions", false)?;
-            let is_proves = type_piop == 1;
             let expr = expressions.get(0);
             let norm_vals = normalize_vals(&expr);
             let hash = hash_vals(norm_vals);
@@ -152,7 +156,7 @@ pub fn extract_hint_fields<F: PrimeField64>(
                 "type_piop",
                 HintFieldOptions::default(),
             )?;
-            if ![0, 1, 2].contains(&type_piop) {
+            if ![PIOP_TYPE_ASSUMES, PIOP_TYPE_PROVES, PIOP_TYPE_FREE].contains(&type_piop) {
                 return Err(ProofmanError::StdError(format!("Invalid type_piop: {type_piop}")));
             }
 
@@ -353,20 +357,16 @@ pub fn update_bus<F: PrimeField64>(
         return Ok(());
     }
 
+    // Determine whether this is a prove or an assume
     let is_proves = match type_piop {
-        0 => false,
-        1 => true,
-        2 => {
-            if num_reps == F::NEG_ONE {
-                // If the type is free and the num_reps is minus_one, simply flip the num_reps
+        PIOP_TYPE_ASSUMES => false,
+        PIOP_TYPE_PROVES => true,
+        PIOP_TYPE_FREE => {
+            if num_reps.as_canonical_u64() > max_positive_multiplicity::<F>() {
                 num_reps = -num_reps;
                 false
-            } else if num_reps == F::ONE {
-                true
             } else {
-                return Err(ProofmanError::StdError(format!(
-                    "The number of repetitions in a free piop can only be {{-1, 0, 1}}, received: {num_reps}"
-                )));
+                true
             }
         }
         _ => unreachable!(),
@@ -418,20 +418,16 @@ fn update_bus_fast<F: PrimeField64>(
         return Ok(());
     }
 
+    // Determine whether this is a prove or an assume
     let is_proves = match type_piop {
-        0 => false,
-        1 => true,
-        2 => {
-            if num_reps == F::NEG_ONE {
-                // If the type is free and the num_reps is minus_one, simply flip the num_reps
+        PIOP_TYPE_ASSUMES => false,
+        PIOP_TYPE_PROVES => true,
+        PIOP_TYPE_FREE => {
+            if num_reps.as_canonical_u64() > max_positive_multiplicity::<F>() {
                 num_reps = -num_reps;
                 false
-            } else if num_reps == F::ONE {
-                true
             } else {
-                return Err(ProofmanError::StdError(format!(
-                    "The number of repetitions in a free piop can only be {{-1, 0, 1}}, received: {num_reps}"
-                )));
+                true
             }
         }
         _ => unreachable!(),

--- a/pil2-components/lib/std/rs/src/std_prod.rs
+++ b/pil2-components/lib/std/rs/src/std_prod.rs
@@ -104,17 +104,12 @@ impl<F: PrimeField64> WitnessComponent<F> for StdProd<F> {
                         continue;
                     }
 
-                    // Get the air associated with the air_instance
-                    let air_name = &pctx.global_info.airs[airgroup_id][air_id].name;
-
                     let setup = sctx.get_setup(airgroup_id, air_id)?;
                     let p_expressions_bin = setup.p_setup.p_expressions_bin;
 
                     let im_hints = get_hint_ids_by_name(p_expressions_bin, "im_col");
-                    let gprod_hints = get_hint_ids_by_name(p_expressions_bin, "gprod_col");
 
                     let n_im_hints = im_hints.len();
-
                     if !im_hints.is_empty() {
                         mul_hint_fields(
                             &sctx,
@@ -130,13 +125,23 @@ impl<F: PrimeField64> WitnessComponent<F> for StdProd<F> {
                         )?;
                     }
 
-                    // We know that at most one product hint exists
-                    let gprod_hint = if gprod_hints.len() > 1 {
-                        return Err(ProofmanError::StdError(format!(
-                            "Multiple gprod hints found for AIR '{air_name}'"
-                        )));
-                    } else {
-                        gprod_hints[0] as usize
+                    // We know that exactly one gprod hint must exist
+                    let air_name = &pctx.global_info.airs[airgroup_id][air_id].name;
+                    let gprod_hints = get_hint_ids_by_name(p_expressions_bin, "gprod_col");
+
+                    let gprod_hint = match gprod_hints.as_slice() {
+                        [] => {
+                            return Err(ProofmanError::StdError(format!(
+                                "No 'gprod_col' hint found for air: {}",
+                                air_name
+                            )))
+                        }
+                        [single] => *single as usize,
+                        _ => {
+                            return Err(ProofmanError::StdError(format!(
+                                "Multiple gprod hints found for AIR '{air_name}'"
+                            )))
+                        }
                     };
 
                     let std_mode = self.std_mode[i];

--- a/pil2-components/test/common/rs/src/lib.rs
+++ b/pil2-components/test/common/rs/src/lib.rs
@@ -64,7 +64,8 @@ pub fn setup(pilout: &Path, build: &Path) -> Result<(), String> {
 /// Call from that test crate's own `tests/*.rs` so it runs in its own process (see the
 /// module docs on the MPI single-init constraint).
 pub fn run_pipeline(dir: &str, pil_file: &str, lib: &str) -> Result<(), String> {
-    let build = std::env::current_dir().map_err(|e| format!("current_dir: {e}"))?.join("build");
+    // Generate the build folder alongside the test's `rs` crate (i.e. `test/<dir>/build`)
+    let build = PathBuf::from(format!("{TESTS_DIR}/{dir}/build"));
 
     let pilout = compile(&format!("{TESTS_DIR}/{dir}/{pil_file}"), &build)?;
     setup(&pilout, &build)?;

--- a/pil2-components/test/simple/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/simple/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "45d74cb13ee8d8cae427b5647e161724e307eca3b1ce5b31a05631ed873466ce";
+pub const PILOUT_HASH: &str = "1e57cceb4ec0c187d7180bcbadaed82f7e75080933a2a76ff18577909069c5f9";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -43,7 +43,7 @@ trace_row!(SimpleLeftFixedRow<F> {
 pub type SimpleLeftFixed<F> = GenericTrace<SimpleLeftFixedRow<F>, 8, 0, 0>;
 
 trace_row!(SimpleLeftTraceRow<F> {
- a:F, b:F, c:F, d:F, e:F, f:F, g:F, h:F, k:[F; 7],
+ a:F, b:F, c:F, d:F, e:F, f:F, g:F, h:F, mul:F, k:[F; 7],
 });
 
 pub type SimpleLeftTrace<F> = GenericTrace<SimpleLeftTraceRow<F>, 8, 0, 0>;

--- a/pil2-components/test/simple/rs/src/simple_left.rs
+++ b/pil2-components/test/simple/rs/src/simple_left.rs
@@ -51,6 +51,8 @@ impl<F: PrimeField64> WitnessComponent<F> for SimpleLeft<F> {
                 trace[i].g = F::from_usize(i);
                 trace[i].h = F::from_usize(num_rows - i - 1);
 
+                trace[i].mul = F::from_isize(-(i as isize));
+
                 let val = [
                     rng.random_range(0..=(1 << 8) - 1),
                     rng.random_range(0..=(1 << 16) - 1),

--- a/pil2-components/test/simple/rs/src/simple_right.rs
+++ b/pil2-components/test/simple/rs/src/simple_right.rs
@@ -35,7 +35,7 @@ impl<F: PrimeField64> WitnessComponent<F> for SimpleRight {
                 trace[i].c = F::from_usize(i);
                 trace[i].d = F::from_usize(num_rows - i - 1);
 
-                trace[i].mul = F::from_usize(1);
+                trace[i].mul = F::from_usize(i);
             }
 
             let air_instance = AirInstance::new_from_trace(FromTrace::new(&mut trace));

--- a/pil2-components/test/simple/simple.pil
+++ b/pil2-components/test/simple/simple.pil
@@ -16,7 +16,8 @@ airtemplate SimpleLeft(const int N = 2**3) {
 
     permutation_assumes(2, [e, f]);
 
-    lookup(3, [g, h], mul: -1);
+    col witness mul;
+    lookup(3, [g, h], mul);
 
     col witness k[7];
     range_check(k[0], 0, 2**8-1, predefined: 1);


### PR DESCRIPTION
### Summary
Follow-up to the selector-control work (#495). The debug-mode bus-balance checker mis-handled **free** PIOPs whose multiplicity isn't `±1` (notably free lookups), and the prod witness component could panic when a `gprod` hint was missing. This PR makes the free-multiplicity handling correct and consistent across all code paths, replaces magic numbers with named constants, fixes the panic, and moves per-test build output beside the `rs/` crate instead of inside it.

### Motivation
A free PIOP encodes its role in the **sign** of its multiplicity (`mul`/`sel`): negative ⇒ assume, positive ⇒ prove. Field elements have no intrinsic sign, so this must be read via the canonical-half convention (upper half of the field ⇒ negative). The debug code had drifted to a strict `{-1, 0, 1}` interpretation, which is only valid for free *permutations* and wrongly rejected free *lookups* with arbitrary integer multiplicities. On top of that, the global/direct path computed `is_proves` incorrectly (a free prove was counted as an assume) and hard-rejected assume multiplicities `!= 1`.