### PR TITLE
new feature to compact/reduce fixeds used by virtual tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node tooling dependencies for proofman proving-key generation",
   "dependencies": {
     "circomlib": "^2.0.5",
-    "pil2-compiler": "https://github.com/0xPolygonHermez/pil2-compiler.git#develop-0.12.0",
+    "pil2-compiler": "https://github.com/0xPolygonHermez/pil2-compiler.git#develop-0.13.0",
     "snarkjs": "0.7.6"
   }
 }

--- a/pil2-components/lib/std/pil/std_tools.pil
+++ b/pil2-components/lib/std/pil/std_tools.pil
@@ -26,6 +26,14 @@ function get_L1(): expr {
     return air.__L1__;
 }
 
+// Shared row index column, i.e. [0, 1, ..., N-1]. Declared only once per air.
+function get_ROW_INDEX(): expr {
+    if (!defined(air.__ROW_INDEX__)) {
+        col fixed air.__ROW_INDEX__ = [0..(N-1)];
+    }
+    return air.__ROW_INDEX__;
+}
+
 /**
  * Enforces that a selector is binary, i.e. sel ∈ {0, 1}.
  *

--- a/pil2-components/lib/std/pil/std_virtual_table.pil
+++ b/pil2-components/lib/std/pil/std_virtual_table.pil
@@ -595,6 +595,113 @@ function pack_tables() {
     }
 }
 
+/**
+ * Initializes the per-air registry of already materialized columns used by simplify_virtual_fixed.
+ *
+ * @param size Upper bound on the number of columns to simplify (one registry slot each).
+ */
+function init_simplify_virtual_fixed(const int size) {
+    int air.signatures_count = 0;
+    int air.signatures[size][2];
+    expr air.signatures_fixed[size];
+    if (DEBUG_MODE_PRINT) {
+        string air.signatures_name[size];
+    }
+}
+
+/**
+ * Replaces a virtual (uncommitted) fixed column by the cheapest expression that reproduces its
+ * contents: a constant, an offset of the row index, an already materialized column (optionally
+ * rotated) or, as a last resort, a newly materialized fixed column.
+ *
+ * The contents are snapshotted here, so the caller can safely refill fixed_col afterwards.
+ *
+ * @param fixed_col The virtual column to simplify.
+ * @param col_name  Name of the column if it ends up being materialized.
+ * @return          An expression equivalent to fixed_col.
+ */
+function simplify_virtual_fixed(expr fixed_col, string col_name) : expr {
+    const int aid = Tables.analyze(fixed_col);
+    const int col_type = Tables.get_analyzed_type(aid);
+    const int signature = Tables.get_analyzed_signature(aid);
+    const int comparative_signature = Tables.get_analyzed_comparative_signature(aid);
+
+    if (DEBUG_MODE_PRINT) {
+        println(`[Debug] Virtual ${col_name} type ${col_type} signature ${signature} comparative_signature ${comparative_signature}`);
+    }
+
+    // Column type 1: constant column, we can prove it directly
+    if (col_type == 1) {
+        return Tables.get_value(fixed_col, 0);
+    }
+
+    // Column type 2: sequential column, i.e. a constant step between consecutive rows, so we can
+    // express it as an affine combination of the row index: value_0 + delta·ROW_INDEX
+    if (col_type == 2) {
+        const int params[2] = Tables.get_analyzed_params(aid);   // [first_value, delta]
+        const int value_0 = params[0];
+        const int delta = params[1];
+        const expr ROW_INDEX = get_ROW_INDEX();
+
+        // The step is not necessarily 1, and it can also be negative
+        expr linear_col = ROW_INDEX;
+        if (delta != 1) {
+            linear_col = delta * ROW_INDEX;
+        }
+        if (value_0 == 0) {
+            return linear_col;
+        }
+        return linear_col + value_0;
+    }
+
+    // Search if exist a previous column compatible with this one (equals without or with offset)
+    int index = 0;
+    while (index < air.signatures_count) {
+        if (air.signatures[index][0] == signature) {
+            if (Tables.are_equals(air.signatures_fixed[index], 0, fixed_col, 0)) {
+                if (DEBUG_MODE_PRINT) {
+                    println(`[Debug] Found matching ${col_name} and ${air.signatures_name[index]}`);
+                }
+                return air.signatures_fixed[index];
+            }
+        }
+        if (air.signatures[index][1] == comparative_signature) {
+            int row_offset = Tables.compatible_offset(air.signatures_fixed[index], 0, fixed_col, 0);
+            if (row_offset != -1) {
+                // The match is fixed_col[i] == registered[(i + row_offset) mod N] + value_offset,
+                // so the value offset is taken between row 0 of this column and row row_offset of
+                // the registered one
+                int reference_value = Tables.get_value(air.signatures_fixed[index], row_offset);
+                int current_value = Tables.get_value(fixed_col, 0);
+                int value_offset = current_value - reference_value;
+                if (DEBUG_MODE_PRINT) {
+                    println(`[Debug] Found matching ${col_name} and ${air.signatures_name[index]} with row_offset ${row_offset} value_offset ${value_offset}`);
+                }
+                if (value_offset == 0) {
+                    return air.signatures_fixed[index]'(row_offset);
+                }
+                return air.signatures_fixed[index]'(row_offset) + value_offset;
+            }
+        }
+        ++index;
+    }
+
+    // No candidate found, materialize the column and register it for the next ones
+    col fixed air.`${col_name}`;
+    expr final_col = air.`${col_name}`;
+    Tables.copy(fixed_col, 0, final_col, 0, N);
+
+    air.signatures[air.signatures_count][0] = signature;
+    air.signatures[air.signatures_count][1] = comparative_signature;
+    air.signatures_fixed[air.signatures_count] = final_col;
+    if (DEBUG_MODE_PRINT) {
+        air.signatures_name[air.signatures_count] = col_name;
+    }
+    ++air.signatures_count;
+
+    return final_col;
+}
+
 airtemplate VirtualTable(const int N, const int tables[], const int num_tables, const int total_height, const int total_area,
                          const int uids[][], const int table_idxs[][], const int widths[], const int lens[],
                          const int num_groups, const int vt_idx, const int est_cost,
@@ -605,9 +712,14 @@ airtemplate VirtualTable(const int N, const int tables[], const int num_tables, 
         sum_widths += widths[i];
     }
 
-    col fixed UID[num_groups];
-    col fixed column[sum_widths];
+    // Virtual (uncommitted) columns: they are only used to build the contents, the columns that
+    // actually reach the air are the ones decided by simplify_virtual_fixed. A single UID buffer
+    // is enough since every group snapshots it before the next one refills it.
+    col fixed virtual(N) tmp_UID;
+    col fixed virtual(N) column[sum_widths];
+
     col witness multiplicity[num_groups];
+    init_simplify_virtual_fixed(num_groups + sum_widths);
 
     // Issue hint information
     int flatten_table_ids[num_tables];
@@ -654,7 +766,7 @@ airtemplate VirtualTable(const int N, const int tables[], const int num_tables, 
             const int height_remaining = height - row_start;
             const int N_remaining = N - group_row_offset;
             const int h = (height_remaining <= N_remaining) ? height_remaining : N_remaining;
-            Tables.fill(uid, UID[i], group_row_offset, h);
+            Tables.fill(uid, tmp_UID, group_row_offset, h);
 
             // Fill the table columns
             for (int l = 0; l < width; l++) {
@@ -672,6 +784,13 @@ airtemplate VirtualTable(const int N, const int tables[], const int num_tables, 
             }
         }
 
+        // Since tmp_UID is shared by all the groups, the rows this group does not fill must be
+        // cleared: otherwise they would keep the UID of the previous group, whose rows are already
+        // padded with zeros in the table columns
+        if (group_row_offset < N) {
+            Tables.fill(0, tmp_UID, group_row_offset, N - group_row_offset);
+        }
+
         int uids_to_prove[group_len];
         for (int j = 0; j < group_len; j++) {
             uids_to_prove[j] = uids[i][j];
@@ -679,11 +798,13 @@ airtemplate VirtualTable(const int N, const int tables[], const int num_tables, 
 
         expr cols_to_prove[group_width];
         for (int j = 0; j < group_width; j++) {
-            cols_to_prove[j] = column[col_offset + j];
+            cols_to_prove[j] = simplify_virtual_fixed(column[col_offset + j], `COL_${i}_${col_offset}_${j}`);
         }
 
+        expr UID = simplify_virtual_fixed(tmp_UID, `UID_${i}`);
+
         // Perform the proving
-        lookup_proves_dynamic(opids: uids_to_prove, busid: UID[i], expressions: cols_to_prove, mul: multiplicity[i]);
+        lookup_proves_dynamic(opids: uids_to_prove, busid: UID, expressions: cols_to_prove, mul: multiplicity[i]);
 
         // Update the column offset
         col_offset += group_width;

--- a/pil2-components/test/direct_update/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/direct_update/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "61f34e7ad927950b2db58f351b8c381495da8ed13b97da220bb17edb1e2e0cde";
+pub const PILOUT_HASH: &str = "059cbb8670da626606653354f4c617b715443b6cde710589361fdd0b495c72c8";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/pil2-components/test/lookup/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/lookup/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "4831e8aaef13109afbf2ba8df1037225b72500150fb218dbe212b77635fab307";
+pub const PILOUT_HASH: &str = "693b265a5595d5897983539b1934744b0961c960579be32f978c5b8fee3a8396";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/pil2-components/test/permutation/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/permutation/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "99c206c513074537f78dae301e5084536fa108c001fe7a76383d6588dfdbabc3";
+pub const PILOUT_HASH: &str = "6a92f17ae0cad0fc54bc58e5ec0ce195c771bda10e22404b7f4d50ce054f0102";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/pil2-components/test/virtual_tables/rs/src/pil_helpers/traces.rs
+++ b/pil2-components/test/virtual_tables/rs/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "50f3ef9317681d4f56eae05e3c8c3059d58607716af3b80fe0007ae2d0b2a29b";
+pub const PILOUT_HASH: &str = "380e6935ccf5e40bbc493001d06e841b2e34fe3ab8d5e498ec53030ed40e48f2";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -164,7 +164,7 @@ trace_row!(SpecifiedRangesTraceRow<F> {
 pub type SpecifiedRangesTrace<F> = GenericTrace<SpecifiedRangesTraceRow<F>, 64, 0, 9>;
 
 trace_row!(VirtualTableVirtualTables0FixedRow<F> {
- UID: [F; 3], column: [F; 10], __L1__: F,
+ COL_0_0_0: F, COL_0_0_1: F, UID_0: F, __ROW_INDEX__: F, COL_2_4_0: F, COL_2_4_1: F, COL_2_4_2: F, COL_2_4_3: F, UID_2: F, __L1__: F,
 });
 pub type VirtualTableVirtualTables0Fixed<F> = GenericTrace<VirtualTableVirtualTables0FixedRow<F>, 512, 0, 10>;
 
@@ -175,7 +175,7 @@ trace_row!(VirtualTableVirtualTables0TraceRow<F> {
 pub type VirtualTableVirtualTables0Trace<F> = GenericTrace<VirtualTableVirtualTables0TraceRow<F>, 512, 0, 10>;
 
 trace_row!(VirtualTableVirtualTables1FixedRow<F> {
- UID: [F; 5], column: [F; 17], __L1__: F,
+ __ROW_INDEX__: F, COL_4_12_0: F, COL_4_12_3: F, UID_4: F, __L1__: F,
 });
 pub type VirtualTableVirtualTables1Fixed<F> = GenericTrace<VirtualTableVirtualTables1FixedRow<F>, 8192, 0, 11>;
 
@@ -186,7 +186,7 @@ trace_row!(VirtualTableVirtualTables1TraceRow<F> {
 pub type VirtualTableVirtualTables1Trace<F> = GenericTrace<VirtualTableVirtualTables1TraceRow<F>, 8192, 0, 11>;
 
 trace_row!(VirtualTableVirtualTables2FixedRow<F> {
- UID: [F; 5], column: [F; 7], __L1__: F,
+ __ROW_INDEX__: F, COL_4_4_0: F, UID_4: F, __L1__: F,
 });
 pub type VirtualTableVirtualTables2Fixed<F> = GenericTrace<VirtualTableVirtualTables2FixedRow<F>, 16384, 0, 12>;
 


### PR DESCRIPTION
# Reduce the committed fixed columns of the virtual tables

## Summary

The `VirtualTable` airtemplate used to commit one fixed column per UID group plus one per packed
table column, regardless of their contents. Most of those columns are trivially reproducible: a
single repeated UID, a plain row counter, or a copy (sometimes rotated or shifted) of another
column already present in the same air.

This PR builds the packed contents in **virtual (uncommitted) columns** and then, per column,
commits only what cannot be expressed as something cheaper. 

## What changes

### `pil2-components/lib/std/pil/std_virtual_table.pil`

- `UID[num_groups]` and `column[sum_widths]` are now `col fixed virtual(N)`, so they are just
  scratch buffers used to assemble the contents. A single `tmp_UID` buffer is enough because every
  group snapshots it before the next one refills it; the rows a group does not fill are cleared so
  they do not inherit the previous group's UID.
- New `simplify_virtual_fixed(fixed_col, col_name)`: analyzes a virtual column once
  (`Tables.analyze`) and returns the cheapest expression that reproduces it, committing a real
  fixed column only as a last resort. Cases, in order:

  | Detected pattern | Returned expression | Cost |
  |---|---|---|
  | constant | `value_0` | none |
  | sequential (constant step) | `value_0 + delta·ROW_INDEX` | shares `__ROW_INDEX__` |
  | equal to a registered column | `K` | none |
  | rotation and/or value shift of a registered column | `K'(row_offset) + value_offset` | none |
  | anything else | newly committed `col fixed` | 1 column |

- New `init_simplify_virtual_fixed(size)`: per-air registry of the columns already committed,
  keyed by their exact and comparative signatures.

The exact signature (`Tables.get_analyzed_signature`) gates the row-by-row equality check, while
the comparative one (`Tables.get_analyzed_comparative_signature`, invariant to cyclic rotation and
to a value shift) gates the `Tables.compatible_offset` search. Both are needed: the exact signature
changes with any rotation or shift, so on its own it would never let the offset search run.

For a match at `row_offset = r`, the builtin guarantees
`fixed_col[i] == registered[(i + r) mod N] + value_offset`, so the value offset is taken between
row `0` of the new column and row `r` of the registered one.

### `pil2-components/lib/std/pil/std_tools.pil`

- New `get_ROW_INDEX()`: lazily declares a shared `__ROW_INDEX__ = [0..(N-1)]` fixed column, in the
  same style as `get_L1()`. It is only created if some column turns out to be sequential.

### `pil2-components/test/*/rs/src/pil_helpers/traces.rs`

Regenerated. The fixed rows of the `VirtualTable` airs now list the columns that survive the
simplification instead of the full `UID[]` / `column[]` arrays:

| Air | Before | After |
|---|---|---|
| `VirtualTableVirtualTables0` | `UID: [F; 3], column: [F; 10], __L1__` (14) | `COL_0_0_0, COL_0_0_1, UID_0, __ROW_INDEX__, COL_2_4_0..3, UID_2, __L1__` (10) |
| `VirtualTableVirtualTables1` | `UID: [F; 5], column: [F; 17], __L1__` (23) | `__ROW_INDEX__, COL_4_12_0, COL_4_12_3, UID_4, __L1__` (5) |
| `VirtualTableVirtualTables2` | `UID: [F; 5], column: [F; 7], __L1__` (13) | `__ROW_INDEX__, COL_4_4_0, UID_4, __L1__` (4) |

Witness columns and air sizes are unchanged. `PILOUT_HASH` is updated in the four affected tests.

### `package.json`

`pil2-compiler` bumped to `develop-0.13.0`, which provides the builtins this PR relies on:
`Tables.analyze`, `get_analyzed_type`, `get_analyzed_params`, `get_analyzed_signature`,
`get_analyzed_comparative_signature`, `get_value`, `are_equals`, `compatible_offset`, plus the
`col fixed virtual(N)` declaration.

## Verification

- `virtual_tables.pil` compiles with no errors and `pil2-compiler/tools/audit.js` passes on the
  resulting pilout.
- The generated bus expressions were inspected in the audit hints: constant UIDs collapse to
  literals (`busid: 6`, `busid: 101`), sequential columns to `__ROW_INDEX__ + k`, and a descending
  table to `-1 * __ROW_INDEX__ + 767`. Repeated columns inside a group collapse to a single one
  (`COL_2_4_3` reused three times).
- Targeted harness over `simplify_virtual_fixed` covering the four cases, checked row by row:
  - identical column → reuses the registered one,
  - rotation 3 with shift +10 → `VA'(3) + 10`,
  - shift only → `VA + 3`,
  - rotation 2 with negative shift → `VA'(2) - 10`.
- Cleared UID tails verified on the test: the last group of each virtual table leaves 12, 8144 and
  16352 unfilled rows respectively, all of them at 0 instead of carrying the previous group's UID.

## Notes for reviewers

- The soundness-relevant bit is the tail clearing: since `tmp_UID` is shared across groups, an
  uncleared tail would publish rows with a valid UID of another group and all-zero values, whose
  multiplicity is prover-supplied.
- `simplify_virtual_fixed` takes the column as `expr`, so all reads go through `Tables.get_value`.
- The working tree also carries an unrelated `pil2-stark/external/sppark` submodule bump and an
  untracked `pil2-stark/.simd_stamp`; they should be dropped from this PR.
