### PR TITLE
Add indexed (compact) cm1 trace-row variant with CPU/GPU unpack

### DIFF
--- a/common/src/packed_info.rs
+++ b/common/src/packed_info.rs
@@ -1,12 +1,16 @@
 use std::os::raw::c_void;
 use serde::Serialize;
 
+/// FFI mirror of the C++ `PackedInfo` (starks_api.hpp). Field order MUST match.
 #[derive(Debug)]
 #[repr(C)]
 pub struct PackedInfoFFI {
     pub is_packed: bool,
     pub num_packed_words: u64,
     pub unpack_info: *mut u64, // raw pointer for C++
+    pub col_source: *const u8, // per column: 0 = row, 1 = table; null if not indexed
+    pub index_bits: u64,
+    pub words_per_entry: u64,
 }
 
 impl PackedInfoFFI {
@@ -21,11 +25,29 @@ pub struct PackedInfo {
     pub is_packed: bool,
     pub num_packed_words: u64,
     pub unpack_info: Vec<u64>,
+    /// Per column source (0 = compact row, 1 = instruction table); empty if not indexed.
+    pub col_source: Vec<u8>,
+    /// Width of the compact row's leading instruction-index header (bits).
+    pub index_bits: u64,
+    /// u64 words per instruction-table entry.
+    pub words_per_entry: u64,
 }
 
 impl PackedInfo {
     pub fn new(is_packed: bool, num_packed_words: u64, unpack_info: Vec<u64>) -> Self {
-        Self { is_packed, num_packed_words, unpack_info }
+        Self { is_packed, num_packed_words, unpack_info, ..Default::default() }
+    }
+
+    /// Attach the indexed-variant descriptor; `num_packed_words` must be the compact row size.
+    pub fn with_indexed(mut self, col_source: Vec<u8>, index_bits: u64, words_per_entry: u64) -> Self {
+        self.col_source = col_source;
+        self.index_bits = index_bits;
+        self.words_per_entry = words_per_entry;
+        self
+    }
+
+    pub fn is_indexed(&self) -> bool {
+        !self.col_source.is_empty()
     }
 
     pub fn as_ffi(&self) -> PackedInfoFFI {
@@ -33,6 +55,10 @@ impl PackedInfo {
             is_packed: self.is_packed,
             num_packed_words: self.num_packed_words,
             unpack_info: self.unpack_info.as_ptr() as *mut u64,
+            // Empty Vec::as_ptr() is dangling-but-non-null; C++ null-checks this, so pass real null.
+            col_source: if self.col_source.is_empty() { std::ptr::null() } else { self.col_source.as_ptr() },
+            index_bits: self.index_bits,
+            words_per_entry: self.words_per_entry,
         }
     }
 }

--- a/common/src/trace.rs
+++ b/common/src/trace.rs
@@ -22,6 +22,16 @@ pub trait TraceRow: Copy + Default + Send {
     const IS_PACKED: bool;
 }
 
+/// Compile-time discriminator for the indexed (compact) row variant from `indexed_trace_row!`,
+/// plus its index setter. Defaulted (`false` / no-op) so full row types satisfy it for free;
+/// the generated indexed row overrides both. Lets a generic filler compile out the
+/// instruction-derived columns (`if !R::IS_INDEXED`) and set the index uniformly.
+pub trait IndexedFill {
+    const IS_INDEXED: bool = false;
+    #[inline(always)]
+    fn set_row_index(&mut self, _index: u32) {}
+}
+
 #[derive(Default)]
 pub struct GenericTrace<
     R,

--- a/macros-test/tests/indexed.rs
+++ b/macros-test/tests/indexed.rs
@@ -1,0 +1,52 @@
+// Coverage for indexed_trace_row!: the compact-row/instruction-table split, COL_SOURCE
+// (which the C++ unpack consumes verbatim), and the @instr setters being no-ops.
+use fields::{Goldilocks, PrimeField64};
+use proofman_common::trace::IndexedFill;
+use proofman_macros::{indexed_trace_row, trace_row};
+
+trace_row!(
+    IxRow<F> {
+        a: u16,
+        op: u8,
+        b: ubit(12),
+        flag: bit,
+    }
+);
+
+indexed_trace_row!(
+    IxRow<F> {
+        a: u16,
+        op: u8 @instr,
+        b: ubit(12),
+        flag: bit @instr,
+    }
+);
+
+#[test]
+fn compiles_and_routes() {
+    // COL_SOURCE must mark op and flag as table-sourced.
+    assert_eq!(IxRowPackedIndexed::<Goldilocks>::COL_SOURCE, [0u8, 1, 0, 1]);
+    assert_eq!(IxRowPackedIndexed::<Goldilocks>::INDEX_BITS, 32);
+    assert!(<IxRowPackedIndexed<Goldilocks> as IndexedFill>::IS_INDEXED);
+    assert!(!<IxRow<Goldilocks> as IndexedFill>::IS_INDEXED);
+
+    // Compact row: index(32) + a(16) + b(12) = 60 bits -> 1 word.
+    assert_eq!(IxRowPackedIndexed::<Goldilocks>::PACKED_BITS, 60);
+    assert_eq!(IxRowPackedIndexed::<Goldilocks>::PACKED_WORDS, 1);
+    // Table entry: op(8) + flag(1) = 9 bits -> 1 word.
+    assert_eq!(IxRowInstrTable::<Goldilocks>::PACKED_BITS, 9);
+
+    // Trait routing: runtime setters land, @instr setters are no-ops.
+    let mut r = IxRowPackedIndexed::<Goldilocks>::default();
+    IxRowOps::set_a(&mut r, 0xBEEF);
+    IxRowOps::set_b(&mut r, 0xABC);
+    IxRowOps::set_op(&mut r, 7);
+    IxRowOps::set_flag(&mut r, true);
+    r.set_row_index(5);
+
+    assert_eq!(IxRowOps::get_a(&r), 0xBEEF);
+    assert_eq!(IxRowOps::get_b(&r), 0xABC);
+    assert_eq!(IxRowOps::get_op(&r), 0, "@instr setter must be a no-op");
+    assert!(!IxRowOps::get_flag(&r), "@instr setter must be a no-op");
+    assert_eq!(r.get_index(), 5);
+}

--- a/macros-test/tests/indexed.rs
+++ b/macros-test/tests/indexed.rs
@@ -22,13 +22,18 @@ indexed_trace_row!(
     }
 );
 
