### PR TITLE
Add stream scheduler for recursive proving

### DIFF
--- a/cli/src/commands/prove_recursive.rs
+++ b/cli/src/commands/prove_recursive.rs
@@ -301,6 +301,7 @@ impl ProveRecursiveCmd {
             proof_type_str,
             false,
             "",
+            u64::MAX, // one-off launch: reserve stream internally
         );
 
         // The recursive prover writes its output asynchronously; the result is only in

--- a/cli/src/commands/prove_recursive.rs
+++ b/cli/src/commands/prove_recursive.rs
@@ -203,7 +203,7 @@ impl ProveRecursiveCmd {
         // buffer under the same proofType gen_recursive_proof_c uses. Mirrors
         // proofman::utils::load_device_setups / load_device_const_pols (the aggregation
         // branch), but for the single AIR we are proving.
-        let proof_type_str: &str = (*proof_type).clone().into();
+        let proof_type_str: &str = (*proof_type).into();
         let d_buffers = pctx.get_device_buffers_ptr();
         load_device_setup_c(
             airgroup_id as u64,

--- a/common/src/distribution_ctx.rs
+++ b/common/src/distribution_ctx.rs
@@ -17,11 +17,33 @@ pub struct InstanceInfo {
     pub shared: bool,
     pub n_chunks: usize,
     pub weight: u64,
+    pub compressor_weight: u64, // Cost of the compressor proof it triggers, 0 if the air has none
 }
 
 impl InstanceInfo {
-    pub fn new(airgroup_id: usize, air_id: usize, table: bool, shared: bool, weight: u64) -> Self {
-        Self { airgroup_id, air_id, table, shared, n_chunks: 0, weight }
+    pub fn new(
+        airgroup_id: usize,
+        air_id: usize,
+        table: bool,
+        shared: bool,
+        weight: u64,
+        compressor_weight: u64,
+    ) -> Self {
+        Self { airgroup_id, air_id, table, shared, n_chunks: 0, weight, compressor_weight }
+    }
+
+    /// Total cost this instance puts on its owner: its basic proof plus its compressor proof
+    #[inline]
+    pub fn total_weight(&self) -> u64 {
+        self.weight + self.compressor_weight
+    }
+
+    /// Whether this instance triggers a compressor proof, i.e. its air has a compressor and the
+    /// compressor setups are loaded (they are not without aggregation, and then there is nothing
+    /// to spread across partitions either)
+    #[inline]
+    pub fn has_compressor(&self) -> bool {
+        self.compressor_weight > 0
     }
 }
 
@@ -55,7 +77,7 @@ pub struct DistributionCtx {
     pub instance_partition: Vec<i32>, // Which partition each instance belongs to (>=0 assigned, -1 unassigned, -2 appended table)
     pub worker_instances: Vec<usize>, // Indexes of instances assigned to this worker
     pub partition_count: Vec<u32>,    // #instances in each partition (does not include tables)
-    pub partition_weight: Vec<u64>,   // Total computational weight per partition (does not include tables)
+    pub partition_weight: Vec<u64>,   // Weight per partition, basic + compressor (does not include tables)
     pub partition_compressor_count: Vec<u32>, // #compressor instances assigned to each partition
 
     // Process-level distribution
@@ -63,7 +85,7 @@ pub struct DistributionCtx {
     pub process_instances: Vec<usize>,       // Indexes of instances assigned to current process
     pub skipped_process_instances: Vec<usize>, // Indexes of instances assigned to current process but skipped for some reason
     pub process_count: Vec<usize>,             // #instances assigned to each process
-    pub process_weight: Vec<u64>,              // Total computational weight per process
+    pub process_weight: Vec<u64>,              // Weight per process, basic + compressor
     pub process_compressor_count: Vec<u32>,    // #compressor instances assigned to each process
 
     pub worker_index: i32, // Index of the current worker
@@ -480,7 +502,42 @@ impl DistributionCtx {
         None
     }
 
-    /// add an instance and assign it to a partition/process based only in the gid
+    /// Partition with the least accumulated cost, ties broken by #compressor instances (to spread
+    /// the recursive pipeline) and then by #instances. Cost must stay the primary criterion: the
+    /// compressor airs are also the heaviest ones, so ordering by compressor count first trades a
+    /// heavy compressor air (Keccakf) for a light one (Sha256f) as if they cost the same.
+    #[inline]
+    fn least_loaded_partition(&self, has_compressor: bool) -> usize {
+        let mut best_idx = 0;
+        let mut best_key = (u64::MAX, u32::MAX, u32::MAX);
+        for (i, &weight) in self.partition_weight.iter().enumerate() {
+            let compressors = if has_compressor { self.partition_compressor_count[i] } else { 0 };
+            let key = (weight, compressors, self.partition_count[i]);
+            if key < best_key {
+                best_key = key;
+                best_idx = i;
+            }
+        }
+        best_idx
+    }
+
+    /// Same criterion as `least_loaded_partition`, over the processes of this worker
+    #[inline]
+    fn least_loaded_process(&self, has_compressor: bool, counts: &[usize]) -> usize {
+        let mut best_idx = 0;
+        let mut best_key = (u64::MAX, u32::MAX, usize::MAX);
+        for (i, &weight) in self.process_weight.iter().enumerate() {
+            let compressors = if has_compressor { self.process_compressor_count[i] } else { 0 };
+            let key = (weight, compressors, counts[i]);
+            if key < best_key {
+                best_key = key;
+                best_idx = i;
+            }
+        }
+        best_idx
+    }
+
+    /// add an instance and assign it immediately to the least loaded partition/process
     /// the instance added is not a table
     #[inline]
     pub fn add_instance(
@@ -488,34 +545,38 @@ impl DistributionCtx {
         airgroup_id: usize,
         air_id: usize,
         weight: u64,
-        has_compressor: bool,
+        compressor_weight: u64,
     ) -> ProofmanResult<usize> {
         if self.assignation_done {
             return Err(ProofmanError::InvalidAssignation("Instances already assigned".to_string()));
         }
         self.validate_static_config().expect("Static configuration invalid or incomplete");
         let gid: usize = self.instances.len();
-        self.instances.push(InstanceInfo::new(airgroup_id, air_id, false, false, weight));
+        let instance = InstanceInfo::new(airgroup_id, air_id, false, false, weight, compressor_weight);
+        let (total_weight, has_compressor) = (instance.total_weight(), instance.has_compressor());
+        self.instances.push(instance);
         self.instances_chunks.push(InstanceChunks { chunks: vec![], slow: false });
         self.instances_calculated.push(AtomicBool::new(false));
         self.n_instances += 1;
-        let partition_id = (gid % self.n_partitions) as u32;
+        // Placed as created, without knowing the instances still to come: greedy least loaded.
+        // Round-robin on the gid handed out the heaviest airs (Main, Keccakf) blindly, leaving
+        // only the instances of assign_instances() to compensate for it.
+        let partition_id = self.least_loaded_partition(has_compressor) as u32;
         self.instance_partition.push(partition_id as i32);
         self.partition_count[partition_id as usize] += 1;
-        self.partition_weight[partition_id as usize] += weight;
+        self.partition_weight[partition_id as usize] += total_weight;
         if has_compressor {
             self.partition_compressor_count[partition_id as usize] += 1;
         }
         let mut local_idx = 0;
         let mut owner = -1;
         if self.partition_mask[partition_id as usize] {
-            let worker_instance_id = self.worker_instances.len();
             self.worker_instances.push(gid);
-            let process_id = worker_instance_id % self.n_processes;
+            let process_id = self.least_loaded_process(has_compressor, &self.process_count);
             owner = process_id as i32;
             local_idx = self.process_count[process_id];
             self.process_count[process_id] += 1;
-            self.process_weight[process_id] += weight;
+            self.process_weight[process_id] += total_weight;
             if has_compressor {
                 self.process_compressor_count[process_id] += 1;
             }
@@ -535,12 +596,18 @@ impl DistributionCtx {
     /// It will be assigned later by assign_instances()
     /// the instance added is not a table
     #[inline]
-    pub fn add_instance_no_assign(&mut self, airgroup_id: usize, air_id: usize, weight: u64) -> ProofmanResult<usize> {
+    pub fn add_instance_no_assign(
+        &mut self,
+        airgroup_id: usize,
+        air_id: usize,
+        weight: u64,
+        compressor_weight: u64,
+    ) -> ProofmanResult<usize> {
         if self.assignation_done {
             return Err(ProofmanError::InvalidAssignation("Instances already assigned".to_string()));
         }
         self.validate_static_config().expect("Static configuration invalid or incomplete");
-        self.instances.push(InstanceInfo::new(airgroup_id, air_id, false, false, weight));
+        self.instances.push(InstanceInfo::new(airgroup_id, air_id, false, false, weight, compressor_weight));
         self.instances_chunks.push(InstanceChunks { chunks: vec![], slow: false });
         self.instances_calculated.push(AtomicBool::new(false));
         self.instance_partition.push(-1);
@@ -556,7 +623,7 @@ impl DistributionCtx {
         }
         self.validate_static_config().expect("Static configuration invalid or incomplete");
         let lid = self.aux_tables.len();
-        self.aux_tables.push(InstanceInfo::new(airgroup_id, air_id, true, true, weight));
+        self.aux_tables.push(InstanceInfo::new(airgroup_id, air_id, true, true, weight, 0));
         self.aux_table_map.push(-1);
         self.n_tables += 1;
         Ok(lid)
@@ -574,14 +641,14 @@ impl DistributionCtx {
         }
         self.validate_static_config().expect("Static configuration invalid or incomplete");
         let lid = self.aux_tables.len();
-        self.aux_tables.push(InstanceInfo::new(airgroup_id, air_id, true, false, weight));
+        self.aux_tables.push(InstanceInfo::new(airgroup_id, air_id, true, false, weight, 0));
         self.aux_table_map.push(-1);
         self.n_tables += 1;
         Ok(lid)
     }
 
     /// Assign instances to partitions and processes
-    pub fn assign_instances(&mut self, compressor_airs: &HashSet<(usize, usize)>) -> ProofmanResult<()> {
+    pub fn assign_instances(&mut self) -> ProofmanResult<()> {
         if self.assignation_done {
             return Err(ProofmanError::InvalidAssignation("Instances already assigned".to_string()));
         }
@@ -592,7 +659,7 @@ impl DistributionCtx {
         let mut unassigned_instances = Vec::new();
         for (gid, &partition_id) in self.instance_partition.iter().enumerate() {
             if partition_id == -1 {
-                unassigned_instances.push((gid, self.instances[gid].weight));
+                unassigned_instances.push((gid, self.instances[gid].total_weight()));
             }
         }
 
@@ -608,79 +675,26 @@ impl DistributionCtx {
         let mut local_process_count = self.process_count.clone();
         for (gid, _) in &unassigned_instances {
             let (airgroup_id, air_id) = self.get_instance_info(*gid)?;
-            let has_compressor = compressor_airs.contains(&(airgroup_id, air_id));
+            let has_compressor = self.instances[*gid].has_compressor();
 
-            // Select target partition: compressor-count-first for compressor airs, weight-first otherwise
-            let mut min_weight_idx = 0;
+            // Select target partition: least loaded first (see least_loaded_partition)
+            let min_weight_idx = self.least_loaded_partition(has_compressor);
             if has_compressor {
-                let mut min_compressors = u32::MAX;
-                let mut min_weight = u64::MAX;
-                for (i, &weight) in self.partition_weight.iter().enumerate() {
-                    let compressors = self.partition_compressor_count[i];
-                    if compressors < min_compressors
-                        || (compressors == min_compressors && weight < min_weight)
-                        || (compressors == min_compressors
-                            && weight == min_weight
-                            && self.partition_count[i] < self.partition_count[min_weight_idx])
-                    {
-                        min_compressors = compressors;
-                        min_weight = weight;
-                        min_weight_idx = i;
-                    }
-                }
                 self.partition_compressor_count[min_weight_idx] += 1;
-            } else {
-                let mut min_weight = u64::MAX;
-                for (i, &weight) in self.partition_weight.iter().enumerate() {
-                    if weight < min_weight {
-                        min_weight = weight;
-                        min_weight_idx = i;
-                    } else if (min_weight == weight) && (self.partition_count[i] < self.partition_count[min_weight_idx])
-                    {
-                        min_weight_idx = i;
-                    }
-                }
             }
 
             *instances_assigned_partition[min_weight_idx].entry((airgroup_id, air_id)).or_insert(0) += 1;
             self.partition_count[min_weight_idx] += 1;
-            self.partition_weight[min_weight_idx] += self.instances[*gid].weight;
+            self.partition_weight[min_weight_idx] += self.instances[*gid].total_weight();
             if self.partition_mask[min_weight_idx] {
-                // Select target process: compressor-count-first for compressor airs, weight-first otherwise
-                let mut min_weight_process_idx = 0;
+                // Select target process with the same criterion as the partition above
+                let min_weight_process_idx = self.least_loaded_process(has_compressor, &local_process_count);
                 if has_compressor {
-                    let mut min_compressors = u32::MAX;
-                    let mut min_weight = u64::MAX;
-                    for (i, &weight) in self.process_weight.iter().enumerate() {
-                        let compressors = self.process_compressor_count[i];
-                        if compressors < min_compressors
-                            || (compressors == min_compressors && weight < min_weight)
-                            || (compressors == min_compressors
-                                && weight == min_weight
-                                && local_process_count[i] < local_process_count[min_weight_process_idx])
-                        {
-                            min_compressors = compressors;
-                            min_weight = weight;
-                            min_weight_process_idx = i;
-                        }
-                    }
                     self.process_compressor_count[min_weight_process_idx] += 1;
-                } else {
-                    let mut min_weight = u64::MAX;
-                    for (i, &weight) in self.process_weight.iter().enumerate() {
-                        if weight < min_weight {
-                            min_weight = weight;
-                            min_weight_process_idx = i;
-                        } else if (min_weight == weight)
-                            && (local_process_count[i] < local_process_count[min_weight_process_idx])
-                        {
-                            min_weight_process_idx = i;
-                        }
-                    }
                 }
 
                 local_process_count[min_weight_process_idx] += 1;
-                self.process_weight[min_weight_process_idx] += self.instances[*gid].weight;
+                self.process_weight[min_weight_process_idx] += self.instances[*gid].total_weight();
                 instances_assigned_process[min_weight_process_idx]
                     .entry((airgroup_id, air_id))
                     .and_modify(|c| *c += 1)
@@ -763,16 +777,7 @@ impl DistributionCtx {
         self.n_tables = 0;
         for (table_idx, table) in self.aux_tables.iter().enumerate() {
             if table.shared {
-                let mut min_weight = u64::MAX;
-                let mut process_id = 0;
-                for (i, &weight) in self.process_weight.iter().enumerate() {
-                    if weight < min_weight {
-                        min_weight = weight;
-                        process_id = i;
-                    } else if (min_weight == weight) && (self.process_count[i] < self.process_count[process_id]) {
-                        process_id = i;
-                    }
-                }
+                let process_id = self.least_loaded_process(false, &self.process_count);
                 let gid = self.instances.len();
                 self.instances.push(*table);
                 self.instances_calculated.push(AtomicBool::new(false));
@@ -792,7 +797,14 @@ impl DistributionCtx {
             } else {
                 for rank in 0..self.n_processes {
                     let gid = self.instances.len();
-                    self.instances.push(InstanceInfo::new(table.airgroup_id, table.air_id, true, false, table.weight));
+                    self.instances.push(InstanceInfo::new(
+                        table.airgroup_id,
+                        table.air_id,
+                        true,
+                        false,
+                        table.weight,
+                        0,
+                    ));
                     self.instances_chunks.push(InstanceChunks { chunks: vec![], slow: false });
                     self.n_instances += 1;
                     self.n_tables += 1;
@@ -853,5 +865,72 @@ impl DistributionCtx {
         average_process_weight /= self.n_processes as f64;
         let max_deviation = max_process_weight as f64 / average_process_weight;
         (average_process_weight, max_process_weight, min_process_weight, max_deviation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DistributionCtx;
+
+    // A compressor air (weight 1000 + compressor 100) and a heavier plain one (5000)
+    const HEAVY_PLAIN: (usize, u64, u64) = (0, 5000, 0);
+    const COMPRESSOR: (usize, u64, u64) = (1, 1000, 100);
+    const LIGHT_PLAIN: (usize, u64, u64) = (2, 100, 0);
+
+    fn ctx(n_partitions: usize) -> DistributionCtx {
+        let mut dctx = DistributionCtx::new();
+        dctx.setup_processes(1, 0).unwrap();
+        dctx.setup_partitions(n_partitions, (0..n_partitions as u32).collect()).unwrap();
+        dctx
+    }
+
+    /// A compressor air must not be handed to an overloaded partition just because that partition
+    /// owns fewer compressor instances: with compressor count as the primary criterion the second
+    /// COMPRESSOR lands on partition 0 (6100 vs 1100) instead of partition 1 (5000 vs 2200).
+    #[test]
+    fn compressor_air_follows_cost_not_compressor_count() {
+        let mut dctx = ctx(2);
+        for (air_id, weight, compressor_weight) in [HEAVY_PLAIN, COMPRESSOR, COMPRESSOR] {
+            dctx.add_instance_no_assign(0, air_id, weight, compressor_weight).unwrap();
+        }
+        dctx.assign_instances().unwrap();
+
+        assert_eq!(dctx.instance_partition, vec![0, 1, 1]);
+        assert_eq!(dctx.partition_weight, vec![5000, 2200]);
+        assert_eq!(dctx.partition_compressor_count, vec![0, 2]);
+    }
+
+    /// Instances assigned as they are created go to the least loaded partition, not to `gid %
+    /// n_partitions`: round-robin would put the second LIGHT_PLAIN back on the heavy partition 0.
+    #[test]
+    fn immediate_assignation_balances_cost_instead_of_round_robin() {
+        let mut dctx = ctx(2);
+        for (air_id, weight, compressor_weight) in [HEAVY_PLAIN, LIGHT_PLAIN, LIGHT_PLAIN] {
+            dctx.add_instance(0, air_id, weight, compressor_weight).unwrap();
+        }
+
+        assert_eq!(dctx.instance_partition, vec![0, 1, 1]);
+        assert_eq!(dctx.partition_weight, vec![5000, 200]);
+    }
+
+    /// The first instance added still lands on partition 0 (zisk relies on it for the Rom instance)
+    #[test]
+    fn first_instance_goes_to_partition_zero() {
+        let mut dctx = ctx(4);
+        dctx.add_instance(0, LIGHT_PLAIN.0, LIGHT_PLAIN.1, LIGHT_PLAIN.2).unwrap();
+
+        assert_eq!(dctx.instance_partition[0], 0);
+        assert_eq!(dctx.instance_process[0], (0, 0));
+    }
+
+    /// The compressor proof is part of the load a partition is given
+    #[test]
+    fn compressor_weight_counts_towards_the_partition_load() {
+        let mut dctx = ctx(1);
+        dctx.add_instance(0, COMPRESSOR.0, COMPRESSOR.1, COMPRESSOR.2).unwrap();
+
+        assert_eq!(dctx.partition_weight, vec![1100]);
+        assert_eq!(dctx.process_weight, vec![1100]);
+        assert_eq!(dctx.partition_compressor_count, vec![1]);
     }
 }

--- a/common/src/proof_ctx.rs
+++ b/common/src/proof_ctx.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::RwLock,
-};
+use std::{collections::HashMap, sync::RwLock};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -14,7 +11,7 @@ use std::fs;
 use fields::{new_transcript, PrimeField64};
 use crate::{
     initialize_logger, format_bytes, AirInstance, DistributionCtx, GlobalInfo, InstanceInfo, PolMap, SetupCtx, StdMode,
-    PackedInfo, RowInfo, StepsParams, SetupsVadcop, VerboseMode, ProofmanResult,
+    PackedInfo, RowInfo, Setup, StepsParams, SetupsVadcop, VerboseMode, ProofmanResult,
 };
 
 use std::ffi::c_void;
@@ -258,6 +255,7 @@ pub struct ProofCtx<F: PrimeField64> {
     pub global_info: GlobalInfo,
     pub air_instances: Vec<RwLock<AirInstance<F>>>,
     pub weights: HashMap<(usize, usize), u64>,
+    pub compressor_weights: HashMap<(usize, usize), u64>,
     pub custom_commits_values: Mutex<HashMap<String, (PathBuf, Vec<u8>)>>,
     pub dctx: RwLock<DistributionCtx>,
     pub debug_info: RwLock<DebugInfo>,
@@ -298,6 +296,7 @@ impl<F: PrimeField64> ProofCtx<F> {
         let n_challenges = global_info.n_challenges.iter().sum::<usize>();
 
         let weights = HashMap::new();
+        let compressor_weights = HashMap::new();
 
         let air_instances: Vec<RwLock<AirInstance<F>>> =
             (0..MAX_INSTANCES).map(|_| RwLock::new(AirInstance::<F>::default())).collect();
@@ -314,6 +313,7 @@ impl<F: PrimeField64> ProofCtx<F> {
             debug_info: RwLock::new(DebugInfo::default()),
             custom_commits_values: Mutex::new(HashMap::new()),
             weights,
+            compressor_weights,
             aggregation,
             witness_tx: RwLock::new(None),
             witness_tx_priority: RwLock::new(None),
@@ -460,23 +460,37 @@ impl<F: PrimeField64> ProofCtx<F> {
         }
     }
 
-    pub fn set_weights(&mut self, sctx: &SetupCtx<F>) -> ProofmanResult<()> {
+    /// Estimated prover cost of a single proof of this setup
+    fn setup_weight(setup: &Setup<F>) -> u64 {
+        let mut total_cols = setup
+            .stark_info
+            .map_sections_n
+            .iter()
+            .filter(|(key, _)| *key != "const")
+            .map(|(_, value)| *value)
+            .sum::<u64>();
+        total_cols += 3; // FRI polinomial
+        let n_openings = setup.stark_info.opening_points.len() as u64;
+        // let n_ops_quotient = setup.n_operations_quotient;
+        // weight += (n_ops_quotient / 10) * (1 << (setup.stark_info.stark_struct.n_bits_ext));
+        (total_cols + n_openings * 3) * (1 << (setup.stark_info.stark_struct.n_bits_ext))
+    }
+
+    /// Cost of the basic proof of every air, plus the compressor proof it triggers if it has one.
+    /// Both are needed to balance instances: a compressor proof runs on the owner of its basic
+    /// proof, and its cost varies ~2x between airs in the current zisk proving key.
+    pub fn set_weights(&mut self, sctx: &SetupCtx<F>, setups_vadcop: &SetupsVadcop<F>) -> ProofmanResult<()> {
         for (airgroup_id, air_group) in self.global_info.airs.iter().enumerate() {
             for (air_id, _) in air_group.iter().enumerate() {
                 let setup = sctx.get_setup(airgroup_id, air_id)?;
-                let mut total_cols = setup
-                    .stark_info
-                    .map_sections_n
-                    .iter()
-                    .filter(|(key, _)| *key != "const")
-                    .map(|(_, value)| *value)
-                    .sum::<u64>();
-                total_cols += 3; // FRI polinomial
-                let n_openings = setup.stark_info.opening_points.len() as u64;
-                // let n_ops_quotient = setup.n_operations_quotient;
-                let weight = (total_cols + n_openings * 3) * (1 << (setup.stark_info.stark_struct.n_bits_ext));
-                // weight += (n_ops_quotient / 10) * (1 << (setup.stark_info.stark_struct.n_bits_ext));
-                self.weights.insert((airgroup_id, air_id), weight);
+                self.weights.insert((airgroup_id, air_id), Self::setup_weight(setup));
+
+                if self.global_info.get_air_has_compressor(airgroup_id, air_id) {
+                    if let Some(sctx_compressor) = setups_vadcop.sctx_compressor.as_ref() {
+                        let compressor_setup = sctx_compressor.get_setup(airgroup_id, air_id)?;
+                        self.compressor_weights.insert((airgroup_id, air_id), Self::setup_weight(compressor_setup));
+                    }
+                }
             }
         }
         Ok(())
@@ -484,6 +498,11 @@ impl<F: PrimeField64> ProofCtx<F> {
 
     pub fn get_weight(&self, airgroup_id: usize, air_id: usize) -> u64 {
         *self.weights.get(&(airgroup_id, air_id)).unwrap()
+    }
+
+    /// 0 if the air has no compressor, or if the compressor setups are not loaded (no aggregation)
+    pub fn get_compressor_weight(&self, airgroup_id: usize, air_id: usize) -> u64 {
+        self.compressor_weights.get(&(airgroup_id, air_id)).copied().unwrap_or(0)
     }
 
     pub fn get_custom_commits_fixed_buffer(&self, name: &str, return_error: bool) -> ProofmanResult<PathBuf> {
@@ -646,14 +665,15 @@ impl<F: PrimeField64> ProofCtx<F> {
     pub fn add_instance_assign(&self, airgroup_id: usize, air_id: usize) -> ProofmanResult<usize> {
         let mut dctx = self.dctx.write().unwrap();
         let weight = self.get_weight(airgroup_id, air_id);
-        let has_compressor = self.global_info.get_air_has_compressor(airgroup_id, air_id);
-        dctx.add_instance(airgroup_id, air_id, weight, has_compressor)
+        let compressor_weight = self.get_compressor_weight(airgroup_id, air_id);
+        dctx.add_instance(airgroup_id, air_id, weight, compressor_weight)
     }
 
     pub fn add_instance(&self, airgroup_id: usize, air_id: usize) -> ProofmanResult<usize> {
         let mut dctx = self.dctx.write().unwrap();
         let weight = self.get_weight(airgroup_id, air_id);
-        dctx.add_instance_no_assign(airgroup_id, air_id, weight)
+        let compressor_weight = self.get_compressor_weight(airgroup_id, air_id);
+        dctx.add_instance_no_assign(airgroup_id, air_id, weight, compressor_weight)
     }
 
     pub fn add_table(&self, airgroup_id: usize, air_id: usize) -> ProofmanResult<usize> {
@@ -670,24 +690,13 @@ impl<F: PrimeField64> ProofCtx<F> {
 
     pub fn dctx_add_instance_no_assign(&self, airgroup_id: usize, air_id: usize, weight: u64) -> ProofmanResult<usize> {
         let mut dctx = self.dctx.write().unwrap();
-        dctx.add_instance_no_assign(airgroup_id, air_id, weight)
+        let compressor_weight = self.get_compressor_weight(airgroup_id, air_id);
+        dctx.add_instance_no_assign(airgroup_id, air_id, weight, compressor_weight)
     }
 
     pub fn dctx_assign_instances(&self) -> ProofmanResult<()> {
-        let compressor_airs: HashSet<(usize, usize)> = self
-            .global_info
-            .airs
-            .iter()
-            .enumerate()
-            .flat_map(|(ag_id, airs)| {
-                airs.iter()
-                    .enumerate()
-                    .filter(|(_, air)| air.has_compressor.unwrap_or(false))
-                    .map(move |(a_id, _)| (ag_id, a_id))
-            })
-            .collect();
         let mut dctx = self.dctx.write().unwrap();
-        dctx.assign_instances(&compressor_airs)
+        dctx.assign_instances()
     }
 
     pub fn dctx_load_balance_info_process(&self) -> (f64, u64, u64, f64) {

--- a/common/src/prover.rs
+++ b/common/src/prover.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use fields::PrimeField64;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ProofType {
     #[default]
     Basic = 0,

--- a/common/src/setup.rs
+++ b/common/src/setup.rs
@@ -400,7 +400,7 @@ impl<F: PrimeField64> Setup<F> {
             exec_data,
             n_adds,
             setup_path: setup_path.to_path_buf().clone(),
-            setup_type: setup_type.clone(),
+            setup_type: *setup_type,
             air_name: air_info.name.clone(),
             const_pols_path,
             const_pols_tree_path,

--- a/common/src/setup_ctx.rs
+++ b/common/src/setup_ctx.rs
@@ -444,7 +444,7 @@ impl<F: PrimeField64> SetupCtx<F> {
             max_n_bits_ext,
             total_const_pols_size,
             total_const_tree_size,
-            setup_type: setup_type.clone(),
+            setup_type: *setup_type,
         })
     }
 

--- a/pil2-stark/src/api/starks_api.cpp
+++ b/pil2-stark/src/api/starks_api.cpp
@@ -833,8 +833,9 @@ void load_device_setup_cpu(uint64_t airgroupId, uint64_t airId, char *proofType,
     }
 }
 
-uint64_t gen_recursive_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char* proof_file, bool vadcop, void *d_buffers_, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id) {
+uint64_t gen_recursive_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char* proof_file, bool vadcop, void *d_buffers_, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_) {
     (void)recurser_id;
+    (void)streamId_;  // CPU backend has no streams
     DeviceCommitBuffersCPU *d_buffers = (DeviceCommitBuffersCPU *)d_buffers_;
     SetupCtx *setupCtx = (SetupCtx *)pSetupCtx;
 

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -95,13 +95,16 @@ void unregister_host_memory_gpu(void *ptr) {
     }
 }
 
-// Block until the async commit on `streamId` (trace H2D + tiling + LDE + Merkle)
-// has finished on the GPU. The trace H2D is no longer synced at copy time (see
-// copy_direct_registered_h2d_if_enabled), so the host trace buffer must not be
-// reused until end_event fires, or the in-flight DMA reads recycled bytes. Called
-// from the buffer pool before reusing a shared trace buffer. No-op if the stream
-// has no outstanding commit (status != 2).
-void wait_stream_commit_done_gpu(void *d_buffers_, uint64_t streamId) {
+// Block until `streamId` has finished reading the caller's host trace buffer, i.e. until the
+// trace H2D completes. The copy is no longer synced at copy time (see
+// copy_direct_registered_h2d_if_enabled), so the buffer must not be recycled before that or the
+// in-flight DMA reads reused bytes. Called from the buffer pool before reusing a shared trace
+// buffer. No-op if the stream has no outstanding commit (status != 2).
+//
+// This waits on trace_copy_event, not end_event: the commit's LDE/Merkle work reads the device
+// copy, not the host buffer, so gating recycling on the whole commit held pool buffers for the
+// entire GPU pipeline and left witness threads queueing in take_buffer for them.
+void wait_trace_h2d_done_gpu(void *d_buffers_, uint64_t streamId) {
     if (d_buffers_ == nullptr) return;
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
     // Guard the C-ABI surface: an out-of-range streamId (e.g. from a future caller
@@ -110,7 +113,7 @@ void wait_stream_commit_done_gpu(void *d_buffers_, uint64_t streamId) {
     if (streamId >= d_buffers->n_total_streams) return;
     cudaSetDevice(d_buffers->streamsData[streamId].gpuId);
     if (d_buffers->streamsData[streamId].status == 2) {
-        CHECKCUDAERR(cudaEventSynchronize(d_buffers->streamsData[streamId].end_event));
+        CHECKCUDAERR(cudaEventSynchronize(d_buffers->streamsData[streamId].trace_copy_event));
     }
 }
 

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -664,8 +664,12 @@ uint64_t gen_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, ui
             return UINT64_MAX;
         }
         reserveStreamLocked(d_buffers, streamId); // mutex held by lock_guard above
+    } else if (streamId_ == UINT64_MAX) {
+        // No reservation supplied (one-off / non-scheduler caller): select internally.
+        streamId = selectStream(d_buffers, airgroupId, airId, proofType, false, false);
     } else {
-        streamId = selectStream(d_buffers, airgroupId, airId, proofType, false);
+        // Recompute path: the scheduler already reserved this stream (status=1).
+        streamId = (uint32_t)streamId_;
     }
     uint32_t gpuId = d_buffers->streamsData[streamId].gpuId;
     uint32_t gpuLocalId = d_buffers->gpus_g2l[gpuId];
@@ -720,7 +724,14 @@ uint64_t gen_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, ui
     totalCopySize += setupCtx->starkInfo.airValuesSize;
     totalCopySize += FIELD_EXTENSION;
 
-    Goldilocks::Element aux_values[totalCopySize];
+    // Stage into the per-stream pinned region for an async copy (no stream sync);
+    // reuse gated by end_event on stream reselect. Runtime check survives NDEBUG.
+    if (totalCopySize > PINNED_AUX_VALUES_MAX) {
+        zklog.error("gen_proof_gpu: aux_values size " + std::to_string(totalCopySize) +
+                    " exceeds PINNED_AUX_VALUES_MAX " + std::to_string(PINNED_AUX_VALUES_MAX));
+        exitProcess();
+    }
+    Goldilocks::Element *aux_values = d_buffers->streamsData[streamId].pinned_aux_values;
     uint64_t offset = 0;
     memcpy(aux_values + offset, params->publicInputs, setupCtx->starkInfo.nPublics * sizeof(Goldilocks::Element));
     offset += setupCtx->starkInfo.nPublics;
@@ -738,7 +749,7 @@ uint64_t gen_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, ui
     }
     memcpy(aux_values + offset, (Goldilocks::Element *)globalChallenge, FIELD_EXTENSION * sizeof(Goldilocks::Element));
 
-    copy_to_device_in_chunks(d_buffers, aux_values, (uint8_t*)(d_aux_trace + offsetPublicInputs), totalCopySize * sizeof(Goldilocks::Element), streamId, timer);
+    CHECKCUDAERR(cudaMemcpyAsync((uint8_t*)(d_aux_trace + offsetPublicInputs), aux_values, totalCopySize * sizeof(Goldilocks::Element), cudaMemcpyHostToDevice, stream));
 
     gl64_t *d_const_pols = d_buffers->d_constPols[gpuLocalId] + air_instance_info->const_pols_offset;
     gl64_t *d_const_tree;
@@ -817,7 +828,14 @@ uint64_t initialize_instance_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t
     totalCopySize += setupCtx->starkInfo.airValuesSize;
     totalCopySize += 2 * FIELD_EXTENSION;
 
-    Goldilocks::Element aux_values[totalCopySize];
+    // Stage into the per-stream pinned region for an async copy (no stream sync);
+    // reuse gated by end_event on stream reselect. Runtime check survives NDEBUG.
+    if (totalCopySize > PINNED_AUX_VALUES_MAX) {
+        zklog.error("initialize_instance_gpu: aux_values size " + std::to_string(totalCopySize) +
+                    " exceeds PINNED_AUX_VALUES_MAX " + std::to_string(PINNED_AUX_VALUES_MAX));
+        exitProcess();
+    }
+    Goldilocks::Element *aux_values = d_buffers->streamsData[streamId].pinned_aux_values;
     uint64_t offset = 0;
     memcpy(aux_values + offset, params->publicInputs, setupCtx->starkInfo.nPublics * sizeof(Goldilocks::Element));
     offset += setupCtx->starkInfo.nPublics;
@@ -835,7 +853,7 @@ uint64_t initialize_instance_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t
     }
     memcpy(aux_values + offset, (Goldilocks::Element *)params->challenges, 2 * FIELD_EXTENSION * sizeof(Goldilocks::Element));
 
-    copy_to_device_in_chunks(d_buffers, aux_values, (uint8_t*)(d_aux_trace + offsetPublicInputs), totalCopySize * sizeof(Goldilocks::Element), streamId, timer);
+    CHECKCUDAERR(cudaMemcpyAsync((uint8_t*)(d_aux_trace + offsetPublicInputs), aux_values, totalCopySize * sizeof(Goldilocks::Element), cudaMemcpyHostToDevice, stream));
     
     gl64_t *d_const_pols = d_buffers->d_constPols[gpuLocalId] + air_instance_info->const_pols_offset;
     
@@ -984,14 +1002,18 @@ void get_stream_id_proof_gpu(void *d_buffers_, uint64_t streamId) {
     collectStreamResult(d_buffers, streamId);
 }
 
-uint64_t gen_recursive_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void *trace, void *aux_trace, void *pConstPols, void *pConstTree, void *pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers_, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id)
+uint64_t gen_recursive_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void *trace, void *aux_trace, void *pConstPols, void *pConstTree, void *pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers_, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_)
 {
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
     bool aggregation = false;
     if(string(proofType) == "recursive1" || string(proofType) == "recursive2") {
         aggregation = true;
     }
-    uint32_t streamId = selectStream(d_buffers, airgroupId, airId, proofType, aggregation, force_recursive_stream);
+    // streamId_ == UINT64_MAX: select internally (one-off launches). Otherwise the scheduler
+    // already reserved this stream — use it directly.
+    uint32_t streamId = (streamId_ == UINT64_MAX)
+        ? selectStream(d_buffers, airgroupId, airId, proofType, aggregation, force_recursive_stream)
+        : (uint32_t)streamId_;
     uint32_t gpuId = d_buffers->streamsData[streamId].gpuId;
     uint32_t gpuLocalId = d_buffers->gpus_g2l[gpuId];
 
@@ -1029,13 +1051,22 @@ uint64_t gen_recursive_proof_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t
     copy_to_device_in_chunks(d_buffers, trace, (uint8_t*)(d_aux_trace + offsetStage1Extended), sizeTrace, streamId, timer);
     
     uint64_t offsetPublicInputs = setupCtx->starkInfo.mapOffsets[std::make_pair("publics", false)];
-    copy_to_device_in_chunks(d_buffers, pPublicInputs, (uint8_t*)(d_aux_trace + offsetPublicInputs), setupCtx->starkInfo.nPublics * sizeof(Goldilocks::Element), streamId, timer);
+    // Stage publics into the per-stream pinned region for an async copy (no stream
+    // sync); reuse gated by end_event on stream reselect. Runtime check survives NDEBUG.
+    if (setupCtx->starkInfo.nPublics > PINNED_AUX_VALUES_MAX) {
+        zklog.error("gen_recursive_proof_gpu: nPublics " + std::to_string(setupCtx->starkInfo.nPublics) +
+                    " exceeds PINNED_AUX_VALUES_MAX " + std::to_string(PINNED_AUX_VALUES_MAX));
+        exitProcess();
+    }
+    Goldilocks::Element *pinned_publics = d_buffers->streamsData[streamId].pinned_aux_values;
+    memcpy(pinned_publics, pPublicInputs, setupCtx->starkInfo.nPublics * sizeof(Goldilocks::Element));
+    CHECKCUDAERR(cudaMemcpyAsync((uint8_t*)(d_aux_trace + offsetPublicInputs), pinned_publics, setupCtx->starkInfo.nPublics * sizeof(Goldilocks::Element), cudaMemcpyHostToDevice, stream));
 
     gl64_t *d_const_pols = d_buffers->d_constPolsAggregation[gpuLocalId] + air_instance_info->const_pols_offset;
     gl64_t *d_const_tree;
     if (air_instance_info->stored_tree) {
         d_const_tree = d_buffers->d_constPolsAggregation[gpuLocalId] + air_instance_info->const_tree_offset;
-    } else {        
+    } else {
         uint64_t offsetConstTree = setupCtx->starkInfo.mapOffsets[std::make_pair("const", true)];
         d_const_tree = d_aux_trace + offsetConstTree;
 
@@ -1903,26 +1934,35 @@ void *get_unified_buffer_gpu_for_recursivef_gpu(void *d_buffers_, void *d_buffer
     return get_unified_buffer_gpu(d_buffers_);
 }
 
-uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint64_t airId, std::string proofType, bool recursive, bool force_recursive){
+// One non-blocking scan+pick+reserve pass (the body of selectStream's old while-loop).
+// Returns a reserved streamId (status=1), or UINT32_MAX if none is free right now. Lets the
+// Rust scheduler drive stream assignment; selectStream just retries this in a loop.
+uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint64_t airId, std::string proofType, bool recursive, bool force_recursive){
     uint32_t countFreeStreamsGPU[d_buffers->n_gpus];
     uint32_t countUnusedStreams[d_buffers->n_gpus];
     int streamIdxGPU[d_buffers->n_gpus];
+    bool warmFoundGPU[d_buffers->n_gpus];
 
     for( uint32_t i = 0; i < d_buffers->n_gpus; i++){
         countUnusedStreams[i] = 0;
         countFreeStreamsGPU[i] = 0;
         streamIdxGPU[i] = -1;
+        warmFoundGPU[i] = false;
     }
 
     bool someFree = false;
-    uint32_t selectedStreamId = 0;
 
     std::vector<bool> streams_locked(d_buffers->n_total_streams, false);
 
     const uint32_t firstGpuId = d_buffers->my_gpu_ids[0];
 
-    while (!someFree){
-        // Re-read every iteration so a release by the borrower is picked up.
+    {
+        // Serialize the scan so this caller sees the full set of free streams
+        // (kills the fragmented try_lock race). Scoped to the scan only: released
+        // before the pick/reserve below, so the global lock is NEVER held across
+        // proof execution (the deadlock trap). Per-stream locks are still taken via
+        // try_lock, so this never blocks on harvest/reserve.
+        std::lock_guard<std::mutex> gsel(d_buffers->stream_selection_mutex);
         const bool firstGpuBorrowed = d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire);
         if (recursive) {
             for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
@@ -1939,13 +1979,20 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
-                            streamIdxGPU[gpuLocalId] = i;
                         }
-                        if (d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3)){
+                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3);
+                        if (warm) {
+                            // Sticky warm choice: keep the stream already holding this
+                            // (airgroup,air,type) so reuse_constants hits; not clobbered by a
+                            // later unused/free stream (the bug that killed affinity).
                             streamIdxGPU[gpuLocalId] = i;
-                        }
-                        if( streamIdxGPU[gpuLocalId] == -1 ){
-                            streamIdxGPU[gpuLocalId] = i;
+                            warmFoundGPU[gpuLocalId] = true;
+                        } else if (!warmFoundGPU[gpuLocalId]) {
+                            // No warm stream yet: prefer an unused (cold, no eviction) stream,
+                            // else any free one.
+                            if (d_buffers->streamsData[i].status==0 || streamIdxGPU[gpuLocalId] == -1) {
+                                streamIdxGPU[gpuLocalId] = i;
+                            }
                         }
                         someFree = true;
                         streams_locked[i] = true;
@@ -1954,10 +2001,12 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
                     }
                 }
             }
-            if(someFree) break;
         }
 
-        if (!recursive || !force_recursive) {
+        // Recursive requests that found a recursive stream skip this (someFree set);
+        // a non-forced recursive request with no free recursive stream falls back to
+        // non-recursive streams, exactly as the old while-loop did.
+        if (!someFree && (!recursive || !force_recursive)) {
             for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
                 if (firstGpuBorrowed && d_buffers->streamsData[i].gpuId == firstGpuId) continue;
                 if (!d_buffers->streamsData[i].recursive && d_buffers->streamsData[i].mutex_stream_selection.try_lock()) {
@@ -1972,13 +2021,20 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
-                            streamIdxGPU[gpuLocalId] = i;
                         }
-                        if (d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3)){
+                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3);
+                        if (warm) {
+                            // Sticky warm choice: keep the stream already holding this
+                            // (airgroup,air,type) so reuse_constants hits; not clobbered by a
+                            // later unused/free stream (the bug that killed affinity).
                             streamIdxGPU[gpuLocalId] = i;
-                        }
-                        if( streamIdxGPU[gpuLocalId] == -1 ){
-                            streamIdxGPU[gpuLocalId] = i;
+                            warmFoundGPU[gpuLocalId] = true;
+                        } else if (!warmFoundGPU[gpuLocalId]) {
+                            // No warm stream yet: prefer an unused (cold, no eviction) stream,
+                            // else any free one.
+                            if (d_buffers->streamsData[i].status==0 || streamIdxGPU[gpuLocalId] == -1) {
+                                streamIdxGPU[gpuLocalId] = i;
+                            }
                         }
                         someFree = true;
                         streams_locked[i] = true;
@@ -1988,10 +2044,10 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
                 }
             }
         }
-
-        if (!someFree)
-            std::this_thread::sleep_for(std::chrono::microseconds(300)); 
     }
+
+    if (!someFree) return UINT32_MAX;  // nothing free this pass; caller retries
+
     // Most free streams wins; ties break on unused count. someFree guarantees a candidate.
     int bestGpu = -1;
     for (uint32_t i = 0; i < d_buffers->n_gpus; i++) {
@@ -2001,7 +2057,7 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
             bestGpu = i;
         }
     }
-    selectedStreamId = streamIdxGPU[bestGpu];
+    uint32_t selectedStreamId = streamIdxGPU[bestGpu];
     for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
         if (streams_locked[i] && i != selectedStreamId) {
             d_buffers->streamsData[i].mutex_stream_selection.unlock();
@@ -2012,6 +2068,49 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
     d_buffers->streamsData[selectedStreamId].mutex_stream_selection.unlock();
 
     return selectedStreamId;
+}
+
+// Blocking wrapper: retry the scan until a stream is reserved. Used by the paths that
+// select internally (contributions/commit/setup, and one-off recursive launches).
+uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint64_t airId, std::string proofType, bool recursive, bool force_recursive){
+    for (;;) {
+        uint32_t s = reserve_best_stream_scan(d_buffers, airgroupId, airId, proofType, recursive, force_recursive);
+        if (s != UINT32_MAX) return s;
+        std::this_thread::sleep_for(std::chrono::microseconds(300));
+    }
+}
+
+// extern "C" entry for the Rust scheduler: reserve a stream, then pass it to
+// gen_*_proof(..., streamId_). Returns UINT32_MAX when nothing is free (caller retries).
+extern "C" uint32_t reserve_best_stream_nonblock(void* d_buffers_, uint64_t airgroupId, uint64_t airId, char* proofType, bool recursive, bool force_recursive){
+    DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
+    return reserve_best_stream_scan(d_buffers, airgroupId, airId, std::string(proofType), recursive, force_recursive);
+}
+
+// Warm-affinity fast path: reserve `streamId` IFF free right now (and a recursive stream
+// for a forced request). Returns 1 on success, 0 otherwise. Same lock order as
+// reserve_best_stream_scan (gsel, then per-stream try_lock) so they can't deadlock.
+extern "C" uint32_t reserve_stream_if_free(void* d_buffers_, uint32_t streamId, bool force_recursive){
+    DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
+    if (streamId >= d_buffers->n_total_streams) return 0;
+    StreamData& sd = d_buffers->streamsData[streamId];
+    // A forced recursive launch must stay on a recursive stream; refuse otherwise so
+    // the caller falls back to the cold scan.
+    if (force_recursive && !sd.recursive) return 0;
+    const uint32_t firstGpuId = d_buffers->my_gpu_ids[0];
+    if (d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire) && sd.gpuId == firstGpuId) return 0;
+
+    std::lock_guard<std::mutex> gsel(d_buffers->stream_selection_mutex);
+    if (!sd.mutex_stream_selection.try_lock()) return 0;
+    if (sd.gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
+        sd.mutex_stream_selection.unlock();
+        return 0;
+    }
+    bool free = sd.status==0 || sd.status==3 || (sd.status==2 && cudaEventQuery(sd.end_event) == cudaSuccess);
+    if (!free) { sd.mutex_stream_selection.unlock(); return 0; }
+    reserveStreamLocked(d_buffers, streamId);
+    sd.mutex_stream_selection.unlock();
+    return 1;
 }
 
 // Requires the caller to hold streamsData[streamId].mutex_stream_selection

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -1973,14 +1973,20 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
                         d_buffers->streamsData[i].mutex_stream_selection.unlock();
                         continue;
                     }
-                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || (d_buffers->streamsData[i].status==2 &&  cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess)) {
+                    // Ran to completion but not yet harvested: free to take, and its
+                    // const-tree is still loaded. Queried once and reused by the warm test.
+                    const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
+                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained) {
                         uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
 
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
                         }
-                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3);
+                        // status==0 is deliberately absent: the only path to it
+                        // (reset_device_streams_gpu) calls invalidateContext() first, so the
+                        // key comparison below can never match an unused stream anyway.
+                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==3 || drained);
                         if (warm) {
                             // Sticky warm choice: keep the stream already holding this
                             // (airgroup,air,type) so reuse_constants hits; not clobbered by a
@@ -2015,14 +2021,20 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
                         d_buffers->streamsData[i].mutex_stream_selection.unlock();
                         continue;
                     }
-                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || (d_buffers->streamsData[i].status==2 &&  cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess)) {
+                    // Ran to completion but not yet harvested: free to take, and its
+                    // const-tree is still loaded. Queried once and reused by the warm test.
+                    const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
+                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained) {
                         uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
 
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
                         }
-                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3);
+                        // status==0 is deliberately absent: the only path to it
+                        // (reset_device_streams_gpu) calls invalidateContext() first, so the
+                        // key comparison below can never match an unused stream anyway.
+                        bool warm = d_buffers->streamsData[i].airgroupId == airgroupId && d_buffers->streamsData[i].airId == airId && d_buffers->streamsData[i].proofType == proofType && (d_buffers->streamsData[i].status==3 || drained);
                         if (warm) {
                             // Sticky warm choice: keep the stream already holding this
                             // (airgroup,air,type) so reuse_constants hits; not clobbered by a
@@ -2080,9 +2092,9 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
     }
 }
 
-// extern "C" entry for the Rust scheduler: reserve a stream, then pass it to
+// GPU backend entry for the Rust scheduler: reserve a stream, then pass it to
 // gen_*_proof(..., streamId_). Returns UINT32_MAX when nothing is free (caller retries).
-extern "C" uint32_t reserve_best_stream_nonblock(void* d_buffers_, uint64_t airgroupId, uint64_t airId, char* proofType, bool recursive, bool force_recursive){
+uint32_t reserve_best_stream_nonblock_gpu(void* d_buffers_, uint64_t airgroupId, uint64_t airId, char* proofType, bool recursive, bool force_recursive){
     DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
     return reserve_best_stream_scan(d_buffers, airgroupId, airId, std::string(proofType), recursive, force_recursive);
 }
@@ -2090,7 +2102,7 @@ extern "C" uint32_t reserve_best_stream_nonblock(void* d_buffers_, uint64_t airg
 // Warm-affinity fast path: reserve `streamId` IFF free right now (and a recursive stream
 // for a forced request). Returns 1 on success, 0 otherwise. Same lock order as
 // reserve_best_stream_scan (gsel, then per-stream try_lock) so they can't deadlock.
-extern "C" uint32_t reserve_stream_if_free(void* d_buffers_, uint32_t streamId, bool force_recursive){
+uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, bool force_recursive){
     DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
     if (streamId >= d_buffers->n_total_streams) return 0;
     StreamData& sd = d_buffers->streamsData[streamId];

--- a/pil2-stark/src/api/starks_api.hpp
+++ b/pil2-stark/src/api/starks_api.hpp
@@ -33,7 +33,7 @@ extern "C" {
     uint64_t get_proof_pinned_size(void *pStarkInfo);
     uint32_t register_host_memory(void *ptr, uint64_t size);
     void unregister_host_memory(void *ptr);
-    void wait_stream_commit_done(void *d_buffers, uint64_t stream_id);
+    void wait_trace_h2d_done(void *d_buffers, uint64_t stream_id);
     void set_memory_expressions(void *pStarkInfo, uint64_t nTmp1, uint64_t nTmp3);
     uint64_t get_map_total_n(void *pStarkInfo);
     uint64_t get_map_total_n_custom_commits_fixed(void *pStarkInfo);

--- a/pil2-stark/src/api/starks_api.hpp
+++ b/pil2-stark/src/api/starks_api.hpp
@@ -114,13 +114,19 @@ extern "C" {
     // Gen proof && Recursive Proof
     // =================================================================================
     uint64_t gen_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void *params, void *globalChallenge, uint64_t* proofBuffer, char *proofFile, void *d_buffers, bool skipRecalculation, uint64_t streamId, char *constPolsPath,  char *constTreePath, char *customCommitsFixedPath);
-    uint64_t gen_recursive_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id);
+    uint64_t gen_recursive_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
     void read_exec_file(uint64_t *exec_data, char *exec_file, uint64_t nCommitedPols);
     void get_committed_pols(void *circomWitness, uint64_t* execData, void *witness, void* pPublics, uint64_t sizeWitness, uint64_t N, uint64_t nPublics, uint64_t nCols);
     void *gen_recursive_proof_final(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
     void get_stream_proofs(void *d_buffers_);
     void get_stream_proofs_non_blocking(void *d_buffers_);
     void get_stream_id_proof(void *d_buffers_, uint64_t streamId);
+    // Central arbiter: reserve the best free stream for (airgroupId,airId,proofType)
+    // without blocking. Returns UINT32_MAX if none is free right now.
+    uint32_t reserve_best_stream_nonblock(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
+    // Central arbiter warm fast path: reserve streamId iff it is free right now.
+    // Returns 1 on success, 0 otherwise.
+    uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, bool force_recursive);
     void add_publics_aggregation(void *pProof, uint64_t offset, void *pPublics, uint64_t nPublicsAggregation);
     void calculate_const_tree_fixed(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);
     // Final proof

--- a/pil2-stark/src/api/starks_backend.cpp
+++ b/pil2-stark/src/api/starks_backend.cpp
@@ -18,7 +18,7 @@ void *gen_device_buffers_cpu(uint32_t node_rank, uint32_t node_size, const int32
 void use_packed_trace_cpu(void *d_buffers_, bool packed);
 void free_device_buffers_cpu(void *d_buffers);
 void load_device_setup_cpu(uint64_t airgroupId, uint64_t airId, char *proofType, void *pSetupCtx_, void *d_buffers_, void *verkeyRoot_, void *packedInfo);
-uint64_t gen_recursive_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id);
+uint64_t gen_recursive_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
 void *gen_recursive_proof_final_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
 void *init_final_snark_prover_cpu(char* zkeyFile, void* d_buffers_recursivef);
 void free_final_snark_prover_cpu(void *snark_prover);
@@ -45,7 +45,7 @@ uint64_t gen_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uin
 void get_stream_proofs_gpu(void *d_buffers_);
 void get_stream_proofs_non_blocking_gpu(void *d_buffers_);
 void get_stream_id_proof_gpu(void *d_buffers_, uint64_t streamId);
-uint64_t gen_recursive_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id);
+uint64_t gen_recursive_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
 void *gen_recursive_proof_final_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
 void calculate_const_tree_fixed_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);
 void *gen_device_buffers_gpu(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);
@@ -282,9 +282,9 @@ void get_stream_id_proof(void *d_buffers_, uint64_t streamId) {
     if (backend->get_stream_id_proof) backend->get_stream_id_proof(d_buffers_, streamId);
 }
 
-uint64_t gen_recursive_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id) {
+uint64_t gen_recursive_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_) {
     auto backend = active_backend.load(std::memory_order_acquire);
-    return backend->gen_recursive_proof(pSetupCtx, airgroupId, airId, instanceId, witness, aux_trace, pConstPols, pConstTree, pPublicInputs, proofBuffer, proof_file, vadcop, d_buffers, constPolsPath, constTreePath, proofType, force_recursive_stream, recurser_id);
+    return backend->gen_recursive_proof(pSetupCtx, airgroupId, airId, instanceId, witness, aux_trace, pConstPols, pConstTree, pPublicInputs, proofBuffer, proof_file, vadcop, d_buffers, constPolsPath, constTreePath, proofType, force_recursive_stream, recurser_id, streamId_);
 }
 
 void *gen_recursive_proof_final(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers) {

--- a/pil2-stark/src/api/starks_backend.cpp
+++ b/pil2-stark/src/api/starks_backend.cpp
@@ -31,7 +31,7 @@ void gen_final_snark_proof_cpu(void *snark_prover, void *circomWitnessFinal, uin
 #ifdef __USE_CUDA__
 uint32_t register_host_memory_gpu(void *ptr, uint64_t size);
 void unregister_host_memory_gpu(void *ptr);
-void wait_stream_commit_done_gpu(void *d_buffers, uint64_t stream_id);
+void wait_trace_h2d_done_gpu(void *d_buffers, uint64_t stream_id);
 void init_gpu_setup_gpu(uint64_t maxBitsExt, uint64_t arity);
 void tile_const_pols_gpu(void *pStarkInfo, void *pConstPols, char *constFile, void *pConstTree, char *constTreeFile, void *unified_buffer_gpu);
 void prepare_blocks_gpu(uint64_t* pol, uint64_t N, uint64_t nCols, void *unified_buffer_gpu);
@@ -107,7 +107,7 @@ StarksBackend cpu_backend = []() {
     backend.calculate_const_tree_fixed = nullptr;
     backend.register_host_memory = nullptr;               // CPU: no GPU to pin for
     backend.unregister_host_memory = nullptr;
-    backend.wait_stream_commit_done = nullptr;            // CPU: no async stream to wait on
+    backend.wait_trace_h2d_done = nullptr;            // CPU: no async stream to wait on
     backend.gen_device_buffers = gen_device_buffers_cpu;
     backend.use_packed_trace = use_packed_trace_cpu;
     backend.free_device_buffers = free_device_buffers_cpu;
@@ -162,7 +162,7 @@ StarksBackend gpu_backend = []() {
     backend.calculate_const_tree_fixed = calculate_const_tree_fixed_gpu;
     backend.register_host_memory = register_host_memory_gpu;
     backend.unregister_host_memory = unregister_host_memory_gpu;
-    backend.wait_stream_commit_done = wait_stream_commit_done_gpu;
+    backend.wait_trace_h2d_done = wait_trace_h2d_done_gpu;
     backend.gen_device_buffers = gen_device_buffers_gpu;
     backend.use_packed_trace = use_packed_trace_gpu;
     backend.free_device_buffers = free_device_buffers_gpu;
@@ -338,9 +338,9 @@ void unregister_host_memory(void *ptr) {
     if (backend->unregister_host_memory) backend->unregister_host_memory(ptr);
 }
 
-void wait_stream_commit_done(void *d_buffers, uint64_t stream_id) {
+void wait_trace_h2d_done(void *d_buffers, uint64_t stream_id) {
     auto backend = active_backend.load(std::memory_order_acquire);
-    if (backend->wait_stream_commit_done) backend->wait_stream_commit_done(d_buffers, stream_id);
+    if (backend->wait_trace_h2d_done) backend->wait_trace_h2d_done(d_buffers, stream_id);
 }
 
 void free_device_buffers(void *d_buffers) {

--- a/pil2-stark/src/api/starks_backend.cpp
+++ b/pil2-stark/src/api/starks_backend.cpp
@@ -45,6 +45,8 @@ uint64_t gen_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uin
 void get_stream_proofs_gpu(void *d_buffers_);
 void get_stream_proofs_non_blocking_gpu(void *d_buffers_);
 void get_stream_id_proof_gpu(void *d_buffers_, uint64_t streamId);
+uint32_t reserve_best_stream_nonblock_gpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
+uint32_t reserve_stream_if_free_gpu(void *d_buffers_, uint32_t streamId, bool force_recursive);
 uint64_t gen_recursive_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
 void *gen_recursive_proof_final_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
 void calculate_const_tree_fixed_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);
@@ -98,6 +100,8 @@ StarksBackend cpu_backend = []() {
     backend.get_stream_proofs = nullptr;
     backend.get_stream_proofs_non_blocking = nullptr;
     backend.get_stream_id_proof = nullptr;
+    backend.reserve_best_stream_nonblock = nullptr;       // default: UINT32_MAX (no streams)
+    backend.reserve_stream_if_free = nullptr;             // default: 0 (not reserved)
     backend.gen_recursive_proof = gen_recursive_proof_cpu;
     backend.gen_recursive_proof_final = gen_recursive_proof_final_cpu;
     backend.calculate_const_tree_fixed = nullptr;
@@ -151,6 +155,8 @@ StarksBackend gpu_backend = []() {
     backend.get_stream_proofs = get_stream_proofs_gpu;
     backend.get_stream_proofs_non_blocking = get_stream_proofs_non_blocking_gpu;
     backend.get_stream_id_proof = get_stream_id_proof_gpu;
+    backend.reserve_best_stream_nonblock = reserve_best_stream_nonblock_gpu;
+    backend.reserve_stream_if_free = reserve_stream_if_free_gpu;
     backend.gen_recursive_proof = gen_recursive_proof_gpu;
     backend.gen_recursive_proof_final = gen_recursive_proof_final_gpu;
     backend.calculate_const_tree_fixed = calculate_const_tree_fixed_gpu;
@@ -280,6 +286,20 @@ void get_stream_proofs_non_blocking(void *d_buffers_) {
 void get_stream_id_proof(void *d_buffers_, uint64_t streamId) {
     auto backend = active_backend.load(std::memory_order_acquire);
     if (backend->get_stream_id_proof) backend->get_stream_id_proof(d_buffers_, streamId);
+}
+
+// No streams on CPU: report "nothing reserved" so a caller that ever reaches here falls
+// back instead of believing it owns stream 0. Today the Rust scheduler is GPU-only.
+uint32_t reserve_best_stream_nonblock(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive) {
+    auto backend = active_backend.load(std::memory_order_acquire);
+    if (!backend->reserve_best_stream_nonblock) return UINT32_MAX;
+    return backend->reserve_best_stream_nonblock(d_buffers_, airgroupId, airId, proofType, recursive, force_recursive);
+}
+
+uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, bool force_recursive) {
+    auto backend = active_backend.load(std::memory_order_acquire);
+    if (!backend->reserve_stream_if_free) return 0;
+    return backend->reserve_stream_if_free(d_buffers_, streamId, force_recursive);
 }
 
 uint64_t gen_recursive_proof(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_) {

--- a/pil2-stark/src/api/starks_backend.hpp
+++ b/pil2-stark/src/api/starks_backend.hpp
@@ -45,7 +45,7 @@ struct StarksBackend {
     void (*unregister_host_memory)(void *ptr);
     // Wait for a stream's async commit (incl. the now-unsynced trace H2D) to
     // finish, so the shared trace buffer can be reused. GPU backend only.
-    void (*wait_stream_commit_done)(void *d_buffers, uint64_t stream_id);
+    void (*wait_trace_h2d_done)(void *d_buffers, uint64_t stream_id);
 
     // Device management
     void *(*gen_device_buffers)(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);

--- a/pil2-stark/src/api/starks_backend.hpp
+++ b/pil2-stark/src/api/starks_backend.hpp
@@ -31,6 +31,11 @@ struct StarksBackend {
     void (*get_stream_proofs)(void *d_buffers_);
     void (*get_stream_proofs_non_blocking)(void *d_buffers_);
     void (*get_stream_id_proof)(void *d_buffers_, uint64_t streamId);
+    // Stream arbiter used by the Rust key-affinity scheduler. GPU backend only: the CPU
+    // backend has no streams, so these stay nullptr and the dispatchers return
+    // "nothing reserved" (UINT32_MAX / 0).
+    uint32_t (*reserve_best_stream_nonblock)(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
+    uint32_t (*reserve_stream_if_free)(void *d_buffers_, uint32_t streamId, bool force_recursive);
     uint64_t (*gen_recursive_proof)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
     void *(*gen_recursive_proof_final)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
     void (*calculate_const_tree_fixed)(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);

--- a/pil2-stark/src/api/starks_backend.hpp
+++ b/pil2-stark/src/api/starks_backend.hpp
@@ -31,7 +31,7 @@ struct StarksBackend {
     void (*get_stream_proofs)(void *d_buffers_);
     void (*get_stream_proofs_non_blocking)(void *d_buffers_);
     void (*get_stream_id_proof)(void *d_buffers_, uint64_t streamId);
-    uint64_t (*gen_recursive_proof)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id);
+    uint64_t (*gen_recursive_proof)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
     void *(*gen_recursive_proof_final)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
     void (*calculate_const_tree_fixed)(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);
 

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
@@ -19,10 +19,10 @@ static bool copy_direct_registered_h2d_if_enabled(const void *src, void *dst, ui
     // Only take the fast path when src is host memory the driver can DMA directly.
     if (attrs.type != cudaMemoryTypeHost) return false;
 
-    // No cudaStreamSynchronize: src (pool-pinned trace buffer) outlives this
-    // stream's end_event, on which the caller gates buffer reuse
-    // (wait_stream_commit_done). Syncing here would serialize the copy against the
-    // LDE/Merkle work (measured ~9.5s vs ~8.7s contributions).
+    // No cudaStreamSynchronize: the caller gates reuse of src (the pool-pinned trace buffer) on
+    // trace_copy_event, recorded by the caller right after this returns (wait_trace_h2d_done).
+    // Syncing here would serialize the copy against the LDE/Merkle work (measured ~9.5s vs ~8.7s
+    // contributions).
     CHECKCUDAERR(cudaMemcpyAsync(dst, src, total_size, cudaMemcpyHostToDevice, stream));
     return true;
 }
@@ -84,6 +84,9 @@ void copy_to_device_in_chunks(
     //  - small:  sub-threshold copy, one shot
     TimerStartCategoryGPU(timer, H2D_COPY);
     if (copy_direct_registered_h2d_if_enabled(src, dst, total_size, stream)) {
+        // The direct path leaves a DMA reading `src`, so mark where it finishes: this is what
+        // gates recycling the host trace buffer (see wait_trace_h2d_done).
+        cudaEventRecord(d_buffers->streamsData[streamId].trace_copy_event, stream);
         TimerStopCategoryGPU(timer, H2D_COPY);
         return;
     }
@@ -133,6 +136,10 @@ void copy_to_device_in_chunks(
     ));
 
     CHECKCUDAERR(cudaStreamSynchronize(stream));
+    // Staged path: `src` was memcpy'd into the pinned staging buffer and the copies are already
+    // synced, so the host trace buffer is free here. Record anyway so the event always marks this
+    // commit's release point rather than leaving a stale record from an earlier one.
+    cudaEventRecord(d_buffers->streamsData[streamId].trace_copy_event, stream);
     TimerStopCategoryGPU(timer, H2D_COPY);
 }
 

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
@@ -27,20 +27,6 @@ static bool copy_direct_registered_h2d_if_enabled(const void *src, void *dst, ui
     return true;
 }
 
-// Small H2D copies don't need the 128MB double-buffered staging; routing them
-// through it makes a few-KB copy contend for the per-GPU pinned mutex behind a
-// GB-scale stage on another stream. Issue one async copy + sync (so a stack-local
-// source is safe on return) without `mutex_pinned`. Returns true if it handled it.
-static constexpr uint64_t SMALL_H2D_THRESHOLD = 2 * 1024 * 1024; // 2MB
-static bool copy_small_h2d_if_applicable(const void *src, void *dst, uint64_t total_size, cudaStream_t stream)
-{
-    if (total_size == 0) return true;
-    if (total_size > SMALL_H2D_THRESHOLD) return false;
-    CHECKCUDAERR(cudaMemcpyAsync(dst, src, total_size, cudaMemcpyHostToDevice, stream));
-    CHECKCUDAERR(cudaStreamSynchronize(stream));
-    return true;
-}
-
 // Kernel: row-major input -> destination layout `layout` (see getBufferOffset).
 // Uses blockIdx.x for rows (which can be very large) and blockIdx.y for cols.
 __global__ void fromRowMajorToColMajor(
@@ -97,8 +83,7 @@ void copy_to_device_in_chunks(
     //  - direct: large + already host-pinned source
     //  - small:  sub-threshold copy, one shot
     TimerStartCategoryGPU(timer, H2D_COPY);
-    if (copy_direct_registered_h2d_if_enabled(src, dst, total_size, stream) ||
-        copy_small_h2d_if_applicable(src, dst, total_size, stream)) {
+    if (copy_direct_registered_h2d_if_enabled(src, dst, total_size, stream)) {
         TimerStopCategoryGPU(timer, H2D_COPY);
         return;
     }
@@ -160,7 +145,6 @@ void copy_to_device_in_chunks(
     cudaStream_t stream
 ){
     if (copy_direct_registered_h2d_if_enabled(src, dst, total_size_bytes, stream)) return;
-    if (copy_small_h2d_if_applicable(src, dst, total_size_bytes, stream)) return;
 
      uint64_t block_size = pinnedBufferSize/2;
     

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -511,6 +511,9 @@ struct DeviceCommitBuffers
     std::mutex *mutex_pinned;
     StreamData *streamsData;
 
+    
+    std::mutex stream_selection_mutex;
+
     bool packedTrace = false;
 
     std::map<std::pair<uint64_t, uint64_t>, std::map<std::string, std::vector<AirInstanceInfo *>>> air_instances;

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -296,13 +296,17 @@ struct StreamData{
     Goldilocks::Element *pinned_aux_values;
 
     //runtime data
-    // Atomic: status is read (unlocked) by wait_stream_commit_done / callbacks while
+    // Atomic: status is read (unlocked) by wait_trace_h2d_done / callbacks while
     // reserveStream/gen_proof write it, so a plain int would be a data race. The
     // atomic only removes UB on the individual load/store; the check-then-act
     // sequences in selectStream/reserveStream/get_stream_proofs_* are made correct
     // by holding mutex_stream_selection, not by the atomic.
     std::atomic<uint32_t> status{0}; //0: unused, 1: loading, 2: full, 3: reusable (not unused)
     cudaEvent_t end_event;
+    // Marks the point where this stream stops reading the caller's host trace buffer, i.e. the
+    // trace H2D. Distinct from end_event (the whole commit): the buffer can be recycled as soon
+    // as the copy is done, and gating that on the LDE/Merkle work kept the pool starved.
+    cudaEvent_t trace_copy_event;
     TimerGPU timer;
 
     TranscriptGL_GPU *transcript;
@@ -349,6 +353,7 @@ struct StreamData{
         localStreamId = localStreamId_;
         recursive = recursive_;
         cudaEventCreate(&end_event);
+        cudaEventCreate(&trace_copy_event);
         instanceId = -1;
         status = 0;
         CHECKCUDAERR(cudaMallocHost((void **)&pinned_buffer_proof, max_size_proof * sizeof(Goldilocks::Element)));
@@ -393,9 +398,9 @@ struct StreamData{
 
     void reset(bool reset_status){
         cudaSetDevice(gpuId);
-        // end_event is created once in initialize() and destroyed in free();
-        // cudaEventRecord overwrites it on each use, so there is no need to
-        // destroy/recreate it on every per-instance reset.
+        // end_event / trace_copy_event are created once in initialize() and destroyed in free();
+        // cudaEventRecord overwrites them on each use, so there is no need to
+        // destroy/recreate them on every per-instance reset.
         status = reset_status ? 0 : 3;
 
         root = nullptr;
@@ -419,6 +424,7 @@ struct StreamData{
 #endif
         cudaStreamDestroy(stream);
         cudaEventDestroy(end_event);
+        cudaEventDestroy(trace_copy_event);
         cudaFreeHost(pinned_buffer_proof);
         cudaFreeHost(pinned_buffer_exps_params);
         cudaFreeHost(pinned_buffer_exps_args);

--- a/proofman/src/lib.rs
+++ b/proofman/src/lib.rs
@@ -1,3 +1,4 @@
+mod scheduler;
 mod proofman;
 mod recursion;
 mod utils;
@@ -7,6 +8,7 @@ mod verify;
 mod challenge_accumulation;
 mod snark_wrapper;
 
+pub use scheduler::*;
 pub use proofman::*;
 pub use recursion::*;
 pub use utils::*;

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -1763,7 +1763,7 @@ where
                 "recurser packed const pols ({packed_len} elements) exceed the reserved GPU slot ({slot})"
             )));
         }
-        let proof_type: &str = setup.setup_type.clone().into();
+        let proof_type: &str = setup.setup_type.into();
         let d_buffers_ptr = self.pctx.get_device_buffers_ptr();
         load_device_setup_c(
             0,
@@ -2800,24 +2800,19 @@ where
                         loop {
                             if !force_recursive_stream {
                                 // Drain ready stored basics into the key-affinity queue.
-                                loop {
-                                    match proofs_rx.try_recv() {
-                                        Ok(id) => match pctx_clone.dctx_get_instance_info(id) {
-                                            Ok((ag, air)) => {
-                                                // Mark resident-tree basics (preallocated const-tree)
-                                                // so the scheduler treats them as filler.
-                                                let resident = sctx_clone
-                                                    .get_setup(ag, air)
-                                                    .map(|s| s.preallocate)
-                                                    .unwrap_or(false);
-                                                guard.push_basic(id, ag, air, resident);
-                                            }
-                                            Err(e) => {
-                                                cancellation_info_clone.write().unwrap().cancel(Some(e));
-                                                return;
-                                            }
-                                        },
-                                        Err(_) => break,
+                                while let Ok(id) = proofs_rx.try_recv() {
+                                    match pctx_clone.dctx_get_instance_info(id) {
+                                        Ok((ag, air)) => {
+                                            // Mark resident-tree basics (preallocated const-tree)
+                                            // so the scheduler treats them as filler.
+                                            let resident =
+                                                sctx_clone.get_setup(ag, air).map(|s| s.preallocate).unwrap_or(false);
+                                            guard.push_basic(id, ag, air, resident);
+                                        }
+                                        Err(e) => {
+                                            cancellation_info_clone.write().unwrap().cancel(Some(e));
+                                            return;
+                                        }
                                     }
                                 }
                             }
@@ -2962,20 +2957,20 @@ where
                             break;
                         }
                     };
-                    let new_proof_type_str: &str = new_proof.proof_type.clone().into();
+                    let new_proof_type_str: &str = new_proof.proof_type.into();
 
-                    let new_proof_type = &new_proof.proof_type.clone();
+                    let new_proof_type = new_proof.proof_type;
 
                     let id = new_proof.global_idx.unwrap();
-                    if *new_proof_type == ProofType::Recursive2 {
+                    if new_proof_type == ProofType::Recursive2 {
                         recursive2_proofs_ongoing_clone.write().unwrap()[id] = Some(new_proof);
-                    } else if *new_proof_type == ProofType::Compressor {
+                    } else if new_proof_type == ProofType::Compressor {
                         *compressor_proofs_clone[id].write().unwrap() = Some(new_proof);
-                    } else if *new_proof_type == ProofType::Recursive1 {
+                    } else if new_proof_type == ProofType::Recursive1 {
                         *recursive1_proofs_clone[id].write().unwrap() = Some(new_proof);
                     }
 
-                    if *new_proof_type == ProofType::Recursive2 {
+                    if new_proof_type == ProofType::Recursive2 {
                         let recursive2_lock = recursive2_proofs_ongoing_clone.read().unwrap();
                         let new_proof_ref = recursive2_lock[id].as_ref().unwrap();
 
@@ -2995,7 +2990,7 @@ where
                             cancellation_info_clone.write().unwrap().cancel(Some(e));
                             break;
                         }
-                    } else if *new_proof_type == ProofType::Compressor {
+                    } else if new_proof_type == ProofType::Compressor {
                         let compressor_lock = compressor_proofs_clone[id].read().unwrap();
                         let new_proof_ref = compressor_lock.as_ref().unwrap();
                         if let Err(e) = generate_recursive_proof(

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -34,10 +34,12 @@ use csv::Writer;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::deterministic_shuffle;
 use proofman_common::{ProofmanResult, ProofmanError, Setup};
 use proofman_verifier::VadcopFinalProof;
-use crate::{check_const_paths, check_const_paths_vadcop, needs_regeneration_fixed, needs_regeneration_vadcop_fixed};
+use crate::{
+    check_const_paths, check_const_paths_vadcop, needs_regeneration_fixed, needs_regeneration_vadcop_fixed,
+    schedule_key,
+};
 
 use proofman_starks_lib_c::{
     gen_proof_c, commit_witness_c, load_custom_commit_c, calculate_impols_expressions_c,
@@ -1086,15 +1088,14 @@ where
 
         let _ = self.exec()?;
 
-        let mut my_instances_sorted = self.pctx.dctx_get_process_instances();
-        deterministic_shuffle(&mut my_instances_sorted, self.mpi_ctx.rank as u64);
+        let my_instances = self.pctx.dctx_get_process_instances();
 
-        let my_instances_sorted_no_tables =
-            my_instances_sorted.iter().filter(|idx| !self.pctx.dctx_is_table(**idx)).copied().collect::<Vec<_>>();
+        let my_instances_no_tables =
+            my_instances.iter().filter(|idx| !self.pctx.dctx_is_table(**idx)).copied().collect::<Vec<_>>();
 
         timer_start_info!(CALCULATING_WITNESS);
         self.calculate_witness(
-            &my_instances_sorted_no_tables,
+            &my_instances_no_tables,
             self.memory_handler.clone(),
             witness_done.clone(),
             options.minimal_memory,
@@ -2289,17 +2290,16 @@ where
                 *witness_start_time.write().unwrap() = Some(std::time::Instant::now());
             }
 
-            let mut my_instances_sorted = self.pctx.dctx_get_process_instances();
-            deterministic_shuffle(&mut my_instances_sorted, self.mpi_ctx.rank as u64);
+            let my_instances = self.pctx.dctx_get_process_instances();
 
             timer_stop_and_log_debug!(PREPARING_CONTRIBUTIONS);
 
-            let my_instances_sorted_no_tables =
-                my_instances_sorted.iter().filter(|idx| !self.pctx.dctx_is_table(**idx)).copied().collect::<Vec<_>>();
+            let my_instances_no_tables =
+                my_instances.iter().filter(|idx| !self.pctx.dctx_is_table(**idx)).copied().collect::<Vec<_>>();
 
             timer_start_debug!(CALCULATING_WITNESS);
             self.calculate_witness(
-                &my_instances_sorted_no_tables,
+                &my_instances_no_tables,
                 self.memory_handler.clone(),
                 witness_done.clone(),
                 options.minimal_memory,
@@ -2462,11 +2462,10 @@ where
         let n_airgroups = self.pctx.global_info.air_groups.len();
 
         let instances = self.pctx.dctx_get_instances();
-        let mut my_instances_sorted = self.pctx.dctx_get_process_instances();
-        deterministic_shuffle(&mut my_instances_sorted, self.mpi_ctx.rank as u64);
+        let mut my_instances = self.pctx.dctx_get_process_instances();
 
         let mut n_airgroup_proofs = vec![0; n_airgroups];
-        for &instance_id in my_instances_sorted.iter() {
+        for &instance_id in my_instances.iter() {
             let instance_info = instances[instance_id];
             n_airgroup_proofs[instance_info.airgroup_id] += 1;
         }
@@ -2490,6 +2489,16 @@ where
 
         self.pctx.set_proof_tx(Some(self.proofs_tx.clone()));
 
+        // Key-affinity recursive scheduler (GPU only; CPU has no streams and uses the witness
+        // channels). Condvar parks idle stream workers.
+        let scheduler: Option<Arc<crate::SharedScheduler<F>>> = if self.pctx.gpu {
+            Some(Arc::new(crate::SharedScheduler::new(crate::RecursiveScheduler::<F>::new(
+                self.pctx.get_device_buffers_ptr(),
+            ))))
+        } else {
+            None
+        };
+
         for _ in 0..self.n_streams {
             let pctx_clone = self.pctx.clone();
             let memory_handler_recursive_witness = self.memory_handler_recursive_witness.clone();
@@ -2506,6 +2515,7 @@ where
             let compressor_witness_tx_clone = self.compressor_witness_tx.clone();
             let recursive_rx_clone = self.recursive_rx.clone();
             let cancellation_info_clone = self.cancellation_info.clone();
+            let scheduler_clone = scheduler.clone();
             let handle_recursive = std::thread::spawn(move || {
                 while let Ok((id, proof_type)) = recursive_rx_clone.recv() {
                     if id == u64::MAX - 1 {
@@ -2629,23 +2639,31 @@ where
                         // New downstream unit; commit to the callback only if the handoff
                         // succeeds, else the guard drops and balances it.
                         let child = proofs_pending_clone.pending();
-                        let sent = if new_proof_type == ProofType::Compressor as usize {
-                            compressor_witness_tx_clone.send(witness)
-                        } else if new_proof_type == ProofType::Recursive1 as usize {
-                            rec1_witness_tx_clone.send(witness)
-                        } else {
-                            rec2_witness_tx_clone.send(witness)
-                        };
-                        if sent.is_ok() {
+                        if let Some(sched) = scheduler_clone.as_ref() {
+                            // Key-affinity scheduler (GPU): push into the shared queue + wake a
+                            // stream worker. The unbounded push can't fail, so always commit.
+                            sched.push(witness);
                             child.commit();
                         } else {
-                            // Witness channels live on `self`, so a failed send means the
-                            // pipeline is torn down mid-run: surface it, don't drop silently.
-                            cancellation_info_clone
-                                .write()
-                                .unwrap()
-                                .cancel(Some(ProofmanError::ProofmanError("witness channel closed".into())));
-                            break;
+                            // CPU: hand off through the witness channels.
+                            let sent = if new_proof_type == ProofType::Compressor as usize {
+                                compressor_witness_tx_clone.send(witness)
+                            } else if new_proof_type == ProofType::Recursive1 as usize {
+                                rec1_witness_tx_clone.send(witness)
+                            } else {
+                                rec2_witness_tx_clone.send(witness)
+                            };
+                            if sent.is_ok() {
+                                child.commit();
+                            } else {
+                                // Witness channels live on `self`, so a failed send means the
+                                // pipeline is torn down mid-run: surface it, don't drop silently.
+                                cancellation_info_clone
+                                    .write()
+                                    .unwrap()
+                                    .cancel(Some(ProofmanError::ProofmanError("witness channel closed".into())));
+                                break;
+                            }
                         }
                     }
                 }
@@ -2675,6 +2693,7 @@ where
                 &self.const_pols,
                 &self.const_tree,
                 Some(stream_id),
+                None, // resident/pinned witness: skip path, no reserved stream
             ) {
                 Ok(sid) => {
                     pending.commit();
@@ -2704,22 +2723,43 @@ where
             my_instances_calculated[*instance_id as usize] = true;
         }
 
-        my_instances_sorted.sort_by_key(|&id| {
+        // Per-AIR per-proof cost proxy for LPT ordering; computed once (not in the
+        // comparator). PROOFMAN_CLUSTER_SCHEDULE=0 falls back to tier-only order.
+        let cluster_schedule =
+            std::env::var("PROOFMAN_CLUSTER_SCHEDULE").map(|v| v != "0" && v != "false").unwrap_or(true);
+        let mut group_cost: HashMap<(usize, usize), u64> = HashMap::new();
+        for &id in my_instances.iter() {
+            let (ag, air) = (instances[id].airgroup_id, instances[id].air_id);
+            group_cost.entry((ag, air)).or_insert_with(|| match self.sctx.get_setup(ag, air) {
+                // Saturating so a pathologically large AIR can't wrap to a tiny cost and defeat LPT.
+                Ok(setup) => 1u64
+                    .checked_shl(setup.stark_info.stark_struct.n_bits as u32)
+                    .unwrap_or(u64::MAX)
+                    .saturating_mul(setup.n_cols),
+                Err(_) => 0,
+            });
+        }
+
+        my_instances.sort_by_key(|&id| {
             let (airgroup_id, air_id) = (instances[id].airgroup_id, instances[id].air_id);
             let is_stored = self.pctx.is_air_instance_stored(id);
             let has_compressor = self.pctx.global_info.get_air_has_compressor(airgroup_id, air_id);
-
-            let priority_tier = if is_stored && has_compressor {
-                0
-            } else if is_stored {
-                1
-            } else if has_compressor {
-                2
+            if cluster_schedule {
+                schedule_key(airgroup_id, air_id, is_stored, has_compressor, group_cost[&(airgroup_id, air_id)])
             } else {
-                3
-            };
-
-            (priority_tier,)
+                // Legacy: tier only. Equal keys within a tier keep prior order
+                // (stable sort), reproducing today's behavior for A/B comparison.
+                let priority_tier: u8 = if is_stored && has_compressor {
+                    0
+                } else if is_stored {
+                    1
+                } else if has_compressor {
+                    2
+                } else {
+                    3
+                };
+                (priority_tier, std::cmp::Reverse(0u64), 0usize, 0usize)
+            }
         });
 
         let proofs_finished = Arc::new(AtomicBool::new(false));
@@ -2744,10 +2784,76 @@ where
             let proofs_finished_clone = proofs_finished.clone();
             let cancellation_info_clone = self.cancellation_info.clone();
             let proofs_pending_clone = proofs_pending.clone();
-            let handle_recursive = std::thread::spawn(move || loop {
-                let force_recursive_stream = stream_id >= n_streams_non_recursive;
-                if !force_recursive_stream {
-                    if let Ok(instance_id) = proofs_rx.try_recv() {
+            let scheduler_clone = scheduler.clone();
+            let handle_recursive = std::thread::spawn(move || {
+                loop {
+                    let force_recursive_stream = stream_id >= n_streams_non_recursive;
+
+                    // One locked pick per iteration (GPU): a Basic is dispatched right below; a
+                    // Recursive witness (in `gpu_witness`) falls through to the recursive dispatch.
+                    // CPU: take a stored basic off the channel and let gen_proof select the stream.
+                    let mut reserved_stream: u64 = u64::MAX;
+                    let mut gpu_witness: Option<Proof<F>> = None;
+                    let basic: Option<(usize, Option<usize>)> = if let Some(sched) = scheduler_clone.as_ref() {
+                        let (lock, cvar) = (&sched.lock, &sched.ready);
+                        let mut guard = lock.lock().unwrap();
+                        loop {
+                            if !force_recursive_stream {
+                                // Drain ready stored basics into the key-affinity queue.
+                                loop {
+                                    match proofs_rx.try_recv() {
+                                        Ok(id) => match pctx_clone.dctx_get_instance_info(id) {
+                                            Ok((ag, air)) => {
+                                                // Mark resident-tree basics (preallocated const-tree)
+                                                // so the scheduler treats them as filler.
+                                                let resident = sctx_clone
+                                                    .get_setup(ag, air)
+                                                    .map(|s| s.preallocate)
+                                                    .unwrap_or(false);
+                                                guard.push_basic(id, ag, air, resident);
+                                            }
+                                            Err(e) => {
+                                                cancellation_info_clone.write().unwrap().cancel(Some(e));
+                                                return;
+                                            }
+                                        },
+                                        Err(_) => break,
+                                    }
+                                }
+                            }
+                            let pick = if force_recursive_stream {
+                                guard.next_recursive().map(|(w, s)| crate::WorkerPick::Recursive(w, s))
+                            } else {
+                                guard.next_nonrecursive()
+                            };
+                            match pick {
+                                Some(crate::WorkerPick::Recursive(w, s)) => {
+                                    reserved_stream = s as u64;
+                                    gpu_witness = Some(w);
+                                    break None;
+                                }
+                                Some(crate::WorkerPick::Basic(id, s)) => break Some((id, Some(s as usize))),
+                                None => {
+                                    // Exit only once everything is drained. Non-force workers
+                                    // also own the basic queue, so they must wait for it too.
+                                    if proofs_finished_clone.load(Ordering::Relaxed)
+                                        && guard.is_empty()
+                                        && (force_recursive_stream || guard.basic_is_empty())
+                                    {
+                                        return;
+                                    }
+                                    let (g, _) = cvar.wait_timeout(guard, std::time::Duration::from_millis(1)).unwrap();
+                                    guard = g;
+                                }
+                            }
+                        }
+                    } else if !force_recursive_stream {
+                        proofs_rx.try_recv().ok().map(|id| (id, None))
+                    } else {
+                        None
+                    };
+
+                    if let Some((instance_id, reserved)) = basic {
                         // Settles on the cancel/free path or a gen_proof error; committed
                         // to the callback only on a successful launch.
                         let pending = PendingProof::from_outstanding(&proofs_pending_clone);
@@ -2770,6 +2876,7 @@ where
                                 &const_pols_clone,
                                 &const_tree_clone,
                                 None,
+                                reserved,
                             ) {
                                 Ok(sid) => {
                                     pending.commit();
@@ -2796,141 +2903,150 @@ where
                             continue;
                         }
                     }
-                }
 
-                if cancellation_info_clone.read().unwrap().token.is_cancelled() {
-                    break;
-                }
-
-                let witness_opt = if force_recursive_stream {
-                    crossbeam_channel::select! {
-                        recv(rec2_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
-                        recv(rec1_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
-                        default(std::time::Duration::from_millis(1)) => None,
+                    if cancellation_info_clone.read().unwrap().token.is_cancelled() {
+                        break;
                     }
-                } else {
-                    crossbeam_channel::select! {
-                        recv(rec2_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
-                        recv(compressor_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
-                        recv(rec1_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
-                        default(std::time::Duration::from_millis(1)) => None,
-                    }
-                };
 
-                let mut witness = match witness_opt {
-                    None => {
-                        if proofs_finished_clone.load(Ordering::Relaxed) {
-                            return;
+                    // The GPU pick above already reserved the stream (`reserved_stream`) and
+                    // produced the recursive witness; on CPU gen_recursive_proof selects internally.
+                    let mut witness = if let Some(w) = gpu_witness {
+                        w
+                    } else {
+                        // CPU: `select!` among the ready witness channels.
+                        let witness_opt = if force_recursive_stream {
+                            crossbeam_channel::select! {
+                                recv(rec2_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
+                                recv(rec1_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
+                                default(std::time::Duration::from_millis(1)) => None,
+                            }
+                        } else {
+                            crossbeam_channel::select! {
+                                recv(rec2_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
+                                recv(compressor_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
+                                recv(rec1_rx) -> msg => match msg { Ok(w) => Some(w), Err(_) => return },
+                                default(std::time::Duration::from_millis(1)) => None,
+                            }
+                        };
+                        match witness_opt {
+                            Some(w) => w,
+                            None => {
+                                if proofs_finished_clone.load(Ordering::Relaxed) {
+                                    return;
+                                }
+                                continue;
+                            }
                         }
-                        continue;
-                    }
-                    Some(w) => w,
-                };
-
-                // Settles on an error `break` below; committed once the recursive proof
-                // is launched and its callback is guaranteed.
-                let pending = PendingProof::from_outstanding(&proofs_pending_clone);
-
-                let force_recursive_stream = stream_id >= n_streams_non_recursive;
-                if witness.proof_type == ProofType::Recursive2 {
-                    let id = {
-                        let mut rec2_proofs = recursive2_proofs_ongoing_clone.write().unwrap();
-                        let id = rec2_proofs.len();
-                        rec2_proofs.push(None);
-                        id
                     };
 
-                    witness.global_idx = Some(id);
-                }
+                    // Settles on an error `break` below; committed once the recursive proof
+                    // is launched and its callback is guaranteed.
+                    let pending = PendingProof::from_outstanding(&proofs_pending_clone);
 
-                let new_proof = match gen_recursive_proof_size(&pctx_clone, &setups_clone, &witness) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        cancellation_info_clone.write().unwrap().cancel(Some(e));
-                        break;
+                    let force_recursive_stream = stream_id >= n_streams_non_recursive;
+                    if witness.proof_type == ProofType::Recursive2 {
+                        let id = {
+                            let mut rec2_proofs = recursive2_proofs_ongoing_clone.write().unwrap();
+                            let id = rec2_proofs.len();
+                            rec2_proofs.push(None);
+                            id
+                        };
+
+                        witness.global_idx = Some(id);
                     }
-                };
-                let new_proof_type_str: &str = new_proof.proof_type.clone().into();
 
-                let new_proof_type = &new_proof.proof_type.clone();
+                    let new_proof = match gen_recursive_proof_size(&pctx_clone, &setups_clone, &witness) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            cancellation_info_clone.write().unwrap().cancel(Some(e));
+                            break;
+                        }
+                    };
+                    let new_proof_type_str: &str = new_proof.proof_type.clone().into();
 
-                let id = new_proof.global_idx.unwrap();
-                if *new_proof_type == ProofType::Recursive2 {
-                    recursive2_proofs_ongoing_clone.write().unwrap()[id] = Some(new_proof);
-                } else if *new_proof_type == ProofType::Compressor {
-                    *compressor_proofs_clone[id].write().unwrap() = Some(new_proof);
-                } else if *new_proof_type == ProofType::Recursive1 {
-                    *recursive1_proofs_clone[id].write().unwrap() = Some(new_proof);
-                }
+                    let new_proof_type = &new_proof.proof_type.clone();
 
-                if *new_proof_type == ProofType::Recursive2 {
-                    let recursive2_lock = recursive2_proofs_ongoing_clone.read().unwrap();
-                    let new_proof_ref = recursive2_lock[id].as_ref().unwrap();
-
-                    if let Err(e) = generate_recursive_proof(
-                        &pctx_clone,
-                        &memory_handler_recursive_witness,
-                        &setups_clone,
-                        &mut witness,
-                        new_proof_ref,
-                        &aux_trace_clone,
-                        &const_tree_clone,
-                        &const_pols_clone,
-                        force_recursive_stream,
-                        None,
-                    ) {
-                        cancellation_info_clone.write().unwrap().cancel(Some(e));
-                        break;
+                    let id = new_proof.global_idx.unwrap();
+                    if *new_proof_type == ProofType::Recursive2 {
+                        recursive2_proofs_ongoing_clone.write().unwrap()[id] = Some(new_proof);
+                    } else if *new_proof_type == ProofType::Compressor {
+                        *compressor_proofs_clone[id].write().unwrap() = Some(new_proof);
+                    } else if *new_proof_type == ProofType::Recursive1 {
+                        *recursive1_proofs_clone[id].write().unwrap() = Some(new_proof);
                     }
-                } else if *new_proof_type == ProofType::Compressor {
-                    let compressor_lock = compressor_proofs_clone[id].read().unwrap();
-                    let new_proof_ref = compressor_lock.as_ref().unwrap();
-                    if let Err(e) = generate_recursive_proof(
-                        &pctx_clone,
-                        &memory_handler_recursive_witness,
-                        &setups_clone,
-                        &mut witness,
-                        new_proof_ref,
-                        &aux_trace_clone,
-                        &const_tree_clone,
-                        &const_pols_clone,
-                        force_recursive_stream,
-                        None,
-                    ) {
-                        cancellation_info_clone.write().unwrap().cancel(Some(e));
-                        break;
-                    }
-                } else {
-                    let recursive1_lock = recursive1_proofs_clone[id].read().unwrap();
-                    let new_proof_ref = recursive1_lock.as_ref().unwrap();
-                    if let Err(e) = generate_recursive_proof(
-                        &pctx_clone,
-                        &memory_handler_recursive_witness,
-                        &setups_clone,
-                        &mut witness,
-                        new_proof_ref,
-                        &aux_trace_clone,
-                        &const_tree_clone,
-                        &const_pols_clone,
-                        force_recursive_stream,
-                        None,
-                    ) {
-                        cancellation_info_clone.write().unwrap().cancel(Some(e));
-                        break;
-                    }
-                }
 
-                pending.commit();
+                    if *new_proof_type == ProofType::Recursive2 {
+                        let recursive2_lock = recursive2_proofs_ongoing_clone.read().unwrap();
+                        let new_proof_ref = recursive2_lock[id].as_ref().unwrap();
 
-                if !pctx_clone.gpu {
-                    launch_callback_c(id as u64, new_proof_type_str);
+                        if let Err(e) = generate_recursive_proof(
+                            &pctx_clone,
+                            &memory_handler_recursive_witness,
+                            &setups_clone,
+                            &mut witness,
+                            new_proof_ref,
+                            &aux_trace_clone,
+                            &const_tree_clone,
+                            &const_pols_clone,
+                            force_recursive_stream,
+                            reserved_stream,
+                            None,
+                        ) {
+                            cancellation_info_clone.write().unwrap().cancel(Some(e));
+                            break;
+                        }
+                    } else if *new_proof_type == ProofType::Compressor {
+                        let compressor_lock = compressor_proofs_clone[id].read().unwrap();
+                        let new_proof_ref = compressor_lock.as_ref().unwrap();
+                        if let Err(e) = generate_recursive_proof(
+                            &pctx_clone,
+                            &memory_handler_recursive_witness,
+                            &setups_clone,
+                            &mut witness,
+                            new_proof_ref,
+                            &aux_trace_clone,
+                            &const_tree_clone,
+                            &const_pols_clone,
+                            force_recursive_stream,
+                            reserved_stream,
+                            None,
+                        ) {
+                            cancellation_info_clone.write().unwrap().cancel(Some(e));
+                            break;
+                        }
+                    } else {
+                        let recursive1_lock = recursive1_proofs_clone[id].read().unwrap();
+                        let new_proof_ref = recursive1_lock.as_ref().unwrap();
+                        if let Err(e) = generate_recursive_proof(
+                            &pctx_clone,
+                            &memory_handler_recursive_witness,
+                            &setups_clone,
+                            &mut witness,
+                            new_proof_ref,
+                            &aux_trace_clone,
+                            &const_tree_clone,
+                            &const_pols_clone,
+                            force_recursive_stream,
+                            reserved_stream,
+                            None,
+                        ) {
+                            cancellation_info_clone.write().unwrap().cancel(Some(e));
+                            break;
+                        }
+                    }
+
+                    pending.commit();
+
+                    if !pctx_clone.gpu {
+                        launch_callback_c(id as u64, new_proof_type_str);
+                    }
                 }
             });
             self.handle_recursives.lock().unwrap().push(handle_recursive);
         }
 
-        let mut instances_to_be_calculated = Vec::with_capacity(my_instances_sorted.len());
-        for &instance_id in my_instances_sorted.iter() {
+        let mut instances_to_be_calculated = Vec::with_capacity(my_instances.len());
+        for &instance_id in my_instances.iter() {
             if my_instances_calculated[instance_id] {
                 continue;
             }
@@ -2947,18 +3063,8 @@ where
 
         let witness_done = Arc::new(Counter::new());
 
-        if !options.minimal_memory && self.pctx.gpu {
-            self.pctx.set_witness_tx(Some(self.witness_tx.clone()));
-            self.pctx.set_witness_tx_priority(Some(self.witness_tx_priority.clone()));
-        }
-
-        let (witness_handler, witness_handles) = self.calc_witness_handler(
-            witness_done.clone(),
-            self.memory_handler.clone(),
-            options.minimal_memory,
-            None,
-            false,
-        );
+        let (witness_handler, witness_handles) =
+            self.calc_witness_handler(witness_done.clone(), self.memory_handler.clone(), true, None, false);
 
         let _witness_guard = WitnessGuard {
             witness_tx: self.witness_tx.clone(),
@@ -2971,15 +3077,10 @@ where
             &instances_to_be_calculated,
             self.memory_handler.clone(),
             witness_done.clone(),
-            options.minimal_memory,
+            true,
             false,
         )?;
         timer_stop_and_log_debug!(CALCULATING_WITNESS);
-
-        if !options.minimal_memory && self.pctx.gpu {
-            self.pctx.set_witness_tx(None);
-            self.pctx.set_witness_tx_priority(None);
-        }
         self.witness_tx.send(usize::MAX).ok();
         if let Some(h) = witness_handler.lock().unwrap().take() {
             h.join().unwrap();
@@ -3674,6 +3775,7 @@ where
                     &const_tree_clone,
                     &const_pols_clone,
                     false,
+                    u64::MAX, // one-off launch: reserve stream internally
                     None,
                 ) {
                     cancellation_info_clone.write().unwrap().cancel(Some(e));
@@ -3693,10 +3795,10 @@ where
         timer_start_info!(VERIFYING_PROOFS);
         let mut valid_proofs = true;
 
-        let my_instances_sorted = self.pctx.dctx_get_process_instances();
+        let my_instances = self.pctx.dctx_get_process_instances();
 
-        let mut airgroup_values_air_instances = vec![Vec::new(); my_instances_sorted.len()];
-        for instance_id in my_instances_sorted.iter() {
+        let mut airgroup_values_air_instances = vec![Vec::new(); my_instances.len()];
+        for instance_id in my_instances.iter() {
             let proof = {
                 let mut lock = self.proofs[*instance_id].write().unwrap();
                 std::mem::take(&mut *lock)
@@ -3878,6 +3980,7 @@ where
                         &const_tree_clone,
                         &const_pols_clone,
                         false,
+                        u64::MAX, // one-off launch: reserve stream internally
                         None,
                     ) {
                         cancellation_info_clone.write().unwrap().cancel(Some(e));
@@ -4342,6 +4445,7 @@ where
         const_pols: &[F],
         const_tree: &[F],
         stream_id_: Option<usize>,
+        reserved_stream: Option<usize>,
     ) -> ProofmanResult<usize> {
         let (airgroup_id, air_id) = pctx.dctx_get_instance_info(instance_id)?;
         timer_start_debug!(GEN_PROOF, "GEN_PROOF_{} [{}:{}]", instance_id, airgroup_id, air_id);
@@ -4373,9 +4477,13 @@ where
             None => String::new(),
         };
 
-        let (skip_recalculation, stream_id) = match stream_id_ {
-            Some(stream_id) => (true, stream_id),
-            None => (false, 0),
+        // stream_id_ Some -> resident witness (skip recompute, pinned to that stream). Else
+        // recompute; reserved_stream Some -> scheduler-reserved stream; None -> u64::MAX
+        // (CPU path — gen_proof_cpu ignores it; on GPU the scheduler always reserves).
+        let (skip_recalculation, stream_id): (bool, u64) = match (stream_id_, reserved_stream) {
+            (Some(s), _) => (true, s as u64),
+            (None, Some(s)) => (false, s as u64),
+            (None, None) => (false, u64::MAX),
         };
 
         let proof = create_buffer_fast(setup.proof_size as usize);
@@ -4395,7 +4503,7 @@ where
             instance_id as u64,
             pctx.get_device_buffers_ptr(),
             skip_recalculation,
-            stream_id as u64,
+            stream_id,
             const_pols_path,
             const_pols_tree_path,
             &custom_commits_fixed_path,

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -4563,7 +4563,7 @@ where
             options.gpu,
         )?);
 
-        pctx.set_weights(&sctx)?;
+        pctx.set_weights(&sctx, &setups_vadcop)?;
 
         let (n_streams_per_gpu, n_recursive_streams_per_gpu, n_gpus) = pctx.set_device_buffers(
             &sctx,

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -44,7 +44,7 @@ use crate::{
 use proofman_starks_lib_c::{
     gen_proof_c, commit_witness_c, load_custom_commit_c, calculate_impols_expressions_c,
     calculate_witness_expressions_c, clear_proof_done_callback_c, launch_callback_c, initialize_instance_c,
-    calculate_trace_instance_c, wait_stream_commit_done_c,
+    calculate_trace_instance_c, wait_trace_h2d_done_c,
 };
 
 use std::{
@@ -2248,7 +2248,7 @@ where
                                 // commit ran on (returned by commit_witness) — the air_instance
                                 // stream_id is unset on the contributions path.
                                 if pctx_clone.gpu {
-                                    wait_stream_commit_done_c(pctx_clone.get_device_buffers_ptr(), commit_stream_id);
+                                    wait_trace_h2d_done_c(pctx_clone.get_device_buffers_ptr(), commit_stream_id);
                                 }
                                 memory_handler_clone.to_be_released_buffer(instance_id, false);
                             }
@@ -2710,7 +2710,7 @@ where
                 // Trace H2D is async: wait on the proof's stream before recycling
                 // the shared buffer, else a concurrent take() overwrites it mid-copy.
                 if let (true, Some(sid)) = (self.pctx.gpu, proof_stream_id) {
-                    wait_stream_commit_done_c(self.pctx.get_device_buffers_ptr(), sid as u64);
+                    wait_trace_h2d_done_c(self.pctx.get_device_buffers_ptr(), sid as u64);
                 }
                 if let Err(e) = self.memory_handler.release_buffer(witness_buffer) {
                     self.cancellation_info.write().unwrap().cancel(Some(e));
@@ -2885,10 +2885,7 @@ where
                             let (is_shared_buffer, witness_buffer) = pctx_clone.free_instance(instance_id);
                             if is_shared_buffer {
                                 if pctx_clone.gpu {
-                                    wait_stream_commit_done_c(
-                                        pctx_clone.get_device_buffers_ptr(),
-                                        proof_stream_id as u64,
-                                    );
+                                    wait_trace_h2d_done_c(pctx_clone.get_device_buffers_ptr(), proof_stream_id as u64);
                                 }
                                 if let Err(e) = memory_handler_clone.release_buffer(witness_buffer) {
                                     cancellation_info_clone.write().unwrap().cancel(Some(e));

--- a/proofman/src/recursion.rs
+++ b/proofman/src/recursion.rs
@@ -287,6 +287,7 @@ pub fn generate_recursive_proof<F: PrimeField64>(
     const_tree: &[F],
     const_pols: &[F],
     force_recursive_stream: bool,
+    reserved_stream: u64,
     calculate_fixed_tree_handle: Option<std::thread::JoinHandle<()>>,
 ) -> ProofmanResult<(u64, Vec<F>)> {
     timer_start_debug!(
@@ -367,6 +368,8 @@ pub fn generate_recursive_proof<F: PrimeField64>(
         handle.join().map_err(|_| ProofmanError::ProofmanError("Failed to calculate fixed tree".into()))?;
     }
 
+    // `reserved_stream`: scheduler-reserved stream, or `u64::MAX` to select internally
+    // (one-off launches — outer aggregation, vadcop_final, recursers).
     let stream_id = gen_recursive_proof_c(
         p_setup,
         trace.as_ptr() as *mut u8,
@@ -386,6 +389,7 @@ pub fn generate_recursive_proof<F: PrimeField64>(
         witness.proof_type.clone().into(),
         force_recursive_stream,
         "",
+        reserved_stream, // scheduler-reserved stream, or u64::MAX for one-off internal selection
     );
 
     // Trace H2D is async: gate buffer reuse on the stream's commit event so a
@@ -529,6 +533,7 @@ pub fn aggregate_worker_proofs<F: PrimeField64>(
                             const_tree,
                             const_pols,
                             false,
+                            u64::MAX, // one-off launch: reserve stream internally
                             None,
                         )?;
 
@@ -662,6 +667,7 @@ pub fn generate_vadcop_final_proof<F: PrimeField64>(
         const_tree,
         const_pols,
         false,
+        u64::MAX, // one-off launch: reserve stream internally
         Some(calculate_fixed_tree_handle),
     )?;
     get_stream_id_proof_c(pctx.get_device_buffers_ptr(), stream_id);
@@ -730,6 +736,7 @@ pub fn generate_vadcop_final_compressed_proof<F: PrimeField64>(
         const_tree,
         const_pols,
         false,
+        u64::MAX, // one-off launch: reserve stream internally
         Some(calculate_fixed_tree_handle),
     )?;
     get_stream_id_proof_c(pctx.get_device_buffers_ptr(), stream_id);
@@ -943,6 +950,7 @@ pub fn generate_recurser_aggregator_proof<F: PrimeField64>(
         setup.setup_type.clone().into(),
         false,
         recurser_id, // disambiguates recurser setups sharing (0,0,"recursive2")
+        u64::MAX,    // one-off launch: reserve stream internally
     );
     get_stream_id_proof_c(d_buffers, stream_id);
     timer_stop_and_log_debug!(GENERATE_RECURSER_AGGREGATOR_PROOF);

--- a/proofman/src/recursion.rs
+++ b/proofman/src/recursion.rs
@@ -261,7 +261,7 @@ pub fn gen_recursive_proof_size<F: PrimeField64>(
     }
 
     let new_proof = create_buffer_fast(new_proof_size as usize);
-    Ok(Proof::new(witness.proof_type.clone(), witness.airgroup_id, witness.air_id, witness.global_idx, new_proof))
+    Ok(Proof::new(witness.proof_type, witness.airgroup_id, witness.air_id, witness.global_idx, new_proof))
 }
 
 /// Writes a vadcop-final proof's public section `[n_publics | publics(n_publics)]`.
@@ -386,7 +386,7 @@ pub fn generate_recursive_proof<F: PrimeField64>(
         pctx.get_device_buffers_ptr(),
         &setup.const_pols_path,
         &setup.const_pols_tree_path,
-        witness.proof_type.clone().into(),
+        witness.proof_type.into(),
         force_recursive_stream,
         "",
         reserved_stream, // scheduler-reserved stream, or u64::MAX for one-off internal selection
@@ -606,7 +606,7 @@ pub fn generate_vadcop_final_proof<F: PrimeField64>(
 
     let p_setup_addr = p_setup as usize;
     let device_buffers_addr = pctx.get_device_buffers_ptr() as usize;
-    let setup_type = setup.setup_type.clone();
+    let setup_type = setup.setup_type;
 
     let calculate_fixed_tree_handle = std::thread::spawn(move || {
         calculate_const_tree_fixed_c(
@@ -700,7 +700,7 @@ pub fn generate_vadcop_final_compressed_proof<F: PrimeField64>(
 
     let p_setup_addr = p_setup as usize;
     let device_buffers_addr = pctx.get_device_buffers_ptr() as usize;
-    let setup_type = setup.setup_type.clone();
+    let setup_type = setup.setup_type;
 
     let calculate_fixed_tree_handle = std::thread::spawn(move || {
         calculate_const_tree_fixed_c(
@@ -858,7 +858,7 @@ pub fn generate_recurser_aggregator_proof<F: PrimeField64>(
 
     let p_setup_addr = p_setup as usize;
     let device_buffers_addr = d_buffers as usize;
-    let setup_type = setup.setup_type.clone();
+    let setup_type = setup.setup_type;
     let calc_handle = std::thread::spawn(move || {
         calculate_const_tree_fixed_c(
             p_setup_addr as *mut c_void,
@@ -947,7 +947,7 @@ pub fn generate_recurser_aggregator_proof<F: PrimeField64>(
         d_buffers,
         &setup.const_pols_path,
         &setup.const_pols_tree_path,
-        setup.setup_type.clone().into(),
+        setup.setup_type.into(),
         false,
         recurser_id, // disambiguates recurser setups sharing (0,0,"recursive2")
         u64::MAX,    // one-off launch: reserve stream internally

--- a/proofman/src/recursion.rs
+++ b/proofman/src/recursion.rs
@@ -395,7 +395,7 @@ pub fn generate_recursive_proof<F: PrimeField64>(
     // Trace H2D is async: gate buffer reuse on the stream's commit event so a
     // concurrent take() can't overwrite `trace` mid-copy (as on the main path).
     if pctx.gpu {
-        wait_stream_commit_done_c(pctx.get_device_buffers_ptr(), stream_id);
+        wait_trace_h2d_done_c(pctx.get_device_buffers_ptr(), stream_id);
     }
     match setup.setup_type {
         ProofType::Compressor => memory_handler_recursive_witness.release_buffer_trace_compressor(trace),

--- a/proofman/src/scheduler.rs
+++ b/proofman/src/scheduler.rs
@@ -1,0 +1,394 @@
+//! Key-affinity recursive scheduler.
+//!
+//! Centralizes the witness pick + CUDA stream reservation behind one lock, tracking which key
+//! each stream holds resident (`stream_warm`) so a popular key drains on one stream instead of
+//! reloading its const-tree on every free stream. Reservation picks in three passes: reuse a
+//! warm free stream → fresh-load an unloaded key → (last resort) reload rather than idle.
+//! Resident-tree basics are filler (never starve a ready compressor on the non-recursive pool).
+//!
+//! Wrap in a `Mutex`; the reserve FFIs are non-blocking, so the lock is held only briefly.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::ffi::c_void;
+use std::sync::{Condvar, Mutex};
+
+use fields::PrimeField64;
+use proofman_common::{Proof, ProofType};
+use proofman_starks_lib_c::{reserve_best_stream_nonblock_c, reserve_stream_if_free_c};
+
+/// Warm-affinity key: launches sharing it can reuse a resident const-tree.
+type Key = (usize, usize, ProofType);
+
+/// `true` for the aggregation proof types (recursive1/recursive2), which mirror the C
+/// `aggregation` flag selecting the recursive stream pool. Compressor is not aggregation.
+fn is_aggregation(t: ProofType) -> bool {
+    t == ProofType::Recursive1 || t == ProofType::Recursive2
+}
+
+/// Recursive-stream priority: aggregate deeper first (rec2 is closer to the root than rec1).
+/// Non-recursive streams handle compressors and basics separately (see `next_nonrecursive`).
+const RECURSIVE_ORDER: [ProofType; 2] = [ProofType::Recursive2, ProofType::Recursive1];
+
+/// A single dispatch decision handed to a stream worker (chosen under the scheduler lock).
+pub enum WorkerPick<F: PrimeField64> {
+    /// A recursive/compressor witness to launch on the reserved stream.
+    Recursive(Proof<F>, u32),
+    /// A stored basic instance to launch on the reserved stream.
+    Basic(usize, u32),
+}
+
+/// Candidate keys most-preferred first: restricted to `order`'s proof types (in that priority),
+/// then backlog desc (drain big runs first → more reuse per load), then `(airgroup, air)`.
+fn candidate_keys(ready: &[(Key, usize)], order: &[ProofType]) -> Vec<Key> {
+    let mut out = Vec::new();
+    for &t in order {
+        let mut of_type: Vec<(Key, usize)> = ready.iter().copied().filter(|((_, _, kt), _)| *kt == t).collect();
+        // backlog desc, then (airgroup, air) asc
+        of_type.sort_by(|(ka, ba), (kb, bb)| bb.cmp(ba).then((ka.0, ka.1).cmp(&(kb.0, kb.1))));
+        out.extend(of_type.into_iter().map(|(k, _)| k));
+    }
+    out
+}
+
+/// Centralized key-affinity scheduler for recursive/compressor launches (+ stored basics).
+pub struct RecursiveScheduler<F: PrimeField64> {
+    /// Opaque device-buffers handle (as usize for `Send`); only handed back to the FFI.
+    d_buffers: usize,
+    /// Ready recursive/compressor witnesses, bucketed by key.
+    queues: HashMap<Key, VecDeque<Proof<F>>>,
+    /// Ready "stored" basic instances (recompute path), bucketed by `(airgroup, air)`.
+    /// Resident-in-GPU basics (skip_recalculation, pinned) never enter here.
+    basic_queue: HashMap<(usize, usize), VecDeque<usize>>,
+    /// Basic AIRs whose const-tree is resident (preallocated on-device). Held back as filler:
+    /// they load nothing, and a big resident table draining first would starve ready
+    /// compressors on the shared non-recursive streams.
+    resident_keys: HashSet<Key>,
+    /// physical stream -> key it currently holds resident (mirrors the CUDA side across
+    /// `reset(false)`). Shared across basic and recursive.
+    stream_warm: HashMap<usize, Key>,
+}
+
+// SAFETY: `d_buffers` is the opaque handle already shared across worker threads and only
+// passed back to the C FFI, never dereferenced in Rust. Other fields are Mutex-guarded.
+unsafe impl<F: PrimeField64> Send for RecursiveScheduler<F> {}
+
+impl<F: PrimeField64> RecursiveScheduler<F> {
+    pub fn new(d_buffers: *mut c_void) -> Self {
+        Self {
+            d_buffers: d_buffers as usize,
+            queues: HashMap::new(),
+            basic_queue: HashMap::new(),
+            resident_keys: HashSet::new(),
+            stream_warm: HashMap::new(),
+        }
+    }
+
+    fn d_buffers(&self) -> *mut c_void {
+        self.d_buffers as *mut c_void
+    }
+
+    pub fn push(&mut self, w: Proof<F>) {
+        let key = (w.airgroup_id, w.air_id, w.proof_type);
+        self.queues.entry(key).or_default().push_back(w);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queues.values().all(|q| q.is_empty())
+    }
+
+    fn pop_key(&mut self, key: Key) -> Option<Proof<F>> {
+        let q = self.queues.get_mut(&key)?;
+        let item = q.pop_front();
+        if q.is_empty() {
+            self.queues.remove(&key);
+        }
+        item
+    }
+
+    /// True if some physical stream currently holds `key` resident.
+    fn is_warm_somewhere(&self, key: Key) -> bool {
+        self.stream_warm.values().any(|k| *k == key)
+    }
+
+    /// Pick + reserve a stream among `order`'s proof types → `(witness, stream)`, or `None` if
+    /// none is ready / no free stream. `force_recursive` restricts the reservation to a
+    /// recursive stream. The returned stream is reserved (status=1): the caller MUST launch.
+    fn next_of_types(&mut self, order: &[ProofType], force_recursive: bool) -> Option<(Proof<F>, u32)> {
+        let ready: Vec<(Key, usize)> =
+            self.queues.iter().filter(|(_, q)| !q.is_empty()).map(|(k, q)| (*k, q.len())).collect();
+        let candidates = candidate_keys(&ready, order);
+        if candidates.is_empty() {
+            return None;
+        }
+        let (key, s) = self.pick_and_reserve(&candidates, force_recursive)?;
+        let w = self.pop_key(key).expect("candidate key non-empty");
+        Some((w, s))
+    }
+
+    /// Force-recursive stream: rec2 > rec1 (never compressor), on a recursive stream.
+    pub fn next_recursive(&mut self) -> Option<(Proof<F>, u32)> {
+        self.next_of_types(&RECURSIVE_ORDER, true)
+    }
+
+    /// Non-recursive stream, one shot: compressor > basic > rec2/rec1. Deciding here (not via two
+    /// racy gates) means a worker yields a basic only when it actually takes recursive work — no
+    /// "yield-then-fail-to-place" idle. Resident basics are filler: eligible only when nothing
+    /// recursive/compressor is queued.
+    pub fn next_nonrecursive(&mut self) -> Option<WorkerPick<F>> {
+        if let Some((w, s)) = self.next_of_types(&[ProofType::Compressor], false) {
+            return Some(WorkerPick::Recursive(w, s));
+        }
+        let allow_resident = self.is_empty();
+        if let Some((id, s)) = self.next_basic(allow_resident) {
+            return Some(WorkerPick::Basic(id, s));
+        }
+        if let Some((w, s)) = self.next_of_types(&RECURSIVE_ORDER, false) {
+            return Some(WorkerPick::Recursive(w, s));
+        }
+        None
+    }
+
+    /// Pick + reserve a stream for the next stored basic → `(instance_id, stream)`. Resident
+    /// basics are excluded unless `include_resident` (held back as filler otherwise).
+    pub fn next_basic(&mut self, include_resident: bool) -> Option<(usize, u32)> {
+        let mut ready: Vec<((usize, usize), usize)> = self
+            .basic_queue
+            .iter()
+            .filter(|(k, q)| {
+                !q.is_empty() && (include_resident || !self.resident_keys.contains(&(k.0, k.1, ProofType::Basic)))
+            })
+            .map(|(k, q)| (*k, q.len()))
+            .collect();
+        if ready.is_empty() {
+            return None;
+        }
+        // Plain key-affinity: backlog desc (drain big runs first), then key for determinism.
+        ready.sort_by(|(ka, ba), (kb, bb)| bb.cmp(ba).then(ka.cmp(kb)));
+        let candidates: Vec<Key> = ready.iter().map(|((ag, air), _)| (*ag, *air, ProofType::Basic)).collect();
+
+        let (key, s) = self.pick_and_reserve(&candidates, false)?;
+        let (ag, air, _) = key;
+        let q = self.basic_queue.get_mut(&(ag, air)).expect("candidate basic key non-empty");
+        let id = q.pop_front().expect("candidate basic key non-empty");
+        if q.is_empty() {
+            self.basic_queue.remove(&(ag, air));
+        }
+        Some((id, s))
+    }
+
+    /// Enqueue a stored basic instance for key-affinity dispatch. `resident` marks whether
+    /// this AIR's basic const-tree is preallocated on-device (→ treated as filler).
+    pub fn push_basic(&mut self, instance_id: usize, airgroup_id: usize, air_id: usize, resident: bool) {
+        if resident {
+            self.resident_keys.insert((airgroup_id, air_id, ProofType::Basic));
+        }
+        self.basic_queue.entry((airgroup_id, air_id)).or_default().push_back(instance_id);
+    }
+
+    pub fn basic_is_empty(&self) -> bool {
+        self.basic_queue.values().all(|q| q.is_empty())
+    }
+
+    /// Three-pass reservation shared by `next_of_types`/`next_basic`: (1) reuse a candidate's warm
+    /// free stream, (2) fresh-load a candidate on no stream, (3) last resort reload rather
+    /// than idle. Returns the chosen `(key, reserved stream)`, or `None` if no free stream.
+    fn pick_and_reserve(&mut self, candidates: &[Key], force_recursive: bool) -> Option<(Key, u32)> {
+        let d = self.d_buffers();
+
+        // Pass 1 — REUSE: a stream already holding this key, free right now.
+        for &key in candidates {
+            for (&s, &k) in self.stream_warm.iter() {
+                if k == key && reserve_stream_if_free_c(d, s as u32, force_recursive) {
+                    return Some((key, s as u32));
+                }
+            }
+        }
+        // Pass 2 — FRESH.
+        for &key in candidates {
+            if self.is_warm_somewhere(key) {
+                continue; // loaded somewhere → not fresh
+            }
+            if let Some(s) = self.reserve_best(key, force_recursive) {
+                return Some((key, s));
+            }
+        }
+        // Pass 3 — REDUNDANT (last resort).
+        for &key in candidates {
+            if let Some(s) = self.reserve_best(key, force_recursive) {
+                return Some((key, s));
+            }
+        }
+        None
+    }
+
+    /// Reserve the best free stream for `key` (today's C selection), recording the
+    /// assignment so future launches of `key` target this stream and stale entries for a
+    /// repurposed stream are overwritten. Returns the reserved stream or `None`.
+    fn reserve_best(&mut self, key: Key, force_recursive: bool) -> Option<u32> {
+        let (ag, air, t) = key;
+        let type_str: &'static str = t.into();
+        let s = reserve_best_stream_nonblock_c(
+            self.d_buffers(),
+            ag as u64,
+            air as u64,
+            type_str,
+            is_aggregation(t),
+            force_recursive,
+        );
+        if s == u32::MAX {
+            return None;
+        }
+        self.stream_warm.insert(s as usize, key);
+        Some(s)
+    }
+}
+
+/// Scheduler shared across the witness and stream workers: the lock plus the condvar that
+/// parks idle stream workers until new work arrives. Wrap in an `Arc` at the use site.
+pub struct SharedScheduler<F: PrimeField64> {
+    pub lock: Mutex<RecursiveScheduler<F>>,
+    pub ready: Condvar,
+}
+
+impl<F: PrimeField64> SharedScheduler<F> {
+    pub fn new(inner: RecursiveScheduler<F>) -> Self {
+        Self { lock: Mutex::new(inner), ready: Condvar::new() }
+    }
+
+    /// Push a ready recursive/compressor witness and wake a parked stream worker.
+    pub fn push(&self, w: Proof<F>) {
+        self.lock.lock().unwrap().push(w);
+        self.ready.notify_all();
+    }
+}
+
+/// Sort key for the basic-proof schedule: `priority_tier` (front-load stored / has-compressor
+/// AIRs to feed the recursive pipeline), then heaviest-per-proof first (LPT), then
+/// `(airgroup_id, air_id)` to cluster each AIR's instances contiguously for const-tree reuse.
+/// `proof_cost` is a per-AIR proxy, e.g. `(1 << n_bits) * n_cols`.
+pub fn schedule_key(
+    airgroup_id: usize,
+    air_id: usize,
+    is_stored: bool,
+    has_compressor: bool,
+    proof_cost: u64,
+) -> (u8, std::cmp::Reverse<u64>, usize, usize) {
+    let priority_tier: u8 = if is_stored && has_compressor {
+        0
+    } else if is_stored {
+        1
+    } else if has_compressor {
+        2
+    } else {
+        3
+    };
+    (priority_tier, std::cmp::Reverse(proof_cost), airgroup_id, air_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{candidate_keys, is_aggregation, Key, RECURSIVE_ORDER};
+    use proofman_common::ProofType;
+
+    const FEED_ORDER: [ProofType; 3] = [ProofType::Compressor, ProofType::Recursive2, ProofType::Recursive1];
+
+    fn k(ag: usize, air: usize, t: ProofType) -> Key {
+        (ag, air, t)
+    }
+
+    #[test]
+    fn aggregation_flag_matches_c() {
+        assert!(is_aggregation(ProofType::Recursive1));
+        assert!(is_aggregation(ProofType::Recursive2));
+        assert!(!is_aggregation(ProofType::Compressor));
+    }
+
+    #[test]
+    fn recursive_order_is_rec2_then_rec1() {
+        assert_eq!(RECURSIVE_ORDER, [ProofType::Recursive2, ProofType::Recursive1]);
+    }
+
+    #[test]
+    fn candidates_prefer_bigger_backlog_within_type() {
+        let ready = vec![(k(0, 5, ProofType::Recursive1), 2), (k(0, 2, ProofType::Recursive1), 9)];
+        let out = candidate_keys(&ready, &FEED_ORDER);
+        assert_eq!(out, vec![k(0, 2, ProofType::Recursive1), k(0, 5, ProofType::Recursive1)]);
+    }
+
+    #[test]
+    fn candidates_respect_type_priority() {
+        let ready = vec![
+            (k(0, 1, ProofType::Recursive1), 5),
+            (k(0, 2, ProofType::Compressor), 1),
+            (k(0, 3, ProofType::Recursive2), 1),
+        ];
+        let out = candidate_keys(&ready, &FEED_ORDER);
+        assert_eq!(
+            out,
+            vec![k(0, 2, ProofType::Compressor), k(0, 3, ProofType::Recursive2), k(0, 1, ProofType::Recursive1),]
+        );
+    }
+
+    #[test]
+    fn candidates_recursive_order_drops_compressor() {
+        let ready = vec![(k(0, 2, ProofType::Compressor), 9), (k(0, 1, ProofType::Recursive1), 1)];
+        let out = candidate_keys(&ready, &RECURSIVE_ORDER);
+        assert_eq!(out, vec![k(0, 1, ProofType::Recursive1)]);
+    }
+
+    #[test]
+    fn candidates_tie_break_by_airgroup_air() {
+        let ready = vec![(k(0, 7, ProofType::Recursive1), 3), (k(0, 2, ProofType::Recursive1), 3)];
+        let out = candidate_keys(&ready, &FEED_ORDER);
+        assert_eq!(out, vec![k(0, 2, ProofType::Recursive1), k(0, 7, ProofType::Recursive1)]);
+    }
+}
+
+#[cfg(test)]
+mod schedule_tests {
+    use super::schedule_key;
+    use std::cmp::Reverse;
+
+    // (airgroup, air, is_stored, has_compressor, proof_cost)
+    fn sort_ids(items: &[(usize, usize, bool, bool, u64)]) -> Vec<usize> {
+        let mut ids: Vec<usize> = (0..items.len()).collect();
+        ids.sort_by_key(|&i| {
+            let (ag, air, st, hc, cost) = items[i];
+            schedule_key(ag, air, st, hc, cost)
+        });
+        ids
+    }
+
+    #[test]
+    fn priority_tier_orders_stored_and_compressor_first() {
+        // tiers: (stored+comp)=0, (stored)=1, (comp)=2, (neither)=3
+        let items = [
+            (9, 0, false, false, 100), // tier 3
+            (8, 0, true, true, 100),   // tier 0
+            (7, 0, false, true, 100),  // tier 2
+            (6, 0, true, false, 100),  // tier 1
+        ];
+        let tiers: Vec<u8> = sort_ids(&items)
+            .iter()
+            .map(|&i| schedule_key(items[i].0, items[i].1, items[i].2, items[i].3, items[i].4).0)
+            .collect();
+        assert_eq!(tiers, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn lpt_orders_heavier_group_first_within_tier() {
+        // Same tier (neither stored nor compressor); heavier proof_cost must come first.
+        let items = [(0, 0, false, false, 50), (0, 1, false, false, 500)];
+        let ordered = sort_ids(&items);
+        assert_eq!(ordered, vec![1, 0]); // air (0,1) cost 500 before (0,0) cost 50
+    }
+
+    #[test]
+    fn key_is_reverse_on_cost() {
+        // Guards the LPT direction explicitly.
+        let hi = schedule_key(0, 0, false, false, 500);
+        let lo = schedule_key(0, 0, false, false, 50);
+        assert!(hi < lo); // higher cost sorts earlier
+        assert_eq!(hi.1, Reverse(500));
+    }
+}

--- a/proofman/src/scheduler.rs
+++ b/proofman/src/scheduler.rs
@@ -68,9 +68,9 @@ pub struct RecursiveScheduler<F: PrimeField64> {
     stream_warm: HashMap<usize, Key>,
 }
 
-// SAFETY: `d_buffers` is the opaque handle already shared across worker threads and only
-// passed back to the C FFI, never dereferenced in Rust. Other fields are Mutex-guarded.
-unsafe impl<F: PrimeField64> Send for RecursiveScheduler<F> {}
+// `Send` is derived, not asserted: `d_buffers` is stored as a `usize` (the opaque handle is only
+// ever handed back to the C FFI, never dereferenced in Rust) and `PrimeField64: Field: Send`, so
+// the auto impl covers the whole struct and the `F: Send` requirement stays compiler-checked.
 
 impl<F: PrimeField64> RecursiveScheduler<F> {
     pub fn new(d_buffers: *mut c_void) -> Self {

--- a/proofman/src/utils.rs
+++ b/proofman/src/utils.rs
@@ -842,7 +842,7 @@ pub fn load_device_setups<F: PrimeField64>(
     for (airgroup_id, air_group) in pctx.global_info.airs.iter().enumerate() {
         for (air_id, _) in air_group.iter().enumerate() {
             let setup = sctx.get_setup(airgroup_id, air_id)?;
-            let proof_type: &str = setup.setup_type.clone().into();
+            let proof_type: &str = setup.setup_type.into();
             if setup.gpu {
                 tracing::debug!(airgroup_id, air_id, proof_type, "Loading expressions setup in GPU");
             }
@@ -865,7 +865,7 @@ pub fn load_device_setups<F: PrimeField64>(
             for (air_id, _) in air_group.iter().enumerate() {
                 if pctx.global_info.get_air_has_compressor(airgroup_id, air_id) {
                     let setup = setups.sctx_compressor.as_ref().unwrap().get_setup(airgroup_id, air_id)?;
-                    let proof_type: &str = setup.setup_type.clone().into();
+                    let proof_type: &str = setup.setup_type.into();
                     if setup.gpu {
                         tracing::debug!(airgroup_id, air_id, proof_type, "Loading expressions setup in GPU");
                     }
@@ -885,7 +885,7 @@ pub fn load_device_setups<F: PrimeField64>(
         for (airgroup_id, air_group) in pctx.global_info.airs.iter().enumerate() {
             for (air_id, _) in air_group.iter().enumerate() {
                 let setup = setups.sctx_recursive1.as_ref().unwrap().get_setup(airgroup_id, air_id)?;
-                let proof_type: &str = setup.setup_type.clone().into();
+                let proof_type: &str = setup.setup_type.into();
                 if setup.gpu {
                     tracing::debug!(airgroup_id, air_id, proof_type, "Loading expressions setup in GPU");
                 }
@@ -904,7 +904,7 @@ pub fn load_device_setups<F: PrimeField64>(
         let n_airgroups = pctx.global_info.air_groups.len();
         for airgroup_id in 0..n_airgroups {
             let setup = setups.sctx_recursive2.as_ref().unwrap().get_setup(airgroup_id, 0)?;
-            let proof_type: &str = setup.setup_type.clone().into();
+            let proof_type: &str = setup.setup_type.into();
             if setup.gpu {
                 tracing::debug!(airgroup_id, air_id = 0, proof_type, "Loading expressions setup in GPU");
             }
@@ -920,7 +920,7 @@ pub fn load_device_setups<F: PrimeField64>(
         }
 
         let setup_vadcop_final = setups.setup_vadcop_final.as_ref().unwrap();
-        let proof_type: &str = setup_vadcop_final.setup_type.clone().into();
+        let proof_type: &str = setup_vadcop_final.setup_type.into();
         if setup_vadcop_final.gpu {
             tracing::debug!(airgroup_id = 0, air_id = 0, proof_type, "Loading expressions setup in GPU");
         }
@@ -935,7 +935,7 @@ pub fn load_device_setups<F: PrimeField64>(
         );
 
         let setup_vadcop_final_compressed = setups.setup_vadcop_final_compressed.as_ref().unwrap();
-        let proof_type: &str = setup_vadcop_final_compressed.setup_type.clone().into();
+        let proof_type: &str = setup_vadcop_final_compressed.setup_type.into();
         if setup_vadcop_final_compressed.gpu {
             tracing::debug!(airgroup_id = 0, air_id = 0, proof_type, "Loading expressions setup in GPU");
         }
@@ -967,7 +967,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
     for (airgroup_id, air_group) in pctx.global_info.airs.iter().enumerate() {
         for (air_id, _) in air_group.iter().enumerate() {
             let setup = sctx.get_setup(airgroup_id, air_id)?;
-            let proof_type: &str = setup.setup_type.clone().into();
+            let proof_type: &str = setup.setup_type.into();
             if setup.gpu {
                 let const_pols_path = &setup.const_pols_path;
                 tracing::debug!(airgroup_id, air_id, proof_type, "Loading const pols in GPU");
@@ -1002,7 +1002,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
             for (air_id, _) in air_group.iter().enumerate() {
                 if pctx.global_info.get_air_has_compressor(airgroup_id, air_id) {
                     let setup = setups.sctx_compressor.as_ref().unwrap().get_setup(airgroup_id, air_id)?;
-                    let proof_type: &str = setup.setup_type.clone().into();
+                    let proof_type: &str = setup.setup_type.into();
                     if setup.gpu {
                         let const_pols_path = &setup.const_pols_path;
                         tracing::debug!(airgroup_id, air_id, proof_type, "Loading const pols in GPU");
@@ -1035,7 +1035,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
         for (airgroup_id, air_group) in pctx.global_info.airs.iter().enumerate() {
             for (air_id, _) in air_group.iter().enumerate() {
                 let setup = setups.sctx_recursive1.as_ref().unwrap().get_setup(airgroup_id, air_id)?;
-                let proof_type: &str = setup.setup_type.clone().into();
+                let proof_type: &str = setup.setup_type.into();
                 if setup.gpu {
                     let const_pols_path = &setup.const_pols_path;
                     tracing::debug!(airgroup_id, air_id, proof_type, "Loading const pols in GPU");
@@ -1067,7 +1067,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
         let n_airgroups = pctx.global_info.air_groups.len();
         for airgroup_id in 0..n_airgroups {
             let setup = setups.sctx_recursive2.as_ref().unwrap().get_setup(airgroup_id, 0)?;
-            let proof_type: &str = setup.setup_type.clone().into();
+            let proof_type: &str = setup.setup_type.into();
             if setup.gpu {
                 let const_pols_path = &setup.const_pols_path;
                 tracing::debug!(airgroup_id, air_id = 0, proof_type, "Loading const pols in GPU");
@@ -1096,7 +1096,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
         }
 
         let setup_vadcop_final = setups.setup_vadcop_final.as_ref().unwrap();
-        let proof_type: &str = setup_vadcop_final.setup_type.clone().into();
+        let proof_type: &str = setup_vadcop_final.setup_type.into();
         if setup_vadcop_final.gpu {
             let const_pols_path = &setup_vadcop_final.const_pols_path;
             tracing::debug!(airgroup_id = 0, air_id = 0, proof_type, "Loading const pols in GPU");
@@ -1124,7 +1124,7 @@ pub fn load_device_const_pols<F: PrimeField64>(
         }
 
         let setup_vadcop_final_compressed = setups.setup_vadcop_final_compressed.as_ref().unwrap();
-        let proof_type: &str = setup_vadcop_final_compressed.setup_type.clone().into();
+        let proof_type: &str = setup_vadcop_final_compressed.setup_type.into();
         if setup_vadcop_final_compressed.gpu {
             let const_pols_path = &setup_vadcop_final_compressed.const_pols_path;
             tracing::debug!(airgroup_id = 0, air_id = 0, proof_type, "Loading const pols in GPU");

--- a/proofman/src/utils.rs
+++ b/proofman/src/utils.rs
@@ -1303,22 +1303,3 @@ pub fn get_vadcop_final_proof_vkey(proving_key_path: &Path, compressed: bool) ->
 
     Ok(contents.chunks_exact(8).map(|c| u64::from_le_bytes(c.try_into().unwrap())).collect())
 }
-
-pub fn deterministic_shuffle<T>(slice: &mut [T], seed: u64) {
-    let len = slice.len();
-    if len <= 1 {
-        return;
-    }
-
-    const A: u64 = 1103515245;
-    const C: u64 = 12345;
-    const M: u64 = 1 << 31;
-
-    let mut state = seed;
-
-    for i in (1..len).rev() {
-        state = state.wrapping_mul(A).wrapping_add(C) % M;
-        let j = (state as usize) % (i + 1);
-        slice.swap(i, j);
-    }
-}

--- a/provers/starks-lib-c/bindings_starks.rs
+++ b/provers/starks-lib-c/bindings_starks.rs
@@ -64,7 +64,7 @@ extern "C" {
 
     pub fn unregister_host_memory(ptr: *mut ::std::os::raw::c_void);
 
-    pub fn wait_stream_commit_done(d_buffers: *mut ::std::os::raw::c_void, stream_id: u64);
+    pub fn wait_trace_h2d_done(d_buffers: *mut ::std::os::raw::c_void, stream_id: u64);
 
     pub fn set_memory_expressions(pStarkInfo: *mut ::std::os::raw::c_void, nTmp1: u64, nTmp3: u64);
     

--- a/provers/starks-lib-c/bindings_starks.rs
+++ b/provers/starks-lib-c/bindings_starks.rs
@@ -95,7 +95,7 @@ extern "C" {
     );
     
     pub fn get_const_tree_size(pStarkInfo: *mut ::std::os::raw::c_void) -> u64;
-    
+
     pub fn get_const_size(pStarkInfo: *mut ::std::os::raw::c_void) -> u64;
 
     pub fn calculate_words_per_row(
@@ -444,7 +444,23 @@ extern "C" {
         proofType: *mut ::std::os::raw::c_char,
         force_recursive_stream: bool,
         recurser_id: *mut ::std::os::raw::c_char,
+        streamId_: u64,
     ) -> u64;
+
+    pub fn reserve_best_stream_nonblock(
+        d_buffers_: *mut ::std::os::raw::c_void,
+        airgroupId: u64,
+        airId: u64,
+        proofType: *mut ::std::os::raw::c_char,
+        recursive: bool,
+        force_recursive: bool,
+    ) -> u32;
+
+    pub fn reserve_stream_if_free(
+        d_buffers_: *mut ::std::os::raw::c_void,
+        streamId: u32,
+        force_recursive: bool,
+    ) -> u32;
 
     pub fn calculate_const_tree_fixed(
         pSetupCtx_: *mut ::std::os::raw::c_void,

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -1035,6 +1035,7 @@ pub fn gen_recursive_proof_c(
     proof_type: &str,
     force_recursive_stream: bool,
     recurser_id: &str,
+    stream_id: u64,
 ) -> u64 {
     let proof_file_name = CString::new(proof_file).unwrap();
     let proof_file_ptr = proof_file_name.as_ptr() as *mut std::os::raw::c_char;
@@ -1071,8 +1072,29 @@ pub fn gen_recursive_proof_c(
             proof_type_ptr,
             force_recursive_stream,
             recurser_id_ptr,
+            stream_id,
         )
     }
+}
+
+/// Scheduler: reserve the best free stream for this key without blocking.
+/// Returns `u32::MAX` when nothing is free right now (caller retries).
+pub fn reserve_best_stream_nonblock_c(
+    d_buffers: *mut c_void,
+    airgroup_id: u64,
+    air_id: u64,
+    proof_type: &str,
+    recursive: bool,
+    force_recursive: bool,
+) -> u32 {
+    let proof_type_name = CString::new(proof_type).unwrap();
+    let proof_type_ptr = proof_type_name.as_ptr() as *mut std::os::raw::c_char;
+    unsafe { reserve_best_stream_nonblock(d_buffers, airgroup_id, air_id, proof_type_ptr, recursive, force_recursive) }
+}
+
+/// Scheduler warm fast path: reserve `stream_id` iff it is free right now. Returns true on success.
+pub fn reserve_stream_if_free_c(d_buffers: *mut c_void, stream_id: u32, force_recursive: bool) -> bool {
+    unsafe { reserve_stream_if_free(d_buffers, stream_id, force_recursive) != 0 }
 }
 
 pub fn calculate_const_tree_fixed_c(

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -204,9 +204,9 @@ pub fn unregister_host_memory_c(ptr: *mut c_void) {
 /// shared trace buffer whose async H2D copy rode that stream can be safely
 /// reused. No-op on the CPU backend (the symbol is GPU-only; callers gate on
 /// `pctx.gpu`).
-pub fn wait_stream_commit_done_c(d_buffers: *mut c_void, stream_id: u64) {
+pub fn wait_trace_h2d_done_c(d_buffers: *mut c_void, stream_id: u64) {
     unsafe {
-        wait_stream_commit_done(d_buffers, stream_id);
+        wait_trace_h2d_done(d_buffers, stream_id);
     }
 }
 


### PR DESCRIPTION
Introduce proofman/src/scheduler.rs and thread a reserved_stream parameter through the recursive proof pipeline. Scheduler-driven launches pass a reserved stream id; one-off launches (outer aggregation, vadcop_final, recursers) pass u64::MAX to select a stream internally. Extends the C FFI (gen_recursive_proof_c) and CUDA backend to accept the reserved stream, and makes ProofType Copy/Eq/Hash for use as a scheduler key.

Small H2D copies (publics/aux_values in gen_proof_gpu, initialize_instance_gpu, gen_recursive_proof_gpu) stage into the per-stream pinned_aux_values buffer and issue a plain async cudaMemcpyAsync, dropping the blocking cudaStreamSynchronize; reuse gated by the existing end_event.