+// The indexed discriminator is what a generic filler branches on to compile out the
+// instruction-derived columns, so assert it where a regression is a build failure
+// rather than a test failure (same style as the constant checks in src/lib.rs).
+const _: () = assert!(<IxRowPackedIndexed<Goldilocks> as IndexedFill>::IS_INDEXED);
+const _: () = assert!(!<IxRow<Goldilocks> as IndexedFill>::IS_INDEXED);
+const _: () = assert!(!<IxRowPacked<Goldilocks> as IndexedFill>::IS_INDEXED);
+
 #[test]
 fn compiles_and_routes() {
     // COL_SOURCE must mark op and flag as table-sourced.
     assert_eq!(IxRowPackedIndexed::<Goldilocks>::COL_SOURCE, [0u8, 1, 0, 1]);
     assert_eq!(IxRowPackedIndexed::<Goldilocks>::INDEX_BITS, 32);
-    assert!(<IxRowPackedIndexed<Goldilocks> as IndexedFill>::IS_INDEXED);
-    assert!(!<IxRow<Goldilocks> as IndexedFill>::IS_INDEXED);
 
     // Compact row: index(32) + a(16) + b(12) = 60 bits -> 1 word.
     assert_eq!(IxRowPackedIndexed::<Goldilocks>::PACKED_BITS, 60);

--- a/macros/src/indexed_trace_row.rs
+++ b/macros/src/indexed_trace_row.rs
@@ -82,6 +82,15 @@ pub fn indexed_trace_row_entrypoint(input: proc_macro::TokenStream) -> proc_macr
     let mut runtime_fields = vec![TraceField { name: format_ident!("index"), ty: BitType::Bit(INDEX_BITS as usize) }];
     let mut table_fields = vec![];
     for (f, instr) in &inp.fields {
+        // Rejected here rather than deeper in expansion so the user gets a spanned
+        // compile error instead of a proc-macro panic backtrace. Array columns would
+        // need per-element source flags; COL_SOURCE is per output column, so an
+        // `@instr` array has no representation today.
+        if *instr && is_array(&f.ty) {
+            return syn::Error::new_spanned(&f.name, "indexed_trace_row!: `@instr` unsupported on array columns")
+                .to_compile_error()
+                .into();
+        }
         if *instr {
             table_fields.push(f.clone());
         } else {
@@ -164,7 +173,9 @@ fn indexed_ops_impl(
                 }
             }
         } else if is_array(&f.ty) {
-            assert!(!*instr, "indexed_trace_row!: `@instr` unsupported on array column `{}`", f.name);
+            // `@instr` on an array is rejected with a spanned error in the entrypoint,
+            // so by here every array column is runtime-sourced.
+            debug_assert!(!*instr);
             let (bits, dims, _) = collect_dimensions(&f.ty);
             let rust_ty = rust_type_for_bits(bits);
             let idx_args: Vec<Ident> = (0..dims.len()).map(|i| format_ident!("i{}", i)).collect();

--- a/macros/src/indexed_trace_row.rs
+++ b/macros/src/indexed_trace_row.rs
@@ -1,0 +1,209 @@
+// The compact/indexed companion for an already-defined trace row. From
+// `indexed_trace_row!(RowName<F> { <fields, some tagged `@instr`> })` it emits, beside the
+// existing `RowName` / `RowNameOps` (from `trace_row!`):
+//   - `RowNamePackedIndexed` : packed row = leading `index: u32` + the untagged (runtime) cols
+//   - `RowNameInstrTable`    : packed row of just the `@instr` (instruction-derived) cols
+//   - impl `RowNameOps` for `RowNamePackedIndexed` : runtime setters forward, `@instr` setters no-op
+//   - impl `IndexedFill` for the row family
+//   - `RowNamePackedIndexed::{COL_SOURCE, INDEX_BITS}`
+// It does NOT redefine `RowName` or `RowNameOps`; those come from the pristine pil-helpers.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::{braced, parse_macro_input, Ident, Result, Token};
+
+use crate::packed_row::packed_row_impl;
+use crate::trace_row::{
+    collect_dimensions, compute_total_bits, contains_generic, is_array, parse_bit_type, BitType, TraceField,
+};
+use crate::trait_row::{generic_tokens, rust_type_for_bits};
+
+/// Fixed width of the compact row's leading instruction-index header.
+const INDEX_BITS: u64 = 32;
+
+struct IndexedInput {
+    name: Ident,
+    generic: Option<Ident>,
+    /// Each field with a flag: `true` = `@instr` (instruction-derived / table column).
+    fields: Vec<(TraceField, bool)>,
+}
+
+impl Parse for IndexedInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let name: Ident = input.parse()?;
+        let generic = if input.peek(Token![<]) {
+            let _lt: Token![<] = input.parse()?;
+            let ident: Ident = input.parse()?;
+            let _gt: Token![>] = input.parse()?;
+            Some(ident)
+        } else {
+            None
+        };
+
+        let content;
+        let _brace = braced!(content in input);
+
+        let mut fields = vec![];
+        while !content.is_empty() {
+            let name: Ident = content.parse()?;
+            let _colon: Token![:] = content.parse()?;
+            let ty = parse_bit_type(&content, generic.as_ref())?;
+            let mut instr = false;
+            if content.peek(Token![@]) {
+                let _at: Token![@] = content.parse()?;
+                let tag: Ident = content.parse()?;
+                if tag == "instr" {
+                    instr = true;
+                } else {
+                    return Err(syn::Error::new_spanned(tag, "unknown tag; expected `@instr`"));
+                }
+            }
+            fields.push((TraceField { name, ty }, instr));
+            if content.peek(Token![,]) {
+                let _comma: Token![,] = content.parse()?;
+            }
+        }
+        Ok(IndexedInput { name, generic, fields })
+    }
+}
+
+pub fn indexed_trace_row_entrypoint(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let inp = parse_macro_input!(input as IndexedInput);
+
+    let name = &inp.name;
+    let generic = &inp.generic;
+    let trait_name = format_ident!("{}Ops", name);
+    let packed_name = format_ident!("{}Packed", name);
+    let indexed_name = format_ident!("{}PackedIndexed", name);
+    let table_name = format_ident!("{}InstrTable", name);
+
+    // Compact runtime subset: leading index header, then the untagged columns in order.
+    let mut runtime_fields = vec![TraceField { name: format_ident!("index"), ty: BitType::Bit(INDEX_BITS as usize) }];
+    let mut table_fields = vec![];
+    for (f, instr) in &inp.fields {
+        if *instr {
+            table_fields.push(f.clone());
+        } else {
+            runtime_fields.push(f.clone());
+        }
+    }
+
+    let indexed_struct = packed_row_impl(&indexed_name, generic, &runtime_fields);
+    let table_struct = packed_row_impl(&table_name, generic, &table_fields);
+    let ops_impl = indexed_ops_impl(&trait_name, &indexed_name, generic, &inp.fields);
+
+    // Per output column (arrays expanded), in declaration order: 1 = instruction-derived.
+    let mut col_source: Vec<u8> = vec![];
+    for (f, instr) in &inp.fields {
+        // collect_dimensions assumes an array; only call it for arrays (scalars are 1 column).
+        let cols = if is_array(&f.ty) {
+            let (_, dims, _) = collect_dimensions(&f.ty);
+            dims.iter().product::<usize>()
+        } else {
+            1
+        };
+        col_source.extend(std::iter::repeat(if *instr { 1u8 } else { 0u8 }).take(cols));
+    }
+    let n_cols = col_source.len();
+    let col_lits = col_source.iter().map(|&s| quote! { #s });
+
+    let (generics, generics_with_bounds) = generic_tokens(generic);
+
+    let expanded = quote! {
+        #indexed_struct
+        #table_struct
+        #ops_impl
+
+        impl #generics_with_bounds #indexed_name #generics {
+            /// Per output column: 1 = instruction-derived (from the table), 0 = runtime row.
+            pub const COL_SOURCE: [u8; #n_cols] = [ #(#col_lits),* ];
+            /// Width of the leading instruction-index header (bits).
+            pub const INDEX_BITS: u64 = #INDEX_BITS;
+        }
+
+        impl #generics_with_bounds proofman_common::trace::IndexedFill for #indexed_name #generics {
+            const IS_INDEXED: bool = true;
+            #[inline(always)]
+            fn set_row_index(&mut self, index: u32) { #indexed_name::set_index(self, index); }
+        }
+        impl #generics_with_bounds proofman_common::trace::IndexedFill for #name #generics {}
+        impl #generics_with_bounds proofman_common::trace::IndexedFill for #packed_name #generics {}
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}
+
+/// `impl {trait} for {indexed}`: untagged columns forward to the compact buffer's inherent
+/// accessors; `@instr` columns are no-ops on set and return the type default on get.
+fn indexed_ops_impl(
+    trait_name: &Ident,
+    indexed_name: &Ident,
+    generic: &Option<Ident>,
+    fields: &[(TraceField, bool)],
+) -> TokenStream {
+    let (generics, generics_with_bounds) = generic_tokens(generic);
+    let mut methods = vec![];
+
+    for (f, instr) in fields.iter() {
+        let setter = format_ident!("set_{}", f.name);
+        let getter = format_ident!("get_{}", f.name);
+
+        if contains_generic(&f.ty) {
+            if !is_array(&f.ty) {
+                if *instr {
+                    methods.push(quote! {
+                        #[inline(always)] fn #setter(&mut self, _value: F) {}
+                        #[inline(always)] fn #getter(&self) -> F { F::default() }
+                    });
+                } else {
+                    methods.push(quote! {
+                        #[inline(always)] fn #setter(&mut self, value: F) { #indexed_name::#setter(self, value); }
+                        #[inline(always)] fn #getter(&self) -> F { #indexed_name::#getter(self) }
+                    });
+                }
+            }
+        } else if is_array(&f.ty) {
+            assert!(!*instr, "indexed_trace_row!: `@instr` unsupported on array column `{}`", f.name);
+            let (bits, dims, _) = collect_dimensions(&f.ty);
+            let rust_ty = rust_type_for_bits(bits);
+            let idx_args: Vec<Ident> = (0..dims.len()).map(|i| format_ident!("i{}", i)).collect();
+            let setter_all = format_ident!("set_all_{}", f.name);
+            let getter_all = format_ident!("get_all_{}", f.name);
+            let mut nested = rust_ty.clone();
+            for &len in dims.iter().rev() {
+                nested = quote! { [#nested; #len] };
+            }
+            methods.push(quote! {
+                #[inline(always)]
+                fn #setter(&mut self, #(#idx_args: usize,)* value: #rust_ty) { #indexed_name::#setter(self, #(#idx_args,)* value); }
+                #[inline(always)]
+                fn #getter(&self, #(#idx_args: usize),*) -> #rust_ty { #indexed_name::#getter(self, #(#idx_args),*) }
+                #[inline(always)]
+                fn #setter_all(&mut self, values: &#nested) { #indexed_name::#setter_all(self, values); }
+                #[inline(always)]
+                fn #getter_all(&self) -> #nested { #indexed_name::#getter_all(self) }
+            });
+        } else {
+            let bits = compute_total_bits(&f.ty);
+            let rust_ty = rust_type_for_bits(bits);
+            if *instr {
+                methods.push(quote! {
+                    #[inline(always)] fn #setter(&mut self, _value: #rust_ty) {}
+                    #[inline(always)] fn #getter(&self) -> #rust_ty { <#rust_ty>::default() }
+                });
+            } else {
+                methods.push(quote! {
+                    #[inline(always)] fn #setter(&mut self, value: #rust_ty) { #indexed_name::#setter(self, value); }
+                    #[inline(always)] fn #getter(&self) -> #rust_ty { #indexed_name::#getter(self) }
+                });
+            }
+        }
+    }
+
+    quote! {
+        impl #generics_with_bounds #trait_name #generics for #indexed_name #generics {
+            #(#methods)*
+        }
+    }
+}

--- a/macros/src/indexed_trace_row.rs
+++ b/macros/src/indexed_trace_row.rs
@@ -112,7 +112,7 @@ pub fn indexed_trace_row_entrypoint(input: proc_macro::TokenStream) -> proc_macr
         } else {
             1
         };
-        col_source.extend(std::iter::repeat(if *instr { 1u8 } else { 0u8 }).take(cols));
+        col_source.extend(std::iter::repeat_n(if *instr { 1u8 } else { 0u8 }, cols));
     }
     let n_cols = col_source.len();
     let col_lits = col_source.iter().map(|&s| quote! { #s });

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,6 +8,7 @@ mod trace_row;
 mod packed_row;
 mod unpacked_row;
 mod trait_row;
+mod indexed_trace_row;
 
 #[proc_macro]
 pub fn trace(input: TokenStream) -> TokenStream {
@@ -22,6 +23,14 @@ pub fn values(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn trace_row(input: TokenStream) -> TokenStream {
     trace_row::trace_row_entrypoint(input)
+}
+
+/// Companion to `trace_row!` for the indexed (compact) variant of an already-defined row.
+/// The base row + its `RowNameOps` trait must already exist (e.g. from `trace_row!`); this
+/// only adds the indexed variant beside them. See `indexed_trace_row.rs` for what it emits.
+#[proc_macro]
+pub fn indexed_trace_row(input: TokenStream) -> TokenStream {
+    indexed_trace_row::indexed_trace_row_entrypoint(input)
 }
 
 // Keep the old packed_row macro for backward compatibility

--- a/macros/src/trait_row.rs
+++ b/macros/src/trait_row.rs
@@ -157,14 +157,14 @@ fn forwarding_methods(type_name: &Ident, fields: &[TraceField]) -> Vec<TokenStre
     out
 }
 
-fn generic_tokens(generic: &Option<Ident>) -> (TokenStream, TokenStream) {
+pub(crate) fn generic_tokens(generic: &Option<Ident>) -> (TokenStream, TokenStream) {
     match generic {
         Some(g) => (quote! { <#g> }, quote! { <#g: PrimeField64 + Copy + Default + Send + 'static> }),
         None => (quote! {}, quote! {}),
     }
 }
 
-fn rust_type_for_bits(bits: usize) -> TokenStream {
+pub(crate) fn rust_type_for_bits(bits: usize) -> TokenStream {
     match bits {
         1 => quote! { bool },
         2..=8 => quote! { u8 },

--- a/pil2-stark/src/api/starks_api.cpp
+++ b/pil2-stark/src/api/starks_api.cpp
@@ -656,6 +656,30 @@ void write_custom_commit_cpu(void* root, uint64_t arity, uint64_t nBits, uint64_
     }
 }
 
+// Unpack a packed cm1 into `dst` (row-major), dispatching plain vs indexed. Fatal
+// when an indexed air has no instruction table registered: falling back to the plain
+// walk would silently decode the compact rows as if they were full ones, so the trace
+// would be wrong with no other symptom. register_instruction_table must be called
+// after load_device_setups and before the first commit of that program.
+static void unpack_cm1_cpu(DeviceCommitBuffersCPU *d_buffers, uint64_t airgroupId, uint64_t airId,
+                           const PackedInfoCPU *pInfo, const uint64_t *src, uint64_t *dst,
+                           uint64_t nRows, uint64_t nCols) {
+    if (!pInfo->indexed()) {
+        d_buffers->unpack_cpu(src, dst, nRows, nCols, pInfo->num_packed_words, pInfo->unpack_info);
+        return;
+    }
+    const uint64_t *table = d_buffers->getInstructionTable(airgroupId, airId);
+    if (table == nullptr) {
+        zklog.error("unpack_cm1_cpu: air (" + std::to_string(airgroupId) + "," + std::to_string(airId) +
+                    ") is indexed but no instruction table is registered; call register_instruction_table first");
+        exitProcess();
+    }
+    d_buffers->unpack_cpu_indexed(src, table, dst, nRows, nCols, pInfo->num_packed_words,
+                                  pInfo->words_per_entry, pInfo->unpack_info, pInfo->col_source,
+                                  pInfo->index_bits, d_buffers->getInstructionTableEntries(airgroupId, airId),
+                                  airgroupId, airId);
+}
+
 uint64_t commit_witness_cpu(void *pSetupCtx_, void *params_, uint64_t instanceId, uint64_t airgroupId, uint64_t airId, void *root, void *d_buffers_, char *customCommitsFixedPath) {
     DeviceCommitBuffersCPU *d_buffers = (DeviceCommitBuffersCPU *)d_buffers_;
     SetupCtx *setupCtx = (SetupCtx *)pSetupCtx_;
@@ -676,10 +700,11 @@ uint64_t commit_witness_cpu(void *pSetupCtx_, void *params_, uint64_t instanceId
 
     PackedInfoCPU *packed_info = d_buffers->getPackedInfo(airgroupId, airId);
     if (packed_info != nullptr && packed_info->is_packed) {
-        d_buffers->unpack_cpu((uint64_t *)params->trace, (uint64_t*)&auxTraceGL[offset_src], N, nCols, packed_info->num_packed_words, packed_info->unpack_info);
+        unpack_cm1_cpu(d_buffers, airgroupId, airId, packed_info, (uint64_t *)params->trace,
+                       (uint64_t *)&auxTraceGL[offset_src], N, nCols);
         memcpy(params->trace, &params->aux_trace[offset_src], N * nCols * sizeof(Goldilocks::Element));
     }
-    
+
     ProverHelpers proverHelpers;
     ExpressionsPack expressionsCtx(*setupCtx, &proverHelpers);
 
@@ -799,7 +824,8 @@ uint64_t gen_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uin
 
     PackedInfoCPU *packed_info = d_buffers->getPackedInfo(airgroupId, airId);
     if (packed_info != nullptr && packed_info->is_packed) {
-        d_buffers->unpack_cpu((uint64_t *)params->trace, (uint64_t*)&params->aux_trace[offsetCm1], N, nCols, packed_info->num_packed_words, packed_info->unpack_info);
+        unpack_cm1_cpu(d_buffers, airgroupId, airId, packed_info, (uint64_t *)params->trace,
+                       (uint64_t *)&params->aux_trace[offsetCm1], N, nCols);
         memcpy(params->trace, &params->aux_trace[offsetCm1], N * nCols * sizeof(Goldilocks::Element));
     }
     genProof(*(SetupCtx *)pSetupCtx, airgroupId, airId, instanceId, *(StepsParams *)params, (Goldilocks::Element *)globalChallenge, proofBuffer, string(proofFile));
@@ -817,6 +843,12 @@ void use_packed_trace_cpu(void *d_buffers_, bool packed) {
     DeviceCommitBuffersCPU *d_buffers = (DeviceCommitBuffersCPU *)d_buffers_;
     d_buffers->packedTrace = packed;
 }
+
+// Store the program's instruction table for an indexed air; used by unpack_cpu_indexed.
+void register_instruction_table_cpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry) {
+    DeviceCommitBuffersCPU *d_buffers = (DeviceCommitBuffersCPU *)d_buffers_;
+    d_buffers->registerInstructionTable(airgroupId, airId, table, num_entries, words_per_entry);
+}
 void free_device_buffers_cpu(void *d_buffers_) {
     DeviceCommitBuffersCPU *d_buffers = (DeviceCommitBuffersCPU *)d_buffers_;
     delete d_buffers;
@@ -829,7 +861,7 @@ void load_device_setup_cpu(uint64_t airgroupId, uint64_t airId, char *proofType,
     uint64_t nCols = setupCtx->starkInfo.mapSectionsN["cm1"];
     PackedInfo *packedInfo = (PackedInfo *)packedInfo_;
     if (packedInfo != nullptr) {
-        d_buffers->addPackedInfoCPU(airgroupId, airId, nCols, packedInfo->is_packed, packedInfo->num_packed_words, packedInfo->unpack_info);
+        d_buffers->addPackedInfoCPU(airgroupId, airId, nCols, packedInfo->is_packed, packedInfo->num_packed_words, packedInfo->unpack_info, packedInfo->col_source, packedInfo->index_bits, packedInfo->words_per_entry);
     }
 }
 

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -355,6 +355,36 @@ void use_packed_trace_gpu(void *d_buffers_, bool packed) {
     d_buffers->packedTrace = packed;
 }
 
+// Upload (per program) the instruction table for an indexed air onto every local GPU's
+// AirInstanceInfo. Non-indexed instances (d_col_source == nullptr) are skipped.
+void register_instruction_table_gpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId,
+                                    uint64_t *table, uint64_t num_entries, uint64_t words_per_entry) {
+    DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
+    std::pair<uint64_t, uint64_t> key = {airgroupId, airId};
+    uint64_t uploaded = 0;
+    auto it = d_buffers->air_instances.find(key);
+    if (it != d_buffers->air_instances.end()) {
+        for (auto &per_proof_type : it->second) {
+            std::vector<AirInstanceInfo *> &instances = per_proof_type.second;
+            for (int i = 0; i < d_buffers->n_gpus && i < (int)instances.size(); ++i) {
+                AirInstanceInfo *aii = instances[i];
+                if (aii == nullptr || aii->d_col_source == nullptr) continue; // indexed airs only
+                cudaSetDevice(d_buffers->my_gpu_ids[i]);
+                aii->set_instruction_table(table, num_entries, words_per_entry);
+                uploaded++;
+            }
+        }
+    }
+    // Silence here used to mean "the table never landed" -- the air had not been set
+    // up yet (register before load_device_setups), or it carries no indexed
+    // descriptor. Either way the later unpack aborts; say so at the actual cause.
+    if (uploaded == 0) {
+        zklog.warning("register_instruction_table: air (" + std::to_string(airgroupId) + "," +
+                      std::to_string(airId) + ") matched no indexed AirInstanceInfo; the table was "
+                      "NOT uploaded (register after load_device_setups, and only for indexed airs)");
+    }
+}
+
 void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation) {
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
     uint64_t constPolsSize = totalConstPols * sizeof(Goldilocks::Element);
@@ -2180,10 +2210,17 @@ static void streamCommitReleaseRegion(DeviceCommitBuffers *d_buffers) {
 // Poseidon1 arity 4 only (family checked here, arity by the caller).
 // Synchronous; safe to call concurrently on distinct slots, and while the
 // first GPU's buffer is borrowed by gpu-mops (touches only the slot).
+//
+// Indexed airs are supported: the compact-row descriptor and the uploaded
+// instruction table are read from the first GPU's AirInstanceInfo (separate
+// cudaMalloc'd allocations, so the gpu-mops borrow of gpuMemoryBuffer[0] does
+// not disturb them) -- hence airgroupId/airId.
+//
 // Returns 0 on success, negative on misuse; -14 (region busy: legacy work is
 // running on an overlapped stream) is an expected transient -- callers fall
 // back to the legacy path silently.
 int64_t commit_witness_streaming_gpu(void *d_buffers_, uint64_t slotIdx,
+                                     uint64_t airgroupId, uint64_t airId,
                                      void *packed, uint64_t nBits, uint64_t nBitsExt,
                                      uint64_t nCols, uint64_t wordsPerRow,
                                      void *colWidths, void *root) {
@@ -2200,6 +2237,35 @@ int64_t commit_witness_streaming_gpu(void *d_buffers_, uint64_t slotIdx,
     if (d_buffers->streamCommitQuiesced.load(std::memory_order_acquire)) return -14;
 
     StreamCommitDims dims{nBits, nBitsExt, nCols, wordsPerRow};
+
+    // Indexed descriptor from the first GPU's AirInstanceInfo (d_col_source is set
+    // at setup from PackedInfo; d_instr_table arrives per program via
+    // register_instruction_table). Both live outside gpuMemoryBuffer[0].
+    const uint8_t *dColSource = nullptr;
+    const uint64_t *dTable = nullptr;
+    AirInstanceInfo *aii = nullptr;
+    auto it = d_buffers->air_instances.find({airgroupId, airId});
+    if (it != d_buffers->air_instances.end()) {
+        auto pit = it->second.find("basic");
+        if (pit != it->second.end() && !pit->second.empty()) aii = pit->second[0];
+    }
+    if (aii != nullptr && aii->d_col_source != nullptr) {
+        if (aii->d_instr_table == nullptr) {
+            // Indexed air with no table yet: the plain walk would decode the compact
+            // rows as full ones, so refuse rather than emit a wrong root. Distinct
+            // from -14 so the caller surfaces it.
+            zklog.error("commit_witness_streaming: air (" + std::to_string(airgroupId) + "," +
+                        std::to_string(airId) + ") is indexed but no instruction table is "
+                        "registered; call register_instruction_table first");
+            return -16;
+        }
+        dColSource = aii->d_col_source;
+        dTable = aii->d_instr_table;
+        dims.indexBits = aii->index_bits;
+        dims.wordsPerEntry = aii->words_per_entry;
+        dims.numEntries = aii->num_entries;
+    }
+
     if (streamCommitSlotElems(dims) * sizeof(Goldilocks::Element) > d_buffers->streamCommitSlotBytes)
         return -13;
 
@@ -2210,7 +2276,8 @@ int64_t commit_witness_streaming_gpu(void *d_buffers_, uint64_t slotIdx,
                        (d_buffers->streamCommitFloorBytes + slotIdx * d_buffers->streamCommitSlotBytes) /
                            sizeof(Goldilocks::Element);
     int64_t rc = streamCommitPacked(slotBase, dims, (const uint64_t *)colWidths, packed,
-                                    (uint64_t *)root, d_buffers->streamCommitStreams[slotIdx]);
+                                    (uint64_t *)root, d_buffers->streamCommitStreams[slotIdx],
+                                    dColSource, dTable);
     streamCommitReleaseRegion(d_buffers);
     return rc;
 }

--- a/pil2-stark/src/api/starks_api.hpp
+++ b/pil2-stark/src/api/starks_api.hpp
@@ -6,11 +6,17 @@
 extern "C" {
 #endif
 
+    // Field order must match the Rust PackedInfoFFI (repr(C)) that is cast to this.
     struct PackedInfo {
         bool is_packed;
         uint64_t num_packed_words;
         uint64_t *unpack_info;
+        // Indexed variant descriptor (nullptr / 0 when the air is not indexed).
+        uint8_t *col_source;      // per column: 0 = row stream, 1 = table stream (len nCols)
+        uint64_t index_bits;      // width of the compact row's leading index header
+        uint64_t words_per_entry; // u64 words per instruction-table entry
 
+        // Only unpack_info is owned here; col_source is borrowed from Rust, do not free it.
         ~PackedInfo() {
             delete[] unpack_info;
             unpack_info = nullptr;
@@ -183,6 +189,7 @@ extern "C" {
     // =================================================================================
     void *gen_device_buffers(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);
     void use_packed_trace(void *d_buffers, bool packed);
+    void register_instruction_table(void *d_buffers, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry);
     void free_device_buffers(void *d_buffers);
     void *gen_device_buffers_recursivef(void *pSetupCtx_, uint64_t proverBufferSize, void *d_commit_buffers, char* verkey);
     void free_device_buffers_recursivef(void *d_buffers);
@@ -206,7 +213,7 @@ extern "C" {
     uint64_t get_stream_commit_floor(void *d_buffers_);
     uint64_t stream_commit_slot_bytes(uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow);
     void configure_stream_commit_slots(void *d_buffers_, uint64_t nSlots, uint64_t slotBytes);
-    int64_t commit_witness_streaming(void *d_buffers_, uint64_t slotIdx, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
+    int64_t commit_witness_streaming(void *d_buffers_, uint64_t slotIdx, uint64_t airgroupId, uint64_t airId, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
     void stream_commit_pause();
     void *get_unified_buffer_gpu_for_recursivef(void *d_buffers_, void *d_buffers_recursivef_);
     void alloc_fixed_pols_buffer_gpu(void *d_buffers_);

--- a/pil2-stark/src/api/starks_api_internal.hpp
+++ b/pil2-stark/src/api/starks_api_internal.hpp
@@ -11,6 +11,8 @@
 #include "hash_family.hpp"
 #include "poseidon_goldilocks.hpp"
 #include "poseidon2_goldilocks.hpp"
+#include "zklog.hpp"
+#include "exit_process.hpp"
 
 inline void runGrinding(uint64_t &nonce,
                         const uint64_t *challenge, uint32_t powBits) {
@@ -34,23 +36,77 @@ struct PackedInfoCPU {
     bool is_packed;
     uint64_t num_packed_words;
     std::vector<uint64_t> unpack_info;
+    // Indexed variant descriptor (empty col_source when the air is not indexed).
+    std::vector<uint8_t> col_source; // per column: 0 = row stream, 1 = table stream
+    uint64_t index_bits = 0;
+    uint64_t words_per_entry = 0;
+    bool indexed() const { return !col_source.empty(); }
 };
+
+// Read `nbits` from a packed stream at cursor (word,idx,off), advancing it.
+// Mirrors the GPU idx_read_bits bit-walk exactly.
+static inline uint64_t cpu_idx_read_bits(
+    const uint64_t* base, uint64_t words, uint64_t &word, uint64_t &idx, uint64_t &off, uint64_t nbits)
+{
+    uint64_t val;
+    uint64_t bits_left = 64 - off;
+    if (nbits <= bits_left) {
+        uint64_t mask = (nbits == 64) ? ~0ULL : ((1ULL << nbits) - 1ULL);
+        val = (word >> off) & mask;
+        off += nbits;
+        if (off == 64 && idx + 1 < words) { word = base[++idx]; off = 0; }
+    } else {
+        uint64_t low = word >> off;
+        word = base[++idx];
+        uint64_t high = word & ((1ULL << (nbits - bits_left)) - 1ULL);
+        val = (high << bits_left) | low;
+        off = nbits - bits_left;
+    }
+    return val;
+}
 
 struct DeviceCommitBuffersCPU
 {
     uint64_t airgroupId;
     uint64_t airId;
     std::string proofType;
-    
+
     bool packedTrace = false;
 
     std::map<std::pair<uint64_t, uint64_t>, PackedInfoCPU> packedInfo;
+    // Per-program instruction tables for indexed airs (num_entries * words_per_entry words).
+    std::map<std::pair<uint64_t, uint64_t>, std::vector<uint64_t>> instrTables;
+    std::map<std::pair<uint64_t, uint64_t>, uint64_t> instrEntries; // entry count, for index bounds
 
-    void addPackedInfoCPU(uint64_t airgroupId, uint64_t airId, uint64_t nCols, bool is_packed, uint64_t num_packed_words, uint64_t* unpack_info_) {
+    void addPackedInfoCPU(uint64_t airgroupId, uint64_t airId, uint64_t nCols, bool is_packed,
+                          uint64_t num_packed_words, uint64_t* unpack_info_, uint8_t* col_source_,
+                          uint64_t index_bits, uint64_t words_per_entry) {
         if (!is_packed) return;
         std::vector<uint64_t> unpack_vec(unpack_info_, unpack_info_ + nCols);
-        PackedInfoCPU pInfo = {is_packed, num_packed_words, unpack_vec};
+        std::vector<uint8_t> col_source_vec;
+        if (col_source_ != nullptr) col_source_vec.assign(col_source_, col_source_ + nCols);
+        PackedInfoCPU pInfo = {is_packed, num_packed_words, unpack_vec, col_source_vec, index_bits, words_per_entry};
         packedInfo[std::make_pair(airgroupId, airId)] = pInfo;
+    }
+
+    void registerInstructionTable(uint64_t airgroupId, uint64_t airId, const uint64_t* table, uint64_t num_entries, uint64_t words_per_entry) {
+        auto key = std::make_pair(airgroupId, airId);
+        instrTables[key].assign(table, table + num_entries * words_per_entry);
+        instrEntries[key] = num_entries;
+        // words_per_entry is also carried in PackedInfoCPU (from setup). Keep them in
+        // step: register_instruction_table is the authority for the live program.
+        auto pit = packedInfo.find(key);
+        if (pit != packedInfo.end()) pit->second.words_per_entry = words_per_entry;
+    }
+
+    const uint64_t* getInstructionTable(uint64_t airgroupId, uint64_t airId) {
+        auto it = instrTables.find({airgroupId, airId});
+        return (it != instrTables.end() && !it->second.empty()) ? it->second.data() : nullptr;
+    }
+
+    uint64_t getInstructionTableEntries(uint64_t airgroupId, uint64_t airId) {
+        auto it = instrEntries.find({airgroupId, airId});
+        return it != instrEntries.end() ? it->second : 0;
     }
 
     PackedInfoCPU* getPackedInfo(uint64_t airgroupId, uint64_t airId) {
@@ -60,6 +116,48 @@ struct DeviceCommitBuffersCPU
         if (it != packedInfo.end())
             return &it->second;
         return nullptr;
+    }
+
+    // Indexed cm1 unpack (row-major dst, matching unpack_cpu): compact rows + shared
+    // instruction table reconstruct the full nCols output per row.
+    void unpack_cpu_indexed(
+        const uint64_t* src,
+        const uint64_t* table,
+        uint64_t* dst,
+        uint64_t nRows,
+        uint64_t nCols,
+        uint64_t words_per_row,
+        uint64_t words_per_entry,
+        const std::vector<uint64_t> &unpack_info,
+        const std::vector<uint8_t> &col_source,
+        uint64_t index_bits,
+        uint64_t num_entries,
+        uint64_t airgroupId,
+        uint64_t airId
+    ) {
+        for (uint64_t row = 0; row < nRows; row++) {
+            const uint64_t* rbase = &src[row * words_per_row];
+            uint64_t rword = rbase[0], ridx = 0, roff = 0;
+            uint64_t index = cpu_idx_read_bits(rbase, words_per_row, rword, ridx, roff, index_bits);
+            if (index >= num_entries) {
+                zklog.error("unpack_cpu_indexed: air (" + std::to_string(airgroupId) + "," +
+                            std::to_string(airId) + ") row " + std::to_string(row) +
+                            " has instruction index " + std::to_string(index) +
+                            " but the table only has " + std::to_string(num_entries) + " entries");
+                exitProcess();
+            }
+
+            const uint64_t* tbase = &table[index * words_per_entry];
+            uint64_t tword = tbase[0], tidx = 0, toff = 0;
+
+            uint64_t* unpacked_row = &dst[row * nCols];
+            for (uint64_t c = 0; c < nCols; c++) {
+                uint64_t nbits = unpack_info[c];
+                unpacked_row[c] = col_source[c]
+                    ? cpu_idx_read_bits(tbase, words_per_entry, tword, tidx, toff, nbits)
+                    : cpu_idx_read_bits(rbase, words_per_row, rword, ridx, roff, nbits);
+            }
+        }
     }
 
     void unpack_cpu(

--- a/pil2-stark/src/api/starks_backend.cpp
+++ b/pil2-stark/src/api/starks_backend.cpp
@@ -16,6 +16,7 @@ void verify_constraints_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId
 uint64_t gen_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void *params, void *globalChallenge, uint64_t* proofBuffer, char *proofFile, void *d_buffers, bool skipRecalculation, uint64_t streamId, char *constPolsPath, char *constTreePath, char *customCommitsFixedPath);
 void *gen_device_buffers_cpu(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);
 void use_packed_trace_cpu(void *d_buffers_, bool packed);
+void register_instruction_table_cpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry);
 void free_device_buffers_cpu(void *d_buffers);
 void load_device_setup_cpu(uint64_t airgroupId, uint64_t airId, char *proofType, void *pSetupCtx_, void *d_buffers_, void *verkeyRoot_, void *packedInfo);
 uint64_t gen_recursive_proof_cpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
@@ -53,6 +54,7 @@ void *gen_recursive_proof_final_gpu(void *pSetupCtx, uint64_t airgroupId, uint64
 void calculate_const_tree_fixed_gpu(void *pSetupCtx_, uint64_t airgroupId, uint64_t airId, char *proofType, void *d_buffers_);
 void *gen_device_buffers_gpu(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);
 void use_packed_trace_gpu(void *d_buffers_, bool packed);
+void register_instruction_table_gpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry);
 void free_device_buffers_gpu(void *d_buffers);
 void *gen_device_buffers_recursivef_gpu(void *pSetupCtx_, uint64_t proverBufferSize, void *d_commit_buffers, char* verkey);
 void free_device_buffers_recursivef_gpu(void *d_buffers);
@@ -76,7 +78,7 @@ uint64_t get_stream_commit_slots_gpu(void *d_buffers_);
 uint64_t get_stream_commit_floor_gpu(void *d_buffers_);
 uint64_t stream_commit_slot_bytes_gpu(uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow);
 void configure_stream_commit_slots_gpu(void *d_buffers_, uint64_t nSlots, uint64_t slotBytes);
-int64_t commit_witness_streaming_gpu(void *d_buffers_, uint64_t slotIdx, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
+int64_t commit_witness_streaming_gpu(void *d_buffers_, uint64_t slotIdx, uint64_t airgroupId, uint64_t airId, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
 void stream_commit_pause_gpu();
 void *get_unified_buffer_gpu_for_recursivef_gpu(void *d_buffers_, void *d_buffers_recursivef_);
 void alloc_fixed_pols_buffer_gpu_gpu(void *d_buffers_);
@@ -119,6 +121,7 @@ StarksBackend cpu_backend = []() {
     backend.wait_trace_h2d_done = nullptr;            // CPU: no async stream to wait on
     backend.gen_device_buffers = gen_device_buffers_cpu;
     backend.use_packed_trace = use_packed_trace_cpu;
+    backend.register_instruction_table = register_instruction_table_cpu;
     backend.free_device_buffers = free_device_buffers_cpu;
     backend.gen_device_buffers_recursivef = nullptr;      // default: nullptr
     backend.free_device_buffers_recursivef = nullptr;
@@ -182,6 +185,7 @@ StarksBackend gpu_backend = []() {
     backend.wait_trace_h2d_done = wait_trace_h2d_done_gpu;
     backend.gen_device_buffers = gen_device_buffers_gpu;
     backend.use_packed_trace = use_packed_trace_gpu;
+    backend.register_instruction_table = register_instruction_table_gpu;
     backend.free_device_buffers = free_device_buffers_gpu;
     backend.gen_device_buffers_recursivef = gen_device_buffers_recursivef_gpu;
     backend.free_device_buffers_recursivef = free_device_buffers_recursivef_gpu;
@@ -360,6 +364,11 @@ void use_packed_trace(void *d_buffers, bool packed) {
     if (backend->use_packed_trace) backend->use_packed_trace(d_buffers, packed);
 }
 
+void register_instruction_table(void *d_buffers, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry) {
+    auto backend = active_backend.load(std::memory_order_acquire);
+    if (backend->register_instruction_table) backend->register_instruction_table(d_buffers, airgroupId, airId, table, num_entries, words_per_entry);
+}
+
 uint32_t register_host_memory(void *ptr, uint64_t size) {
     auto backend = active_backend.load(std::memory_order_acquire);
     return backend->register_host_memory ? backend->register_host_memory(ptr, size) : 0;
@@ -504,13 +513,14 @@ void stream_commit_pause() {
 }
 
 int64_t commit_witness_streaming(void *d_buffers_, uint64_t slotIdx,
+                                 uint64_t airgroupId, uint64_t airId,
                                  void *packed, uint64_t nBits, uint64_t nBitsExt,
                                  uint64_t nCols, uint64_t wordsPerRow,
                                  void *colWidths, void *root) {
     auto backend = active_backend.load(std::memory_order_acquire);
     return backend->commit_witness_streaming
-               ? backend->commit_witness_streaming(d_buffers_, slotIdx, packed, nBits,
-                                                   nBitsExt, nCols, wordsPerRow, colWidths, root)
+               ? backend->commit_witness_streaming(d_buffers_, slotIdx, airgroupId, airId, packed,
+                                                   nBits, nBitsExt, nCols, wordsPerRow, colWidths, root)
                : -1;
 }
 

--- a/pil2-stark/src/api/starks_backend.hpp
+++ b/pil2-stark/src/api/starks_backend.hpp
@@ -51,6 +51,7 @@ struct StarksBackend {
     // Device management
     void *(*gen_device_buffers)(uint32_t node_rank, uint32_t node_size, const int32_t* numa_nodes, uint32_t arity, uint32_t max_n_bits_ext);
     void (*use_packed_trace)(void *d_buffers, bool packed);
+    void (*register_instruction_table)(void *d_buffers, uint64_t airgroupId, uint64_t airId, uint64_t *table, uint64_t num_entries, uint64_t words_per_entry);
     void (*free_device_buffers)(void *d_buffers);
     void *(*gen_device_buffers_recursivef)(void *pSetupCtx_, uint64_t proverBufferSize, void *d_commit_buffers, char* verkey);
     void (*free_device_buffers_recursivef)(void *d_buffers);
@@ -74,7 +75,7 @@ struct StarksBackend {
     uint64_t (*get_stream_commit_floor)(void *d_buffers_);
     uint64_t (*stream_commit_slot_bytes)(uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow);
     void (*configure_stream_commit_slots)(void *d_buffers_, uint64_t nSlots, uint64_t slotBytes);
-    int64_t (*commit_witness_streaming)(void *d_buffers_, uint64_t slotIdx, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
+    int64_t (*commit_witness_streaming)(void *d_buffers_, uint64_t slotIdx, uint64_t airgroupId, uint64_t airId, void *packed, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols, uint64_t wordsPerRow, void *colWidths, void *root);
     void (*stream_commit_pause)();
     void *(*get_unified_buffer_gpu_for_recursivef)(void *d_buffers_, void *d_buffers_recursivef_);
     void (*alloc_fixed_pols_buffer_gpu)(void *d_buffers_);

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -79,7 +79,34 @@ struct AirInstanceInfo {
     uint64_t num_packed_words = 0;
     uint64_t *unpack_info = nullptr;
     uint64_t* d_num_packed_words;
-    
+
+    // Indexed (compact) cm1 unpack. The program-independent descriptor arrives via PackedInfo
+    // at setup; the instruction table is uploaded later, per program, via
+    // set_instruction_table(). d_instr_table == nullptr selects the plain unpack path.
+    uint8_t  *d_col_source = nullptr;   // per column: 0 = row stream, 1 = table stream
+    uint64_t  index_bits = 0;           // width of the leading index header in a compact row
+    uint64_t  words_per_entry = 0;      // u64 words per instruction-table entry
+    uint64_t *d_instr_table = nullptr;  // num_entries * words_per_entry, uploaded per program
+    uint64_t  num_entries = 0;
+
+    // Upload (replacing any previous) the program-specific instruction table. Caller must
+    // have selected the target GPU. Safe to call repeatedly ACROSS programs, but never
+    // while work using d_instr_table is in flight on this GPU -- the cudaFree below would
+    // pull the table out from under a running unpack. `words` also refreshes
+    // words_per_entry (seeded from PackedInfo at setup); the live program wins.
+    void set_instruction_table(const uint64_t *table, uint64_t entries, uint64_t words) {
+        if (d_instr_table != nullptr) {
+            CHECKCUDAERR(cudaFree(d_instr_table));
+            d_instr_table = nullptr;
+        }
+        num_entries = entries;
+        words_per_entry = words;
+        if (entries > 0 && words > 0) {
+            CHECKCUDAERR(cudaMalloc(&d_instr_table, entries * words * sizeof(uint64_t)));
+            CHECKCUDAERR(cudaMemcpy(d_instr_table, table, entries * words * sizeof(uint64_t), cudaMemcpyHostToDevice));
+        }
+    }
+
     AirInstanceInfo(uint64_t airgroupId, uint64_t airId, SetupCtx *setupCtx, Goldilocks::Element *verkeyRoot_, PackedInfo *packedInfo): setupCtx(setupCtx), airgroupId(airgroupId), airId(airId) {
         int64_t *d_openingPoints;
         CHECKCUDAERR(cudaMalloc(&d_openingPoints, setupCtx->starkInfo.openingPoints.size() * sizeof(int64_t)));
@@ -220,6 +247,14 @@ struct AirInstanceInfo {
                 CHECKCUDAERR(cudaMemcpy(unpack_info, packedInfo->unpack_info, nCols * sizeof(uint64_t), cudaMemcpyHostToDevice));
             }
             cudaMemcpy(d_num_packed_words, &num_packed_words, sizeof(uint64_t), cudaMemcpyHostToDevice);
+
+            // Indexed variant descriptor; the table itself arrives via set_instruction_table().
+            if (packedInfo->col_source != nullptr) {
+                index_bits = packedInfo->index_bits;
+                words_per_entry = packedInfo->words_per_entry;
+                CHECKCUDAERR(cudaMalloc(&d_col_source, nCols * sizeof(uint8_t)));
+                CHECKCUDAERR(cudaMemcpy(d_col_source, packedInfo->col_source, nCols * sizeof(uint8_t), cudaMemcpyHostToDevice));
+            }
         }
     }
 
@@ -267,6 +302,14 @@ struct AirInstanceInfo {
 
         if (unpack_info != nullptr) {
             CHECKCUDAERR(cudaFree(unpack_info));
+        }
+
+        if (d_col_source != nullptr) {
+            CHECKCUDAERR(cudaFree(d_col_source));
+        }
+
+        if (d_instr_table != nullptr) {
+            CHECKCUDAERR(cudaFree(d_instr_table));
         }
     }
 };

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -82,7 +82,9 @@ struct AirInstanceInfo {
 
     // Indexed (compact) cm1 unpack. The program-independent descriptor arrives via PackedInfo
     // at setup; the instruction table is uploaded later, per program, via
-    // set_instruction_table(). d_instr_table == nullptr selects the plain unpack path.
+    // set_instruction_table(). d_col_source == nullptr is what selects the plain unpack
+    // path -- when it is set, d_instr_table must have been registered before the first
+    // unpack, and unpack_trace aborts rather than silently falling back to the plain walk.
     uint8_t  *d_col_source = nullptr;   // per column: 0 = row stream, 1 = table stream
     uint64_t  index_bits = 0;           // width of the leading index header in a compact row
     uint64_t  words_per_entry = 0;      // u64 words per instruction-table entry

--- a/pil2-stark/src/goldilocks/src/stream_commit.cu
+++ b/pil2-stark/src/goldilocks/src/stream_commit.cu
@@ -50,6 +50,43 @@ static void scEnsureConstants()
     if (memoized) uploaded[dev] = true;
 }
 
+// Advance the cursor (word,idx,off) over `nbits` of a packed stream, returning the
+// value when Extract. The prover's unpack bit walk (starks_gpu.cu unpack /
+// idx_read_bits) -- the cursor updates are kept character-for-character identical so
+// slot roots match the prover's cm1.
+//
+// A chunked commit re-walks columns [0, c0) purely to reposition the cursors, and the
+// value there is dead. Extract=false is that case: one template keeps a single copy of
+// the cursor logic (so skip and read can never drift) while the mask/shift/or folds
+// away. The word loads stay -- they are what advances the cursor, and they are also
+// why this is not a speedup: the kernel is DRAM-bound, so dropping the arithmetic
+// measures as noise. It is kept for the single-source-of-truth cursor, not for time.
+template <bool Extract>
+__device__ __forceinline__ static uint64_t scStepBits(
+    const uint64_t *__restrict__ base, uint64_t words,
+    uint64_t &word, uint64_t &idx, uint64_t &off, uint64_t nbits)
+{
+    uint64_t val = 0;
+    uint64_t bits_left = 64 - off;
+    if (nbits <= bits_left) {
+        if (Extract) {
+            uint64_t mask = (nbits == 64) ? ~0ULL : ((1ULL << nbits) - 1ULL);
+            val = (word >> off) & mask;
+        }
+        off += nbits;
+        if (off == 64 && idx + 1 < words) { word = base[++idx]; off = 0; }
+    } else {
+        uint64_t low = word >> off;
+        word = base[++idx];
+        if (Extract) {
+            uint64_t high = word & ((1ULL << (nbits - bits_left)) - 1ULL);
+            val = (high << bits_left) | low;
+        }
+        off = nbits - bits_left;
+    }
+    return val;
+}
+
 // The prover's unpack bit walk (starks_gpu.cu unpack), writing only columns
 // [c0, c0+cc) into cc ColMajor columns of dst (columns before c0 are skipped
 // by advancing the cursor). Widths come from global memory so concurrent
@@ -65,23 +102,70 @@ __global__ static void scUnpackRangeKernel(const uint64_t *__restrict__ src,
     const uint64_t *packed_row = src + row * wordsPerRow;
     uint64_t word = packed_row[0];
     uint64_t word_idx = 0, bit_offset = 0;
-    for (uint64_t c = 0; c < nCols && c < (uint64_t)c0 + cc; c++) {
-        uint64_t nbits = widths[c];
-        uint64_t val;
-        uint64_t bits_left = 64 - bit_offset;
-        if (nbits <= bits_left) {
-            uint64_t mask = (nbits == 64) ? ~0ULL : ((1ULL << nbits) - 1ULL);
-            val = (word >> bit_offset) & mask;
-            bit_offset += nbits;
-            if (bit_offset == 64 && word_idx + 1 < wordsPerRow) { word = packed_row[++word_idx]; bit_offset = 0; }
-        } else {
-            uint64_t low = word >> bit_offset;
-            word = packed_row[++word_idx];
-            uint64_t high = word & ((1ULL << (nbits - bits_left)) - 1ULL);
-            val = (high << bits_left) | low;
-            bit_offset = nbits - bits_left;
-        }
-        if (c >= c0) dst[(uint64_t)(c - c0) * nRows + row] = val;
+    // Reposition over the columns this chunk does not write, then extract.
+    for (uint64_t c = 0; c < (uint64_t)c0 && c < nCols; c++)
+        scStepBits<false>(packed_row, wordsPerRow, word, word_idx, bit_offset, widths[c]);
+    for (uint64_t c = c0; c < nCols && c < (uint64_t)c0 + cc; c++) {
+        uint64_t val = scStepBits<true>(packed_row, wordsPerRow, word, word_idx, bit_offset, widths[c]);
+        dst[(uint64_t)(c - c0) * nRows + row] = val;
+    }
+}
+
+// Indexed counterpart of scUnpackRangeKernel: two cursors (compact row, shared
+// instruction table), each output column sourced per colSource. Mirrors
+// unpack_indexed (starks_gpu.cu), so a slot root equals the prover's cm1 root.
+// Columns before c0 still have to be walked -- both cursors are sequential.
+__global__ static void scUnpackRangeIndexedKernel(const uint64_t *__restrict__ src,
+                                                  const uint64_t *__restrict__ table,
+                                                  const uint64_t *__restrict__ widths,
+                                                  const uint8_t *__restrict__ colSource,
+                                                  uint64_t *__restrict__ dst,
+                                                  uint64_t nCols, uint64_t nRows,
+                                                  uint64_t wordsPerRow, uint64_t wordsPerEntry,
+                                                  uint64_t numEntries, uint64_t indexBits,
+                                                  uint32_t c0, uint32_t cc)
+{
+    // Per-column metadata is uniform across rows, so stage it once per block the way
+    // the prover's unpack does with its widths. One shared word carries BOTH the width
+    // and the source flag (nbits in the low 32 bits, source in bit 32) -- nbits <= 64,
+    // so they fit, and the inner loops take one shared read instead of two global ones.
+    // nCols <= SC_MAX_COLS, so at most 512 B per block. Note this is a tidiness/latency
+    // measure, not a throughput lever: the kernel runs at ~83% of DRAM roofline, so its
+    // cost is the row traffic below, not this metadata.
+    extern __shared__ uint64_t scInfo[];
+    for (uint64_t i = threadIdx.x; i < nCols; i += blockDim.x)
+        scInfo[i] = widths[i] | ((uint64_t)(colSource[i] != 0) << 32);
+    __syncthreads();
+
+    uint64_t row = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= nRows) return;
+
+    const uint64_t *rbase = src + row * wordsPerRow;
+    uint64_t rword = rbase[0], ridx = 0, roff = 0;
+    uint64_t index = scStepBits<true>(rbase, wordsPerRow, rword, ridx, roff, indexBits);
+    // A witness bug can put an out-of-range index here. The CPU unpack reports
+    // it and aborts; a kernel cannot, so fall back to entry 0 to stay in bounds
+    // -- the root then simply fails verification instead of reading past the table.
+    if (index >= numEntries) index = 0;
+
+    const uint64_t *tbase = table + index * wordsPerEntry;
+    uint64_t tword = tbase[0], tidx = 0, toff = 0;
+
+    // Both cursors are sequential, so the columns this chunk does not write still have
+    // to be walked -- but only to reposition, so their values are never materialized.
+    for (uint64_t c = 0; c < (uint64_t)c0 && c < nCols; c++) {
+        uint64_t info = scInfo[c];
+        if (info >> 32) scStepBits<false>(tbase, wordsPerEntry, tword, tidx, toff, info & 0xFFFFFFFFull);
+        else            scStepBits<false>(rbase, wordsPerRow,   rword, ridx, roff, info & 0xFFFFFFFFull);
+    }
+    for (uint64_t c = c0; c < nCols && c < (uint64_t)c0 + cc; c++) {
+        uint64_t info = scInfo[c];
+        uint64_t nbits = info & 0xFFFFFFFFull;
+        // Warp-uniform: colSource depends only on c, so this never diverges.
+        uint64_t val = (info >> 32)
+            ? scStepBits<true>(tbase, wordsPerEntry, tword, tidx, toff, nbits)
+            : scStepBits<true>(rbase, wordsPerRow,   rword, ridx, roff, nbits);
+        dst[(uint64_t)(c - c0) * nRows + row] = val;
     }
 }
 
@@ -189,10 +273,16 @@ uint64_t streamCommitSlotElems(const StreamCommitDims &dims)
 
 int64_t streamCommitPacked(gl64_t *slotBase, const StreamCommitDims &dims,
                            const uint64_t *colWidths, const void *hPacked,
-                           uint64_t *hRoot, cudaStream_t stream)
+                           uint64_t *hRoot, cudaStream_t stream,
+                           const uint8_t *dColSource, const uint64_t *dTable)
 {
     if (dims.nCols == 0 || dims.nCols > SC_MAX_COLS) return -1;
     if (dims.nBitsExt <= dims.nBits) return -2;
+    // Indexed descriptor must be complete or entirely absent.
+    const bool indexed = (dColSource != nullptr);
+    if (indexed && (dTable == nullptr || dims.wordsPerEntry == 0 || dims.numEntries == 0 ||
+                    dims.indexBits == 0 || dims.indexBits > 64))
+        return -4;
 
     const uint64_t N = 1ull << dims.nBits, NExt = 1ull << dims.nBitsExt;
     const uint64_t treeElems = scTreeNumElements(NExt);
@@ -230,9 +320,16 @@ int64_t streamCommitPacked(gl64_t *slotBase, const StreamCommitDims &dims,
     for (uint32_t k = 0; k < nChunks; k++) {
         uint32_t cc = (uint32_t)((uint64_t)(k + 1) * SC_RATE <= dims.nCols ? SC_RATE
                                                                            : dims.nCols - (uint64_t)k * SC_RATE);
-        scUnpackRangeKernel<<<ublk, SC_TPB, 0, stream>>>(d_packed, d_widths, (uint64_t *)d_rate,
-                                                         dims.nCols, N, dims.wordsPerRow,
-                                                         (uint32_t)(k * SC_RATE), cc);
+        if (indexed) {
+            scUnpackRangeIndexedKernel<<<ublk, SC_TPB, dims.nCols * sizeof(uint64_t), stream>>>(
+                d_packed, dTable, d_widths, dColSource, (uint64_t *)d_rate,
+                dims.nCols, N, dims.wordsPerRow, dims.wordsPerEntry, dims.numEntries,
+                dims.indexBits, (uint32_t)(k * SC_RATE), cc);
+        } else {
+            scUnpackRangeKernel<<<ublk, SC_TPB, 0, stream>>>(d_packed, d_widths, (uint64_t *)d_rate,
+                                                             dims.nCols, N, dims.wordsPerRow,
+                                                             (uint32_t)(k * SC_RATE), cc);
+        }
         CHECKCUDAERR(cudaGetLastError());
         // In-place spread: src == dst base (equal-base aliasing path);
         // preserve_src must be false under aliasing.

--- a/pil2-stark/src/goldilocks/src/stream_commit.cuh
+++ b/pil2-stark/src/goldilocks/src/stream_commit.cuh
@@ -33,6 +33,15 @@ struct StreamCommitDims {
     uint64_t nBitsExt;     // log2 extended rows
     uint64_t nCols;        // witness columns (<= SC_MAX_COLS)
     uint64_t wordsPerRow;  // packed 64-bit words per row
+
+    // Indexed (compact) witness. Each row is a leading instruction-index header
+    // (indexBits wide) followed by the runtime columns; the columns flagged in
+    // dColSource are read instead from a shared instruction table of numEntries
+    // entries, wordsPerEntry words each. Left zero for a plain packed witness --
+    // dColSource == nullptr at the call is what actually selects the plain path.
+    uint64_t indexBits = 0;
+    uint64_t wordsPerEntry = 0;
+    uint64_t numEntries = 0;
 };
 
 // Returns required slot size in gl64 elements for the given dims. Slot layout:
@@ -44,13 +53,23 @@ uint64_t streamCommitSlotElems(const StreamCommitDims &dims);
 
 // Commit the bit-packed witness at hPacked (N*wordsPerRow u64, row-major) and
 // write the 4-element root to hRoot. colWidths: per-column bit widths (nCols
-// entries). The packed upload is issued as 32 MiB cudaMemcpyAsync blocks.
+// entries, host). The packed upload is issued as 32 MiB cudaMemcpyAsync blocks.
 // Synchronous on return: the root is valid, and both the slot and the caller's
 // packed-witness buffer are free for reuse -- callers need no event handling.
+//
+// dColSource / dTable are DEVICE pointers and select the indexed unpack: per
+// column 0 = read from the row stream, 1 = read from the instruction table.
+// Both must be non-null together, resident on the current device, and stay
+// alive for the call; they are borrowed, never freed here. Pass nullptr for
+// both (the default) to commit a plain packed witness.
+//
 // Returns 0, or a negative value on invalid dims (nCols outside
-// (0, SC_MAX_COLS], arity mismatch with the slot layout contract).
+// (0, SC_MAX_COLS], arity mismatch with the slot layout contract, or an
+// inconsistent indexed descriptor).
 int64_t streamCommitPacked(gl64_t *slotBase, const StreamCommitDims &dims,
                            const uint64_t *colWidths, const void *hPacked,
-                           uint64_t *hRoot, cudaStream_t stream);
+                           uint64_t *hRoot, cudaStream_t stream,
+                           const uint8_t *dColSource = nullptr,
+                           const uint64_t *dTable = nullptr);
 
 #endif

--- a/pil2-stark/src/goldilocks/tests/test_stream_commit_gpu.cu
+++ b/pil2-stark/src/goldilocks/tests/test_stream_commit_gpu.cu
@@ -181,6 +181,118 @@ TEST(GOLDILOCKS_TEST, stream_commit_reduced_small)
     runStreamCommitReduced(16, 38, 2);
 }
 
+// Indexed (compact) witness: the same 38-column trace, but the columns flagged
+// in COL_SOURCE are hoisted into a shared instruction table and each row keeps
+// only a 32-bit index plus its runtime columns. The slot root must be identical
+// to committing the equivalent FULL packed trace -- that equality is what lets
+// try_slot_commit hand indexed airs to a slot at all.
+static void runStreamCommitIndexed(uint64_t nBits, uint64_t nCols, uint64_t nEntries)
+{
+    const uint64_t nBitsExt = nBits + 1;
+    const uint32_t CAP = 4, TPB = 128;
+    const uint64_t N = 1ull << nBits, NExt = 1ull << nBitsExt;
+    const uint64_t INDEX_BITS = 32;
+
+    ASSERT_LE(nCols, 38u);
+    cudaStream_t s; CHECKCUDAERR(cudaStreamCreate(&s));
+
+    // Every 3rd column is instruction-derived.
+    std::vector<uint8_t> colSource(nCols);
+    for (uint64_t c = 0; c < nCols; c++) colSource[c] = (c % 3 == 2) ? 1 : 0;
+
+    // Compact-row widths: the index header, then the runtime columns.
+    // Table-entry widths: the instruction columns.
+    std::vector<uint64_t> rowW{INDEX_BITS}, tabW;
+    for (uint64_t c = 0; c < nCols; c++)
+        (colSource[c] ? tabW : rowW).push_back(MAIN_WIDTHS[c]);
+    auto wordsFor = [](const std::vector<uint64_t> &w) {
+        uint64_t b = 0; for (uint64_t x : w) b += x; return (b + 63) / 64;
+    };
+    const uint64_t rowWords = wordsFor(rowW), entWords = wordsFor(tabW);
+
+    // Instruction table + per-row values, then BOTH encodings of the same trace.
+    std::vector<uint64_t> table(nEntries * entWords), tabVals(tabW.size());
+    std::vector<std::vector<uint64_t>> entryVals(nEntries, std::vector<uint64_t>(tabW.size()));
+    uint64_t x = 0x9E3779B97F4A7C15ull;
+    auto next = [&]() { x ^= x << 13; x ^= x >> 7; x ^= x << 17; return x; };
+    for (uint64_t e = 0; e < nEntries; e++) {
+        for (size_t i = 0; i < tabW.size(); i++) entryVals[e][i] = next();
+        packRow(entryVals[e].data(), tabW.size(), tabW.data(), entWords, &table[e * entWords]);
+    }
+
+    std::vector<uint64_t> hCompact(N * rowWords), hFull(N * MAIN_WORDS);
+    {
+        std::vector<uint64_t> rowVals(nCols), compactVals(rowW.size()), fullVals(nCols);
+        for (uint64_t r = 0; r < N; r++) {
+            uint64_t idx = r % nEntries;
+            compactVals[0] = idx;
+            size_t ri = 1, ti = 0;
+            for (uint64_t c = 0; c < nCols; c++) {
+                if (colSource[c]) {
+                    // Mask exactly as packRow would, so the full encoding carries
+                    // the same value the table entry decodes to.
+                    uint64_t nb = MAIN_WIDTHS[c];
+                    uint64_t m = (nb == 64) ? ~0ULL : ((1ULL << nb) - 1ULL);
+                    fullVals[c] = entryVals[idx][ti++] & m;
+                } else {
+                    uint64_t v = next();
+                    compactVals[ri++] = v;
+                    fullVals[c] = v;
+                }
+            }
+            packRow(compactVals.data(), rowW.size(), rowW.data(), rowWords, &hCompact[r * rowWords]);
+            packRow(fullVals.data(), nCols, MAIN_WIDTHS, MAIN_WORDS, &hFull[r * MAIN_WORDS]);
+        }
+    }
+
+    // Reference: commit the FULL packed trace through the plain slot path.
+    std::vector<uint64_t> rootRef(CAP), rootIdx(CAP);
+    {
+        StreamCommitDims d{nBits, nBitsExt, nCols, MAIN_WORDS};
+        gl64_t *slot; CHECKCUDAERR(cudaMalloc(&slot, streamCommitSlotElems(d) * 8));
+        ASSERT_EQ(streamCommitPacked(slot, d, MAIN_WIDTHS, hFull.data(), rootRef.data(), s), 0);
+        CHECKCUDAERR(cudaFree(slot));
+    }
+    // Under test: commit the COMPACT trace + table through the indexed slot path.
+    {
+        StreamCommitDims d{nBits, nBitsExt, nCols, rowWords, INDEX_BITS, entWords, nEntries};
+        uint8_t *dCS; CHECKCUDAERR(cudaMalloc(&dCS, nCols));
+        CHECKCUDAERR(cudaMemcpy(dCS, colSource.data(), nCols, cudaMemcpyHostToDevice));
+        uint64_t *dT; CHECKCUDAERR(cudaMalloc(&dT, table.size() * 8));
+        CHECKCUDAERR(cudaMemcpy(dT, table.data(), table.size() * 8, cudaMemcpyHostToDevice));
+        gl64_t *slot; CHECKCUDAERR(cudaMalloc(&slot, streamCommitSlotElems(d) * 8));
+        ASSERT_EQ(streamCommitPacked(slot, d, MAIN_WIDTHS, hCompact.data(), rootIdx.data(), s, dCS, dT), 0);
+        CHECKCUDAERR(cudaFree(slot)); CHECKCUDAERR(cudaFree(dCS)); CHECKCUDAERR(cudaFree(dT));
+    }
+
+    printf("[stream-commit] indexed nBits=%lu nCols=%lu: %lu words/row vs %lu full, %lu-entry table\n",
+           nBits, nCols, rowWords, MAIN_WORDS, nEntries);
+    for (uint32_t i = 0; i < CAP; i++)
+        ASSERT_EQ(rootRef[i], rootIdx[i]) << "indexed root element " << i << " differs";
+
+    // An incomplete indexed descriptor must be rejected, not silently mis-unpacked.
+    {
+        StreamCommitDims d{nBits, nBitsExt, nCols, rowWords, INDEX_BITS, entWords, nEntries};
+        uint8_t *dCS; CHECKCUDAERR(cudaMalloc(&dCS, nCols));
+        gl64_t *slot; CHECKCUDAERR(cudaMalloc(&slot, streamCommitSlotElems(d) * 8));
+        EXPECT_LT(streamCommitPacked(slot, d, MAIN_WIDTHS, hCompact.data(), rootIdx.data(), s, dCS, nullptr), 0);
+        CHECKCUDAERR(cudaFree(slot)); CHECKCUDAERR(cudaFree(dCS));
+    }
+    CHECKCUDAERR(cudaStreamDestroy(s));
+}
+
+// Multi-chunk (38 cols = 4 chunks) so the per-chunk cursor repositioning over
+// both the row and table streams is exercised, not just chunk 0.
+TEST(GOLDILOCKS_TEST, stream_commit_indexed_small)
+{
+    runStreamCommitIndexed(16, 38, 7);
+}
+
+TEST(GOLDILOCKS_TEST, stream_commit_indexed_main_shape)
+{
+    runStreamCommitIndexed(20, 38, 64);
+}
+
 // Main cm1 shape (2^22 x 38, blowup 2): exercises the SERIAL aliased-LDE
 // flow -- the production slot configuration.
 TEST(GOLDILOCKS_TEST, stream_commit_reduced_main_shape)

--- a/pil2-stark/src/goldilocks/tests/test_stream_commit_gpu.cu
+++ b/pil2-stark/src/goldilocks/tests/test_stream_commit_gpu.cu
@@ -189,8 +189,8 @@ TEST(GOLDILOCKS_TEST, stream_commit_reduced_small)
 static void runStreamCommitIndexed(uint64_t nBits, uint64_t nCols, uint64_t nEntries)
 {
     const uint64_t nBitsExt = nBits + 1;
-    const uint32_t CAP = 4, TPB = 128;
-    const uint64_t N = 1ull << nBits, NExt = 1ull << nBitsExt;
+    const uint32_t CAP = 4;
+    const uint64_t N = 1ull << nBits;
     const uint64_t INDEX_BITS = 32;
 
     ASSERT_LE(nCols, 38u);
@@ -211,7 +211,7 @@ static void runStreamCommitIndexed(uint64_t nBits, uint64_t nCols, uint64_t nEnt
     const uint64_t rowWords = wordsFor(rowW), entWords = wordsFor(tabW);
 
     // Instruction table + per-row values, then BOTH encodings of the same trace.
-    std::vector<uint64_t> table(nEntries * entWords), tabVals(tabW.size());
+    std::vector<uint64_t> table(nEntries * entWords);
     std::vector<std::vector<uint64_t>> entryVals(nEntries, std::vector<uint64_t>(tabW.size()));
     uint64_t x = 0x9E3779B97F4A7C15ull;
     auto next = [&]() { x ^= x << 13; x ^= x >> 7; x ^= x << 17; return x; };
@@ -222,7 +222,7 @@ static void runStreamCommitIndexed(uint64_t nBits, uint64_t nCols, uint64_t nEnt
 
     std::vector<uint64_t> hCompact(N * rowWords), hFull(N * MAIN_WORDS);
     {
-        std::vector<uint64_t> rowVals(nCols), compactVals(rowW.size()), fullVals(nCols);
+        std::vector<uint64_t> compactVals(rowW.size()), fullVals(nCols);
         for (uint64_t r = 0; r < N; r++) {
             uint64_t idx = r % nEntries;
             compactVals[0] = idx;

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -102,6 +102,83 @@ __global__ void unpack(
     }
 }
 
+// Read `nbits` from a packed stream at cursor (word,idx,off), advancing the cursor.
+// Mirrors unpack()'s bit-walk exactly so indexed output is bit-identical.
+__device__ __forceinline__ uint64_t idx_read_bits(
+    const uint64_t* base, uint64_t words, uint64_t &word, uint64_t &idx, uint64_t &off, uint64_t nbits)
+{
+    uint64_t val;
+    uint64_t bits_left = 64 - off;
+    if (nbits <= bits_left) {
+        uint64_t mask = (nbits == 64) ? ~0ULL : ((1ULL << nbits) - 1ULL);
+        val = (word >> off) & mask;
+        off += nbits;
+        if (off == 64 && idx + 1 < words) { word = base[++idx]; off = 0; }
+    } else {
+        uint64_t low = word >> off;
+        word = base[++idx];
+        uint64_t high = word & ((1ULL << (nbits - bits_left)) - 1ULL);
+        val = (high << bits_left) | low;
+        off = nbits - bits_left;
+    }
+    return val;
+}
+
+// Indexed unpack: each compact row holds a leading instruction index plus the runtime
+// columns; the instruction-derived columns live once in `table`. Two bit cursors (row,
+// table); each output column c is sourced per d_col_source[c]. Bit-identical to unpack().
+__global__ void unpack_indexed(
+    const uint64_t* src,             // compact rows: words_per_row each
+    const uint64_t* table,           // instruction table: words_per_entry each
+    uint64_t* dst,
+    uint64_t nRows,
+    uint64_t nCols,
+    uint64_t words_per_row,
+    uint64_t words_per_entry,
+    const uint64_t* d_unpack_info,   // nbits per output column
+    const uint8_t*  d_col_source,    // 0 = from row stream, 1 = from table stream
+    uint64_t index_bits,             // width of the leading index header in the row
+    uint64_t num_entries,            // instruction-table entry count (index bound)
+    Layout layout
+) {
+    // One shared word per column carries BOTH the width and the source flag
+    // (nbits in the low 32 bits, source in bit 32) -- nbits <= 64, so they fit.
+    // Folding them keeps the inner loop at a single shared read instead of also
+    // taking a dependent global load for d_col_source, and keeps the shared
+    // footprint identical to the plain unpack, so unpack_trace's sharedMemSize
+    // (nCols * 8) covers both kernels unchanged. This kernel is DRAM-bound (the
+    // strided row reads dominate), so treat it as hygiene, not a throughput win.
+    extern __shared__ uint64_t shared_unpack_info[];
+    for (uint64_t i = threadIdx.x; i < nCols; i += blockDim.x) {
+        shared_unpack_info[i] = d_unpack_info[i] | ((uint64_t)(d_col_source[i] != 0) << 32);
+    }
+    __syncthreads();
+
+    uint64_t row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= nRows) return;
+
+    const uint64_t* rbase = src + row * words_per_row;
+    uint64_t rword = rbase[0], ridx = 0, roff = 0;
+    uint64_t index = idx_read_bits(rbase, words_per_row, rword, ridx, roff, index_bits);
+    // A witness bug can put an out-of-range index here. The CPU unpack reports it and
+    // aborts; a kernel cannot, so fall back to entry 0 to stay in bounds -- the proof
+    // then simply fails instead of reading past the table.
+    if (index >= num_entries) index = 0;
+
+    const uint64_t* tbase = table + index * words_per_entry;
+    uint64_t tword = tbase[0], tidx = 0, toff = 0;
+
+    for (uint64_t c = 0; c < nCols; c++) {
+        uint64_t info = shared_unpack_info[c];
+        uint64_t nbits = info & 0xFFFFFFFFull;
+        // Warp-uniform: col_source depends only on c, so this never diverges.
+        uint64_t val = (info >> 32)
+            ? idx_read_bits(tbase, words_per_entry, tword, tidx, toff, nbits)
+            : idx_read_bits(rbase, words_per_row, rword, ridx, roff, nbits);
+        dst[getBufferOffset(row, c, nRows, nCols, layout)] = val;
+    }
+}
+
 void unpack_fixed(
     uint64_t* d_num_packed_words,
     uint64_t* d_unpack_info,
@@ -144,17 +221,47 @@ void unpack_trace(
     dim3 blocks((nRows + threads.x - 1) / threads.x);
 
     size_t sharedMemSize = nCols * sizeof(uint64_t);
+    Layout layout = resolveLayout(63 - __builtin_clzll(nRows), nCols);
     TimerStartCategoryGPU(timer, UNPACK_TRACE);
-    // cm1 unpack: same storage layout the commit/LDE uses (resolveLayout on the small domain).
-    unpack<<<blocks, threads, sharedMemSize, stream>>>(
-        src,
-        dst,
-        nRows,
-        nCols,
-        air_instance_info->d_num_packed_words,
-        air_instance_info->unpack_info,
-        resolveLayout(63 - __builtin_clzll(nRows), nCols)
-    );
+    // d_col_source (set at setup from PackedInfo) is what makes an air indexed; the
+    // table arrives later per program. Dispatch on the descriptor, NOT on the table:
+    // an indexed air with no table must abort, because the plain walk would happily
+    // decode compact rows as full ones and yield a silently wrong trace.
+    if (air_instance_info->d_col_source != nullptr) {
+        if (air_instance_info->d_instr_table == nullptr) {
+            zklog.error("unpack_trace: air (" + std::to_string(air_instance_info->airgroupId) + "," +
+                        std::to_string(air_instance_info->airId) + ") is indexed but no instruction "
+                        "table is registered; call register_instruction_table first");
+            exitProcess();
+        }
+        // Indexed cm1 unpack: compact rows + shared instruction table reconstruct the full
+        // nCols output. Same storage layout as the plain path.
+        unpack_indexed<<<blocks, threads, sharedMemSize, stream>>>(
+            src,
+            air_instance_info->d_instr_table,
+            dst,
+            nRows,
+            nCols,
+            air_instance_info->num_packed_words,
+            air_instance_info->words_per_entry,
+            air_instance_info->unpack_info,
+            air_instance_info->d_col_source,
+            air_instance_info->index_bits,
+            air_instance_info->num_entries,
+            layout
+        );
+    } else {
+        // cm1 unpack: same storage layout the commit/LDE uses (resolveLayout on the small domain).
+        unpack<<<blocks, threads, sharedMemSize, stream>>>(
+            src,
+            dst,
+            nRows,
+            nCols,
+            air_instance_info->d_num_packed_words,
+            air_instance_info->unpack_info,
+            layout
+        );
+    }
     TimerStopCategoryGPU(timer, UNPACK_TRACE);
     CHECKCUDAERR(cudaGetLastError());
 }

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -13,7 +13,7 @@ use proofman_starks_lib_c::{init_gpu_setup_c, set_gpu_mode_c, GOLDILOCKS_MERKLE_
 use proofman_starks_lib_c::{load_device_const_pols_c, load_device_setup_c};
 use proofman_starks_lib_c::{
     get_stream_proofs_c, get_stream_proofs_non_blocking_c, reset_device_streams_c, get_instances_ready_c,
-    free_device_buffers_c, use_packed_trace_c, is_first_gpu_buffer_borrowed_c,
+    free_device_buffers_c, use_packed_trace_c, register_instruction_table_c, is_first_gpu_buffer_borrowed_c,
 };
 use crate::add_publics_circom;
 use proofman_verifier::verifier;
@@ -2331,6 +2331,42 @@ where
 
     pub fn register_custom_commits(&self, custom_commits_fixed: HashMap<String, PathBuf>) -> ProofmanResult<()> {
         self.pctx.initialize_custom_commits(custom_commits_fixed, &self.sctx, false)
+    }
+
+    /// Upload (per program) the instruction table for an indexed air. `table` is
+    /// `num_entries * words_per_entry` packed u64 words.
+    ///
+    /// Must be called AFTER the setups are loaded (the air's `AirInstanceInfo` has to
+    /// exist to receive it) and BEFORE the first commit of that program -- the contribution
+    /// phase already unpacks. An air with an indexed descriptor but no table aborts at
+    /// unpack rather than silently decoding compact rows as full ones.
+    pub fn register_instruction_table(
+        &self,
+        airgroup_id: usize,
+        air_id: usize,
+        table: &[u64],
+        num_entries: u64,
+        words_per_entry: u64,
+    ) -> ProofmanResult<()> {
+        // The C side copies num_entries * words_per_entry words out of `table`; a short
+        // slice would be an out-of-bounds read there, so reject it here where we can.
+        let expected = (num_entries as usize).saturating_mul(words_per_entry as usize);
+        if table.len() != expected {
+            return Err(ProofmanError::InvalidParameters(format!(
+                "register_instruction_table [{airgroup_id}:{air_id}]: table has {} words, expected \
+                 num_entries ({num_entries}) * words_per_entry ({words_per_entry}) = {expected}",
+                table.len()
+            )));
+        }
+        register_instruction_table_c(
+            self.pctx.get_device_buffers_ptr(),
+            airgroup_id as u64,
+            air_id as u64,
+            table,
+            num_entries,
+            words_per_entry,
+        );
+        Ok(())
     }
 
     pub fn register_witness(&self, witness_lib: &mut dyn WitnessLibrary<F>, library: Library) -> ProofmanResult<()> {
@@ -5226,6 +5262,10 @@ where
     /// (caller takes the legacy stream path) when the AIR is not slot-eligible,
     /// no slot token is free, or the C side rejects the shape.
     ///
+    /// Indexed AIRs are eligible: the C side looks up the air's indexed descriptor
+    /// (col_source / index_bits / words_per_entry) and its uploaded instruction
+    /// table from the first GPU's AirInstanceInfo, and drives the indexed slot
+    /// unpack -- hence airgroup_id/air_id are passed through.
     #[allow(clippy::too_many_arguments)]
     fn try_slot_commit(
         pctx: &ProofCtx<F>,
@@ -5266,6 +5306,8 @@ where
         let rc = commit_witness_streaming_c(
             pctx.get_device_buffers_ptr(),
             slot,
+            airgroup_id as u64,
+            air_id as u64,
             trace as *mut c_void,
             ss.n_bits,
             ss.n_bits_ext,
@@ -5282,7 +5324,10 @@ where
             // busy (streamCommitAcquireRegion could not claim every overlapped
             // first-GPU stream). Both mean "take the legacy path this time".
             // Anything else is a misconfiguration worth surfacing (e.g. -15 wrong
-            // hash family, -13 shape/slot-size drift).
+            // hash family, -13 shape/slot-size drift, -16 indexed air whose
+            // instruction table was never registered, -4 incomplete indexed
+            // descriptor). Note the legacy fallback is NOT a rescue for -16: the
+            // prover-side unpack aborts on the same missing table.
             if rc != -14 {
                 tracing::warn!(
                     "Streaming slot commit rejected (rc={rc}) for instance {instance_id} [{airgroup_id}:{air_id}]; using legacy path"

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -2348,6 +2348,14 @@ where
         num_entries: u64,
         words_per_entry: u64,
     ) -> ProofmanResult<()> {
+        // An empty descriptor would register nothing, leave d_instr_table null, and only
+        // surface as an abort at the first unpack -- far from the cause. Reject it here.
+        if num_entries == 0 || words_per_entry == 0 {
+            return Err(ProofmanError::InvalidParameters(format!(
+                "register_instruction_table [{airgroup_id}:{air_id}]: num_entries ({num_entries}) and \
+                 words_per_entry ({words_per_entry}) must both be > 0"
+            )));
+        }
         // The C side copies num_entries * words_per_entry words out of `table`; a short
         // slice would be an out-of-bounds read there, so reject it here where we can.
         let expected = (num_entries as usize).saturating_mul(words_per_entry as usize);

--- a/provers/starks-lib-c/bindings_starks.rs
+++ b/provers/starks-lib-c/bindings_starks.rs
@@ -621,7 +621,16 @@ extern "C" {
         d_commit_buffers: *mut ::std::os::raw::c_void,
         packed_trace: bool,
     );
-    
+
+    pub fn register_instruction_table(
+        d_commit_buffers: *mut ::std::os::raw::c_void,
+        airgroup_id: u64,
+        air_id: u64,
+        table: *const u64,
+        num_entries: u64,
+        words_per_entry: u64,
+    );
+
     pub fn free_device_buffers_recursivef(d_buffers: *mut ::std::os::raw::c_void);
     
     pub fn free_device_buffers(d_buffers: *mut ::std::os::raw::c_void);
@@ -705,6 +714,8 @@ extern "C" {
     pub fn commit_witness_streaming(
         d_buffers: *mut ::std::os::raw::c_void,
         slot_idx: u64,
+        airgroup_id: u64,
+        air_id: u64,
         packed: *mut ::std::os::raw::c_void,
         n_bits: u64,
         n_bits_ext: u64,

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -1413,6 +1413,19 @@ pub fn use_packed_trace_c(d_commit_buffers: *mut ::std::os::raw::c_void, packed_
     }
 }
 
+pub fn register_instruction_table_c(
+    d_commit_buffers: *mut ::std::os::raw::c_void,
+    airgroup_id: u64,
+    air_id: u64,
+    table: &[u64],
+    num_entries: u64,
+    words_per_entry: u64,
+) {
+    unsafe {
+        register_instruction_table(d_commit_buffers, airgroup_id, air_id, table.as_ptr(), num_entries, words_per_entry);
+    }
+}
+
 pub fn gen_device_buffers_recursivef_c(
     p_setup_ctx: *mut u8,
     prover_buffer_size: u64,
@@ -1561,6 +1574,8 @@ pub fn configure_stream_commit_slots_c(d_buffers: *mut ::std::os::raw::c_void, n
 pub fn commit_witness_streaming_c(
     d_buffers: *mut ::std::os::raw::c_void,
     slot_idx: u64,
+    airgroup_id: u64,
+    air_id: u64,
     packed: *mut ::std::os::raw::c_void,
     n_bits: u64,
     n_bits_ext: u64,
@@ -1573,6 +1588,8 @@ pub fn commit_witness_streaming_c(
         commit_witness_streaming(
             d_buffers,
             slot_idx,
+            airgroup_id,
+            air_id,
             packed,
             n_bits,
             n_bits_ext,

--- a/setup/pil2-stark/src/types/security/pcs/whir.rs
+++ b/setup/pil2-stark/src/types/security/pcs/whir.rs
@@ -864,8 +864,8 @@ mod tests {
         let grinding_bits_folding = &sec.grinding_bits_folding;
         assert!(grinding_bits_folding.len() == 6, "Expected 6 iterations, got {}", grinding_bits_folding.len());
         for (i, g) in grinding_bits_folding.iter().enumerate() {
-            for s in 0..g.len() {
-                assert_eq!(g[s], 0, "grinding_bits_folding mismatch for iteration {i}, round {}: got {}", s + 1, g[s]);
+            for (s, bits) in g.iter().enumerate() {
+                assert_eq!(*bits, 0, "grinding_bits_folding mismatch for iteration {i}, round {}: got {bits}", s + 1);
             }
         }
 
@@ -1015,8 +1015,8 @@ mod tests {
         let grinding_bits_folding = &sec.grinding_bits_folding;
         assert!(grinding_bits_folding.len() == 5, "Expected 5 iterations, got {}", grinding_bits_folding.len());
         for (i, g) in grinding_bits_folding.iter().enumerate() {
-            for s in 0..g.len() {
-                assert_eq!(g[s], 0, "grinding_bits_folding mismatch for iteration {i}, round {}: got {}", s + 1, g[s]);
+            for (s, bits) in g.iter().enumerate() {
+                assert_eq!(*bits, 0, "grinding_bits_folding mismatch for iteration {i}, round {}: got {bits}", s + 1);
             }
         }
 


### PR DESCRIPTION
Introduces the indexed_trace_row! macro companion and the CPU/GPU unpack paths that reconstruct full cm1 columns from compact rows plus a shared per-program instruction table, wired through the PackedInfo FFI and a register_instruction_table entry point on both backends.