### PR TITLE
GPU stream size classes and witness admission control

### DIFF
--- a/common/src/gpu_stream_layout.rs
+++ b/common/src/gpu_stream_layout.rs
@@ -1,0 +1,431 @@
+//! Cutting the per-GPU aux-trace budget into stream size classes.
+//!
+//! Per-air aux-trace requirements are far from uniform — one outlier air can need several times the
+//! next largest — so sizing every stream to the maximum buys concurrency at the outlier's price. The
+//! budget is instead cut into two classes: *large*, sized to the biggest air so nothing is homeless,
+//! and *regular*, sized to whichever smaller air requirement carves best. A proof runs on any stream
+//! at least as large as it needs, so an air between the two sizes has only the large streams.
+//!
+//! Streams are added keeping the classes in equilibrium — one large per [`REGULARS_PER_LARGE`]
+//! regulars — so growth goes 1L, 1L+1R, 1L+2R, 2L+2R, … Whatever they leave becomes recursive streams.
+//!
+//! Every class is floored at the largest compressor / vadcop_final / recursive launch, since those
+//! share the non-recursive streams with basics (see `RecursiveScheduler::next_nonrecursive`).
+
+/// One aux-trace size class: `count` streams of `size` field elements each.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamClass {
+    pub size: usize,
+    pub count: usize,
+}
+
+/// How one GPU's aux-trace budget is cut up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamLayout {
+    /// The large and (when funded) regular class, in that order — at most two entries. Both host
+    /// basic *and* compressor/vadcop_final launches. Never empty, and `basic[0].size` covers the
+    /// largest air, so no proof is left without a home.
+    pub basic: Vec<StreamClass>,
+    /// Recursive1/recursive2-only streams.
+    pub recursive: StreamClass,
+    /// Budget left over: smaller than any class that could still have been cut.
+    pub unused: usize,
+}
+
+/// Recursive streams kept funded before any basic class beyond the first is cut. Basic classes are
+/// funded first, so without a floor they spend the last byte and aggregation's small proofs end up
+/// running a handful at a time in whatever huge basic class is free. A floor, not a reservation:
+/// the remainder still becomes recursive streams up to the caller's cap.
+const RECURSIVE_STREAM_FLOOR: usize = 1;
+
+/// How close the two class sizes must be before the split collapses to one uniform class. A split that
+/// buys no extra stream is a pure loss — it only confines the airs above the smaller class — but
+/// collapsing costs recursive streams (uniform classes are larger), so a genuine outlier keeps its split.
+const UNIFORM_COLLAPSE_RATIO: f64 = 1.25;
+
+/// Target regular streams per large stream. The carve adds whichever class is behind this ratio,
+/// so neither the outlier nor the bulk airs end up with a single stream on a card that could
+/// fund both.
+const REGULARS_PER_LARGE: usize = 2;
+
+impl StreamLayout {
+    pub fn n_basic_streams(&self) -> usize {
+        self.basic.iter().map(|c| c.count).sum()
+    }
+
+    /// Buffer sizes for the basic streams, in stream order (largest class first).
+    pub fn basic_stream_sizes(&self) -> Vec<usize> {
+        self.basic.iter().flat_map(|c| std::iter::repeat_n(c.size, c.count)).collect()
+    }
+}
+
+/// Streams bought for one (large, regular) pairing: counts plus the budget still unspent.
+#[derive(Clone, Copy)]
+struct Carve {
+    n_large: usize,
+    n_regular: usize,
+    remaining: usize,
+}
+
+/// Grow both classes from the mandatory first large stream, always adding whichever is behind the
+/// [`REGULARS_PER_LARGE`] equilibrium. A class that no longer fits yields to the other rather than
+/// ending the carve — that turns 2L+2R into 1L+3R on a card that cannot afford a second large.
+fn grow(budget: usize, large: usize, regular: usize, reserve: usize, max_basic_streams: usize) -> Carve {
+    let mut carve = Carve { n_large: 1, n_regular: 0, remaining: budget - large };
+    while carve.n_large + carve.n_regular < max_basic_streams {
+        let regular_first = carve.n_regular < REGULARS_PER_LARGE * carve.n_large;
+        // `regular == 0` means no candidate below the large size; those entries never fit.
+        let wanted = if regular_first { [regular, large] } else { [large, regular] };
+        let affordable = carve.remaining.saturating_sub(reserve);
+        match wanted.iter().find(|&&s| s > 0 && s <= affordable) {
+            // `regular` is strictly below `large` (distinct sizes), so the size identifies the class.
+            Some(&size) => {
+                carve.remaining -= size;
+                if size == large {
+                    carve.n_large += 1;
+                } else {
+                    carve.n_regular += 1;
+                }
+            }
+            None => break,
+        }
+    }
+    carve
+}
+
+/// Cut `budget` (in field elements, per GPU) into a large and a regular stream class.
+///
+/// `basic_sizes_desc` is the per-air basic requirement, largest first; duplicates are harmless.
+/// `class_floor` is the smallest a basic class may be: it must hold anything besides a basic proof that
+/// can land on one of these streams — today the compressor/vadcop_final launches that share them.
+/// `recursive_size` sizes the recursive1/recursive2 class.
+///
+/// The large size is fixed by the biggest air. The regular size is chosen by carving once per
+/// candidate air requirement and keeping the one that buys the most basic streams, ties going to the
+/// larger size — a smaller regular exiles every air above it, so it must earn its place.
+///
+/// Basic streams are funded first — they are the only home for basics *and* compressors — and
+/// aggregation takes the remainder, subject only to [`RECURSIVE_STREAM_FLOOR`].
+///
+/// Returns `None` when the budget cannot even hold one stream for the largest air.
+pub fn plan_stream_layout(
+    budget: usize,
+    basic_sizes_desc: &[usize],
+    class_floor: usize,
+    recursive_size: usize,
+    max_basic_streams: usize,
+    max_recursive_streams: usize,
+) -> Option<StreamLayout> {
+    if max_basic_streams == 0 {
+        return None;
+    }
+
+    // The candidate sizes are the distinct air requirements, each raised to the floor so either class
+    // can also take a compressor and any contributions commit. Largest first.
+    let mut sizes: Vec<usize> = basic_sizes_desc.iter().map(|&s| s.max(class_floor)).collect();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+    sizes.dedup();
+
+    // The large class must hold anything that can land on a non-recursive stream.
+    let &large = sizes.first()?;
+    if large == 0 || budget < large {
+        return None;
+    }
+
+    let reserve = recursive_size * RECURSIVE_STREAM_FLOOR.min(max_recursive_streams);
+    // Most streams wins; the size in the key breaks ties toward the larger regular class.
+    // Uniform: one class, sized to the largest air. Also the fallback when there is only one size.
+    let uniform = grow(budget, large, 0, reserve, max_basic_streams);
+    let (regular, carve) = sizes
+        .iter()
+        .skip(1)
+        .map(|&regular| (regular, grow(budget, large, regular, reserve, max_basic_streams)))
+        .chain(std::iter::once((0, uniform)))
+        .max_by_key(|(size, c)| (c.n_large + c.n_regular, *size))
+        .expect("the chained fallback is always a candidate");
+
+    // No extra stream and sizes close: collapse, so nothing is confined to a subset of the streams.
+    let split_streams = carve.n_large + carve.n_regular;
+    let (regular, carve) =
+        if regular > 0 && uniform.n_large >= split_streams && large as f64 <= regular as f64 * UNIFORM_COLLAPSE_RATIO {
+            (0, uniform)
+        } else {
+            (regular, carve)
+        };
+
+    let mut basic = vec![StreamClass { size: large, count: carve.n_large }];
+    if carve.n_regular > 0 {
+        basic.push(StreamClass { size: regular, count: carve.n_regular });
+    }
+
+    let mut remaining = carve.remaining;
+    let n_recursive = match recursive_size {
+        0 => 0,
+        size => max_recursive_streams.min(remaining / size),
+    };
+    remaining -= n_recursive * recursive_size;
+
+    Some(StreamLayout { basic, recursive: StreamClass { size: recursive_size, count: n_recursive }, unused: remaining })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Measured from a zisk proving key, GB, largest first. Keccakf is the outlier: 14.57 vs 6.45.
+    const ZISK_BASIC_GB: &[f64] = &[14.57, 6.45, 6.26, 5.82, 5.57, 4.74, 4.52, 4.43, 3.82, 2.63, 1.47, 0.75];
+    const ZISK_COMPRESSOR_GB: f64 = 6.24;
+    const ZISK_RECURSIVE_GB: f64 = 1.33;
+    const ZISK_BUDGET_GB: f64 = 25.23;
+
+    fn gb(v: f64) -> usize {
+        (v * (1 << 30) as f64 / 8.0) as usize
+    }
+
+    fn zisk_layout(budget_gb: f64, max_basic: usize, max_recursive: usize) -> StreamLayout {
+        let sizes: Vec<usize> = ZISK_BASIC_GB.iter().copied().map(gb).collect();
+        plan_stream_layout(
+            gb(budget_gb),
+            &sizes,
+            gb(ZISK_COMPRESSOR_GB),
+            gb(ZISK_RECURSIVE_GB),
+            max_basic,
+            max_recursive,
+        )
+        .expect("zisk budget holds the largest air")
+    }
+
+    /// The carve is two sizes at most, whatever the budget or the air distribution.
+    #[test]
+    fn the_carve_never_has_more_than_two_sizes() {
+        let uneven = [gb(14.5), gb(12.0), gb(9.1), gb(7.0), gb(3.2)];
+        for budget in [20.0, 26.15, 33.0, 40.0, 60.0, 80.0, 200.0] {
+            for sizes in [&ZISK_BASIC_GB.iter().copied().map(gb).collect::<Vec<_>>()[..], &uneven[..]] {
+                let layout =
+                    plan_stream_layout(gb(budget), sizes, gb(ZISK_COMPRESSOR_GB), gb(ZISK_RECURSIVE_GB), 16, 10);
+                let Some(layout) = layout else { continue };
+                assert!(layout.basic.len() <= 2, "budget {budget}: {:?}", layout.basic);
+            }
+        }
+    }
+
+    /// Neither class runs away with the card: streams are added 1L, 1L+1R, 1L+2R, 2L+2R, … Driven
+    /// by the stream cap on a budget large enough that only the cap binds.
+    #[test]
+    fn classes_grow_in_equilibrium() {
+        let expected = [(1, 0), (1, 1), (1, 2), (2, 2), (2, 3), (2, 4), (3, 4)];
+        for (max_basic, (n_large, n_regular)) in expected.into_iter().enumerate() {
+            let layout = zisk_layout(120.0, max_basic + 1, 10);
+            let got = (layout.basic[0].count, layout.basic.get(1).map_or(0, |c| c.count));
+            assert_eq!(got, (n_large, n_regular), "max_basic {}: {:?}", max_basic + 1, layout.basic);
+        }
+    }
+
+    /// Equilibrium wants a large stream next, but the remainder cannot fund one: the carve keeps
+    /// buying regulars rather than stopping there.
+    #[test]
+    fn a_class_that_no_longer_fits_yields_to_the_other() {
+        let layout = zisk_layout(70.0, 16, 10);
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 2 }, StreamClass { size: gb(6.45), count: 6 }]
+        );
+    }
+
+    /// 6.26 GB regulars would fit just as many streams as 6.45 GB ones, and picking them would
+    /// exile the 6.45 air to the large streams for nothing. Ties go to the larger size.
+    #[test]
+    fn a_smaller_regular_is_only_taken_when_it_buys_a_stream() {
+        for budget in [ZISK_BUDGET_GB, 33.0, 40.0, 60.0, 80.0] {
+            let layout = zisk_layout(budget, 16, 10);
+            assert_eq!(layout.basic[1].size, gb(6.45), "budget {budget}: {:?}", layout.basic);
+        }
+    }
+
+    /// The zisk budget buys a second class with no flag: the outlier gets its own, the rest share one.
+    #[test]
+    fn basic_classes_are_funded_before_recursive_streams() {
+        let layout = zisk_layout(ZISK_BUDGET_GB, 16, 10);
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 1 }, StreamClass { size: gb(6.45), count: 1 }]
+        );
+        assert!(layout.basic[1].size >= gb(ZISK_COMPRESSOR_GB), "every basic class must hold a compressor");
+        assert!(layout.recursive.count >= 3, "aggregation still gets the remainder: {:?}", layout.recursive);
+    }
+
+    /// Preloaded const trees push every non-outlier air below the compressor floor, so the floor
+    /// sizes the second class. Matches zisk1: 14.57 + 6.24, four recursive.
+    #[test]
+    fn preloaded_sizes_put_the_second_class_at_the_compressor_floor() {
+        let sizes = [gb(14.57), gb(5.9), gb(3.8), gb(2.6), gb(0.75)];
+        let layout =
+            plan_stream_layout(gb(26.15), &sizes, gb(ZISK_COMPRESSOR_GB), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 1 }, StreamClass { size: gb(ZISK_COMPRESSOR_GB), count: 1 }]
+        );
+        assert_eq!(layout.recursive.count, 4);
+    }
+
+    /// The floor must never cost this card its second basic class — that undoes the whole measured
+    /// gain (26.7s -> 21.5s) and the margin is thin, so pin it.
+    #[test]
+    fn the_recursive_floor_does_not_cost_the_second_class() {
+        let sizes = [gb(14.57), gb(5.9), gb(3.8), gb(2.6), gb(0.75)];
+        let layout =
+            plan_stream_layout(gb(26.15), &sizes, gb(ZISK_COMPRESSOR_GB), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
+        assert_eq!(layout.n_basic_streams(), 2, "second class lost to the floor: {:?}", layout.basic);
+        assert_eq!(layout.recursive.count, 4, "floor is a minimum, not a cap: {:?}", layout.recursive);
+    }
+
+    /// The floor is what stops a large budget from spending everything on classes.
+    #[test]
+    fn a_large_budget_still_gets_recursive_streams() {
+        let sizes = [gb(14.5), gb(12.0), gb(6.23), gb(3.8), gb(1.5)];
+        for budget in [33.0, 40.0, 80.0] {
+            let layout = plan_stream_layout(gb(budget), &sizes, gb(6.24), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
+            assert!(
+                layout.recursive.count >= RECURSIVE_STREAM_FLOOR,
+                "budget {budget}: {:?} / {:?}",
+                layout.basic,
+                layout.recursive
+            );
+        }
+    }
+
+    /// The recursive cap bounds the remainder: excess goes unused, not into extra streams.
+    #[test]
+    fn the_recursive_cap_still_bounds_the_remainder() {
+        let layout = zisk_layout(ZISK_BUDGET_GB, 16, 1);
+        assert_eq!(layout.recursive.count, 1);
+        assert!(layout.unused > 0);
+    }
+
+    /// A card with room to spare keeps cutting classes. Funding basic first means a large card can
+    /// leave aggregation nothing, so cap `max_basic_streams` to hold streams back.
+    #[test]
+    fn a_larger_budget_cuts_more_classes() {
+        let layout = zisk_layout(80.0, 16, 8);
+        assert!(layout.n_basic_streams() >= 4, "got {:?}", layout.basic);
+
+        // Holding the basic classes down is what leaves room for aggregation streams.
+        let capped = zisk_layout(80.0, 3, 8);
+        assert_eq!(capped.n_basic_streams(), 3);
+        assert_eq!(capped.recursive.count, 8);
+    }
+
+    /// Classes never drop below the compressor floor, even where a small air would fit.
+    #[test]
+    fn classes_never_fall_below_the_compressor_floor() {
+        let layout = zisk_layout(ZISK_BUDGET_GB, 16, 0);
+        for class in &layout.basic {
+            assert!(class.size >= gb(ZISK_COMPRESSOR_GB), "class {class:?} cannot host a compressor");
+        }
+    }
+
+    /// The carve is bounded by the stream cap, not only by memory.
+    #[test]
+    fn the_basic_stream_cap_is_respected() {
+        let layout = zisk_layout(80.0, 2, 0);
+        assert_eq!(layout.n_basic_streams(), 2);
+    }
+
+    /// Anything left over must be too small to have funded another class.
+    #[test]
+    fn leftover_is_smaller_than_any_further_class() {
+        let layout = zisk_layout(ZISK_BUDGET_GB, 16, 3);
+        assert!(layout.unused < gb(ZISK_COMPRESSOR_GB));
+    }
+
+    /// Prints the carve across budgets for a second near-outlier (14.5/12/6.23). Inspection only:
+    /// `cargo test -p proofman-common carve_shape -- --nocapture`.
+    #[test]
+    fn carve_shape_with_a_second_near_outlier() {
+        let sizes = [gb(14.5), gb(12.0), gb(6.23), gb(3.8), gb(1.5)];
+        for budget in [20.0, 26.15, 33.0, 40.0, 80.0] {
+            let layout = plan_stream_layout(gb(budget), &sizes, gb(6.24), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
+            let classes: Vec<String> = layout
+                .basic
+                .iter()
+                .map(|c| format!("{} x {:.2}", c.count, c.size as f64 * 8.0 / (1 << 30) as f64))
+                .collect();
+            println!(
+                "budget {budget:>6.2} -> basic [{}]  recursive {}  unused {:.2}",
+                classes.join(" + "),
+                layout.recursive.count,
+                layout.unused as f64 * 8.0 / (1 << 30) as f64,
+            );
+        }
+    }
+
+    /// A near-outlier the budget cannot give a regular class to falls back to the large streams.
+    /// The candidate search must keep looking past it instead of settling for one class.
+    #[test]
+    fn an_air_too_big_for_the_regular_class_falls_back_to_the_large_one() {
+        let sizes = [gb(14.5), gb(12.0), gb(6.23)];
+        let layout = plan_stream_layout(gb(26.15), &sizes, gb(6.24), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
+
+        // 14.5 + 12 overruns the budget, so the 12 GB air keeps the large class as its only home.
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(6.24), count: 1 }]
+        );
+        // The 6.23 GB air is below the floor, so its class is the floor -- never smaller.
+        assert!(layout.basic[1].size >= gb(6.23));
+        assert!(layout.recursive.count >= 3);
+    }
+
+    /// The measured ZisK key: 7.42 GB largest air against a 6.24 GB compressor floor (ratio 1.19). The
+    /// split `1x7.42 + 2x6.24` and uniform `3x7.42` buy the same three streams, so the split bought
+    /// nothing while confining the 7.42 air to one stream for the whole run. Collapse to uniform.
+    #[test]
+    fn a_split_that_buys_no_stream_collapses_to_uniform() {
+        let sizes: Vec<usize> =
+            [7.42, 5.99, 5.82, 5.57, 5.31, 4.52, 4.43, 3.82, 2.60, 1.47, 0.75].iter().map(|&g| gb(g)).collect();
+        let layout = plan_stream_layout(gb(26.18), &sizes, gb(6.24), gb(1.33), 16, 10).unwrap();
+        assert_eq!(layout.basic, vec![StreamClass { size: gb(7.42), count: 3 }], "should be uniform");
+        // Every air can now use every stream -- that is the whole point.
+        assert!(sizes.iter().all(|&s| s <= layout.basic[0].size));
+        // Uniform costs recursive streams; the trade must stay visible, not silent.
+        assert!(layout.recursive.count >= 1, "aggregation must keep at least the floor");
+    }
+
+    /// A genuine outlier keeps its own class: 14.57 against 6.45 is ratio 2.3, far outside the collapse
+    /// window, and there the split really does buy streams.
+    #[test]
+    fn a_real_outlier_still_gets_its_own_class() {
+        let layout = zisk_layout(70.0, 16, 10);
+        assert_eq!(layout.basic.len(), 2, "outlier must not be collapsed: {:?}", layout.basic);
+        assert_eq!(layout.basic[0].size, gb(14.57));
+    }
+
+    /// A budget under the largest air is a configuration error, not a silently truncated carve.
+    #[test]
+    fn too_small_a_budget_is_rejected() {
+        let sizes = [gb(14.57)];
+        assert!(plan_stream_layout(gb(10.0), &sizes, gb(6.24), gb(1.33), 16, 8).is_none());
+    }
+
+    /// Class 0 is sized by whichever of the largest air and the compressor floor is bigger.
+    #[test]
+    fn first_class_covers_both_the_largest_air_and_the_compressor() {
+        let layout = plan_stream_layout(gb(40.0), &[gb(2.0)], gb(9.0), gb(1.0), 16, 0).unwrap();
+        assert_eq!(layout.basic[0].size, gb(9.0));
+
+        let layout = plan_stream_layout(gb(40.0), &[gb(12.0)], gb(9.0), gb(1.0), 16, 0).unwrap();
+        assert_eq!(layout.basic[0].size, gb(12.0));
+    }
+
+    /// Stream order must match the class order the device carve walks.
+    #[test]
+    fn stream_sizes_expand_classes_largest_first() {
+        let layout = StreamLayout {
+            basic: vec![StreamClass { size: 9, count: 1 }, StreamClass { size: 4, count: 2 }],
+            recursive: StreamClass { size: 1, count: 3 },
+            unused: 0,
+        };
+        assert_eq!(layout.basic_stream_sizes(), vec![9, 4, 4]);
+        assert_eq!(layout.n_basic_streams(), 3);
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,7 @@
 mod air_instance;
 mod verbose_mode;
 mod distribution_ctx;
+mod gpu_stream_layout;
 mod mpi_ctx;
 mod proof_ctx;
 mod prover;
@@ -35,6 +36,7 @@ pub use std_mode::*;
 pub use publics::*;
 pub use utils::*;
 pub use distribution_ctx::*;
+pub use gpu_stream_layout::*;
 pub use custom_commits::*;
 pub use constraints::*;
 pub use fixed_cols::*;

--- a/common/src/memory_handler.rs
+++ b/common/src/memory_handler.rs
@@ -44,6 +44,19 @@ fn aligned_host_range(ptr: usize, bytes: usize) -> Option<(usize, usize)> {
 /// panic. Returns the distinct base pages (unregister each once on Drop); a registered buffer must
 /// never be reallocated — registration pins a specific address (see `reset`). Dedups the base page
 /// because `cudaHostRegister` rejects an already-registered one.
+/// Pin a long-lived host buffer so H2D can DMA straight out of it instead of taking the staging path.
+/// Returns the page base for [`unregister_host_buffer`]. Registration is not cheap: reused buffers only.
+pub fn register_host_buffer<T>(buffer: &[T]) -> Option<usize> {
+    let bytes = buffer.len().saturating_mul(std::mem::size_of::<T>());
+    let (base, size) = aligned_host_range(buffer.as_ptr() as usize, bytes)?;
+    register_host_memory_c(base as *mut c_void, size as u64).then_some(base)
+}
+
+/// Release a base from [`register_host_buffer`]. Must run before the buffer is freed.
+pub fn unregister_host_buffer(base: usize) {
+    unregister_host_memory_c(base as *mut c_void);
+}
+
 fn register_pool<F: PrimeField64>(buffers: &[Vec<F>]) -> Vec<usize> {
     let mut registered: Vec<usize> = Vec::with_capacity(buffers.len());
     let mut covered: HashSet<usize> = HashSet::with_capacity(buffers.len());

--- a/common/src/proof_ctx.rs
+++ b/common/src/proof_ctx.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
+use crate::{plan_stream_layout, StreamClass, StreamLayout};
 use crate::{MpiCtx, ProofmanError};
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::fs::File;
@@ -288,6 +289,10 @@ pub struct ProofCtx<F: PrimeField64> {
     pub d_buffers: Arc<DeviceBuffer>,
     pub gpu: bool,
     pub reload_fixed_pols_gpu: Arc<AtomicBool>,
+    /// Aux-trace size of each basic GPU stream, largest class first (empty until `set_device_buffers`,
+    /// and on CPU). An air can only run on a stream at least as large as its `prover_buffer_size`, so
+    /// this is what makes stream eligibility visible to the Rust-side schedulers.
+    pub basic_stream_sizes: Vec<usize>,
 }
 
 pub const MAX_INSTANCES: u64 = 1 << 17;
@@ -343,6 +348,7 @@ impl<F: PrimeField64> ProofCtx<F> {
             d_buffers: Arc::new(DeviceBuffer::default()),
             gpu,
             reload_fixed_pols_gpu: Arc::new(AtomicBool::new(false)),
+            basic_stream_sizes: Vec::new(),
         })
     }
 
@@ -1002,57 +1008,74 @@ impl<F: PrimeField64> ProofCtx<F> {
             }
         }
 
-        let max_size_buffer = (free_memory_gpu / 8.0).floor() as u64 - total_const_area - total_const_area_aggregation;
-        let max_prover_buffer_size = sctx.max_prover_buffer_size.max(setups_vadcop.max_prover_buffer_size);
+        // Wrapping here would carve streams out of a budget the card does not have, and only fail
+        // later inside cudaMalloc.
+        let max_size_buffer = ((free_memory_gpu / 8.0).floor() as u64)
+            .checked_sub(total_const_area + total_const_area_aggregation)
+            .ok_or_else(|| {
+                ProofmanError::InvalidConfiguration(format!(
+                    "Fixed polynomials need {} but only {} is free on the GPU",
+                    format_bytes((total_const_area + total_const_area_aggregation) as f64 * 8.0),
+                    format_bytes(free_memory_gpu),
+                ))
+            })?;
 
-        let n_streams_per_gpu = match gpu {
-            true => {
-                let max_number_proofs_per_gpu =
-                    max_number_streams_gpu.min(max_size_buffer as usize / max_prover_buffer_size);
-                if max_number_proofs_per_gpu < 1 {
-                    return Err(ProofmanError::InvalidConfiguration("Not enough GPU memory to run the proof".into()));
-                }
-                max_number_proofs_per_gpu
-            }
-            false => 1,
-        };
+        // Non-recursive streams also take compressor/vadcop_final launches, which floors their classes.
+        let recursive_capable_size = setups_vadcop.max_prover_recursive_buffer_size;
+        let max_prover_recursive2_buffer_size =
+            if aggregation { setups_vadcop.max_prover_recursive2_buffer_size } else { 0 };
 
-        let max_prover_buffer_size =
-            sctx.max_prover_buffer_size.max(setups_vadcop.max_prover_recursive_buffer_size) as u64;
-
-        let max_prover_recursive2_buffer_size = setups_vadcop.max_prover_recursive2_buffer_size as u64;
-
-        tracing::info!("Max prover buffer size: {}", format_bytes(max_prover_buffer_size as f64 * 8.0));
         tracing::info!(
-            "Max prover recursive buffer size: {}",
-            format_bytes(setups_vadcop.max_prover_recursive_buffer_size as f64 * 8.0)
+            "Max prover buffer size: {}",
+            format_bytes(sctx.max_prover_buffer_size.max(recursive_capable_size) as f64 * 8.0)
         );
+        tracing::info!("Max prover recursive buffer size: {}", format_bytes(recursive_capable_size as f64 * 8.0));
         tracing::info!(
             "Max prover recursive1/recursive2 buffer size: {}",
             format_bytes(setups_vadcop.max_prover_recursive2_buffer_size as f64 * 8.0)
         );
 
-        let mut gpu_available_memory = match gpu {
-            true => max_size_buffer as i64 - (n_streams_per_gpu * max_prover_buffer_size as usize) as i64,
-            false => 0,
+        let basic_sizes: Vec<usize> = sctx.prover_buffer_sizes.iter().map(|(_, size)| *size).collect();
+
+        let layout = match gpu {
+            true => plan_stream_layout(
+                max_size_buffer as usize,
+                &basic_sizes,
+                recursive_capable_size,
+                max_prover_recursive2_buffer_size,
+                max_number_streams_gpu,
+                if aggregation { max_number_recursive_streams_gpu } else { 0 },
+            )
+            .ok_or_else(|| ProofmanError::InvalidConfiguration("Not enough GPU memory to run the proof".into()))?,
+            // No device streams to carve: one nominal stream, sized for the largest proof.
+            false => StreamLayout {
+                basic: vec![StreamClass { size: sctx.max_prover_buffer_size.max(recursive_capable_size), count: 1 }],
+                recursive: StreamClass { size: max_prover_recursive2_buffer_size, count: 0 },
+                unused: 0,
+            },
         };
-        let mut n_recursive_streams_per_gpu = 0;
-        if aggregation {
-            while gpu_available_memory > 0 && n_recursive_streams_per_gpu < max_number_recursive_streams_gpu {
-                gpu_available_memory -= max_prover_recursive2_buffer_size as i64;
-                if gpu_available_memory < 0 {
-                    break;
-                }
-                n_recursive_streams_per_gpu += 1;
-            }
-        }
+
+        let aux_trace_sizes: Vec<u64> = layout.basic_stream_sizes().iter().map(|&s| s as u64).collect();
+        // Retained so the witness admission can tell which airs are confined to a subset of streams.
+        self.basic_stream_sizes = layout.basic_stream_sizes();
+        let n_streams_per_gpu = layout.n_basic_streams();
+        let n_recursive_streams_per_gpu = layout.recursive.count;
 
         if gpu {
+            let classes = layout
+                .basic
+                .iter()
+                .map(|c| format!("{} x {}", c.count, format_bytes(c.size as f64 * 8.0)))
+                .collect::<Vec<_>>()
+                .join(" + ");
             tracing::info!(
-                "Using {} streams per GPU for basic proofs and {} streams per GPU for recursive proofs. Using {} for fixed pols",
+                "Using {} streams per GPU for basic proofs ({}) and {} streams per GPU for recursive proofs. \
+                 Using {} for fixed pols, {} unused",
                 n_streams_per_gpu,
+                classes,
                 n_recursive_streams_per_gpu,
-                format_bytes((total_const_area + total_const_area_aggregation) as f64 * 8.0)
+                format_bytes((total_const_area + total_const_area_aggregation) as f64 * 8.0),
+                format_bytes(layout.unused as f64 * 8.0),
             );
         }
 
@@ -1063,18 +1086,16 @@ impl<F: PrimeField64> ProofCtx<F> {
 
         let n_gpus: u64 = gen_device_streams_c(
             d_buffers.get_ptr(),
-            n_streams_per_gpu as u64,
+            &aux_trace_sizes,
             n_recursive_streams_per_gpu as u64,
-            max_prover_buffer_size,
-            max_prover_recursive2_buffer_size,
+            max_prover_recursive2_buffer_size as u64,
             max_pinned_proof_size,
             self.global_info.transcript_arity as u64,
         );
 
         alloc_device_large_buffers_c(
             d_buffers.get_ptr(),
-            max_prover_buffer_size,
-            max_prover_recursive2_buffer_size,
+            max_prover_recursive2_buffer_size as u64,
             total_const_area,
             total_const_area_aggregation,
         );

--- a/common/src/setup_ctx.rs
+++ b/common/src/setup_ctx.rs
@@ -4,6 +4,7 @@ use std::ffi::c_void;
 use fields::PrimeField64;
 use proofman_starks_lib_c::{expressions_bin_new_c, expressions_bin_free_c};
 
+use crate::format_bytes;
 use crate::load_const_pols;
 use crate::{GlobalInfo, GlobalInfoAir};
 use crate::ProofmanError;
@@ -178,6 +179,29 @@ impl<F: PrimeField64> SetupsVadcop<F> {
                 .max(setup_vadcop_final.prover_buffer_size as usize + vadcop_final_trace_size as usize)
                 .max(setup_vadcop_final_compressed.prover_buffer_size as usize + vadcop_final_trace_size as usize);
 
+            // This floors every non-recursive GPU stream class, so which term dominates decides
+            // whether a regular class fits at all.
+            tracing::debug!(
+                "Recursive buffer requirement: compressor {}, recursive1 {}, recursive2 {}, vadcop_final {}, vadcop_final_compressed {}",
+                format_bytes(
+                    (sctx_compressor.max_prover_buffer_size + sctx_compressor.max_prover_trace_size) as f64 * 8.0
+                ),
+                format_bytes(
+                    (sctx_recursive1.max_prover_buffer_size + sctx_recursive1.max_prover_trace_size) as f64 * 8.0
+                ),
+                format_bytes(
+                    (sctx_recursive2.max_prover_buffer_size + sctx_recursive2.max_prover_trace_size) as f64 * 8.0
+                ),
+                format_bytes(
+                    (setup_vadcop_final.prover_buffer_size as usize + vadcop_final_trace_size as usize) as f64 * 8.0
+                ),
+                format_bytes(
+                    (setup_vadcop_final_compressed.prover_buffer_size as usize + vadcop_final_trace_size as usize)
+                        as f64
+                        * 8.0
+                ),
+            );
+
             let max_pinned_proof_size = sctx_compressor
                 .max_pinned_proof_size
                 .max(sctx_recursive1.max_pinned_proof_size)
@@ -272,6 +296,7 @@ pub struct SetupRepository<F: PrimeField64> {
     max_const_tree_size: usize,
     max_const_size: usize,
     max_prover_buffer_size: usize,
+    prover_buffer_sizes: Vec<((usize, usize), usize)>,
     max_prover_contributions_size: usize,
     max_prover_trace_size: usize,
     max_pinned_proof_size: usize,
@@ -324,6 +349,7 @@ impl<F: PrimeField64> SetupRepository<F> {
         let mut max_n_bits_ext = 0;
         let mut max_prover_contributions_size = 0;
         let mut max_prover_buffer_size = 0;
+        let mut prover_buffer_sizes: Vec<((usize, usize), usize)> = Vec::new();
         let mut max_prover_trace_size = 0;
         let mut max_pinned_proof_size = 0;
         let mut total_const_pols_size = 0;
@@ -375,6 +401,7 @@ impl<F: PrimeField64> SetupRepository<F> {
                     if max_prover_buffer_size < setup.prover_buffer_size {
                         max_prover_buffer_size = setup.prover_buffer_size;
                     }
+                    prover_buffer_sizes.push(((airgroup_id, air_id), setup.prover_buffer_size as usize));
                     if max_prover_contributions_size < setup.contributions_size {
                         max_prover_contributions_size = setup.contributions_size;
                     }
@@ -435,6 +462,8 @@ impl<F: PrimeField64> SetupRepository<F> {
             );
         }
 
+        prover_buffer_sizes.sort_by(|(ka, sa), (kb, sb)| sb.cmp(sa).then(ka.cmp(kb)));
+
         Ok(Self {
             setups,
             fixed_groups,
@@ -444,6 +473,7 @@ impl<F: PrimeField64> SetupRepository<F> {
             max_const_size,
             max_prover_contributions_size: max_prover_contributions_size as usize,
             max_prover_buffer_size: max_prover_buffer_size as usize,
+            prover_buffer_sizes,
             max_prover_trace_size,
             max_pinned_proof_size: max_pinned_proof_size as usize,
             total_const_pols_size,
@@ -463,6 +493,8 @@ pub struct SetupCtx<F: PrimeField64> {
     pub max_const_size: usize,
     pub max_prover_contributions_size: usize,
     pub max_prover_buffer_size: usize,
+    /// Per-air prover buffer size, largest first. See `SetupRepository::prover_buffer_sizes`.
+    pub prover_buffer_sizes: Vec<((usize, usize), usize)>,
     pub max_prover_trace_size: usize,
     pub max_pinned_proof_size: usize,
     pub max_witness_size: usize,
@@ -488,6 +520,7 @@ impl<F: PrimeField64> SetupCtx<F> {
         let max_const_size = setup_repository.max_const_size;
         let max_prover_contributions_size = setup_repository.max_prover_contributions_size;
         let max_prover_buffer_size = setup_repository.max_prover_buffer_size;
+        let prover_buffer_sizes = setup_repository.prover_buffer_sizes.clone();
         let max_prover_trace_size = setup_repository.max_prover_trace_size;
         let max_pinned_proof_size = setup_repository.max_pinned_proof_size;
         let total_const_pols_size = setup_repository.total_const_pols_size;
@@ -501,6 +534,7 @@ impl<F: PrimeField64> SetupCtx<F> {
             max_const_size,
             max_prover_contributions_size,
             max_prover_buffer_size,
+            prover_buffer_sizes,
             max_witness_size,
             max_trace_size,
             max_prover_trace_size,

--- a/pil2-components/lib/std/rs/src/std_virtual_table.rs
+++ b/pil2-components/lib/std/rs/src/std_virtual_table.rs
@@ -10,7 +10,10 @@ use rayon::prelude::*;
 use fields::PrimeField64;
 
 use witness::WitnessComponent;
-use proofman_common::{AirInstance, BufferPool, ProofCtx, ProofmanResult, ProofmanError, SetupCtx, TraceInfo};
+use proofman_common::{
+    register_host_buffer, unregister_host_buffer, AirInstance, BufferPool, ProofCtx, ProofmanError, ProofmanResult,
+    SetupCtx, TraceInfo,
+};
 use proofman_hints::{get_hint_ids_by_name, HintFieldOptions};
 
 use crate::{get_global_hint_field_constant_a_as, get_hint_field_constant_a_as, get_hint_field_constant_as};
@@ -37,6 +40,17 @@ pub struct VirtualTableAir<F: PrimeField64> {
     // Persistent trace buffer slot. Pre-allocated in `StdVirtualTable::new`; taken in
     // `calculate_witness` and refilled by `ProofCtx::free_instance_traces`.
     trace_buffer: Arc<Mutex<Option<Vec<F>>>>,
+    // Pinned-registration page base for `trace_buffer`; unpinned it takes the staging H2D path.
+    trace_buffer_pinned: Option<usize>,
+}
+
+impl<F: PrimeField64> Drop for VirtualTableAir<F> {
+    fn drop(&mut self) {
+        // Runs before the field drops, so the pages are still live here.
+        if let Some(base) = self.trace_buffer_pinned {
+            unregister_host_buffer(base);
+        }
+    }
 }
 
 impl<F: PrimeField64> StdVirtualTable<F> {
@@ -115,7 +129,10 @@ impl<F: PrimeField64> StdVirtualTable<F> {
             let multiplicities: Vec<AtomicU64> =
                 (0..(num_muls as usize * num_rows)).into_par_iter().map(|_| AtomicU64::new(0)).collect();
 
-            let trace_buffer = Arc::new(Mutex::new(Some(vec![F::ZERO; num_muls as usize * num_rows])));
+            let buffer = vec![F::ZERO; num_muls as usize * num_rows];
+            // The reclaim slot returns this same allocation every iteration, so one pin covers every H2D.
+            let trace_buffer_pinned = if pctx.gpu { register_host_buffer(&buffer) } else { None };
+            let trace_buffer = Arc::new(Mutex::new(Some(buffer)));
             let virtual_table_air = VirtualTableAir::<F> {
                 airgroup_id,
                 air_id,
@@ -129,6 +146,7 @@ impl<F: PrimeField64> StdVirtualTable<F> {
                 calculated: AtomicBool::new(false),
                 shared_tables,
                 trace_buffer,
+                trace_buffer_pinned,
             };
             virtual_tables.push(Arc::new(virtual_table_air));
         }

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -385,16 +385,20 @@ void register_instruction_table_gpu(void *d_buffers_, uint64_t airgroupId, uint6
     }
 }
 
-void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation) {
+// Non-recursive areas are sized per stream from d_buffers->aux_trace_sizes, not one uniform size.
+void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation) {
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
     uint64_t constPolsSize = totalConstPols * sizeof(Goldilocks::Element);
     uint64_t constPolsAggregationSize = totalConstPolsAggregation * sizeof(Goldilocks::Element);
-    uint64_t auxTraceSize = auxTraceArea * sizeof(Goldilocks::Element);
     uint64_t auxTraceRecursiveSize = auxTraceRecursiveArea * sizeof(Goldilocks::Element);
-    
-    uint64_t totalAuxTraceSize = d_buffers->n_streams * auxTraceSize;
+
+    uint64_t totalAuxTraceArea = 0;
+    for (uint32_t j = 0; j < d_buffers->n_streams; ++j) {
+        totalAuxTraceArea += d_buffers->aux_trace_sizes[j];
+    }
+    uint64_t totalAuxTraceSize = totalAuxTraceArea * sizeof(Goldilocks::Element);
     uint64_t totalAuxTraceRecursiveSize = d_buffers->n_recursive_streams * auxTraceRecursiveSize;
-    
+
     uint64_t totalGpuMemoryPerGpu = constPolsAggregationSize + 
                                      totalAuxTraceSize + totalAuxTraceRecursiveSize;
     
@@ -403,7 +407,18 @@ void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uin
     zklog.info("Memory allocation per GPU:");
     zklog.info("  - Constant polynomials (separate): " + std::to_string(constPolsSize / (1024.0 * 1024.0 * 1024.0)) + " GB");
     zklog.info("  - Constant polynomials aggregation: " + std::to_string(constPolsAggregationSize / (1024.0 * 1024.0 * 1024.0)) + " GB");
-    zklog.info("  - Auxiliary trace (" + std::to_string(d_buffers->n_streams) + " streams): " + std::to_string(totalAuxTraceSize / (1024.0 * 1024.0 * 1024.0)) + " GB");
+    // Collapse the per-stream sizes back into "count x size" classes; they arrive grouped.
+    std::string auxTraceClasses;
+    for (uint32_t j = 0; j < d_buffers->n_streams; ) {
+        uint32_t k = j;
+        while (k < d_buffers->n_streams && d_buffers->aux_trace_sizes[k] == d_buffers->aux_trace_sizes[j]) ++k;
+        if (j != 0) auxTraceClasses += " + ";
+        auxTraceClasses += std::to_string(k - j) + " x " +
+            std::to_string(d_buffers->aux_trace_sizes[j] * sizeof(Goldilocks::Element) / (1024.0 * 1024.0 * 1024.0)) +
+            " GB";
+        j = k;
+    }
+    zklog.info("  - Auxiliary trace (" + std::to_string(d_buffers->n_streams) + " streams): " + std::to_string(totalAuxTraceSize / (1024.0 * 1024.0 * 1024.0)) + " GB [" + auxTraceClasses + "]");
     zklog.info("  - Auxiliary trace recursive (" + std::to_string(d_buffers->n_recursive_streams) + " streams): " + std::to_string(totalAuxTraceRecursiveSize / (1024.0 * 1024.0 * 1024.0)) + " GB");
     zklog.info("  - Unified buffer per GPU: " + std::to_string(totalGpuMemoryPerGpu / (1024.0 * 1024.0 * 1024.0)) + " GB");
     zklog.info("  - Total GPU memory per GPU: " + std::to_string((totalGpuMemoryPerGpu + constPolsSize) / (1024.0 * 1024.0 * 1024.0)) + " GB");
@@ -415,7 +430,7 @@ void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uin
    
     gStreamCommitBuffers.store(d_buffers, std::memory_order_release);
 
-    d_buffers->auxTraceBytes = auxTraceSize;
+    d_buffers->auxTraceTotalBytes = totalAuxTraceSize;
     d_buffers->auxTraceRecursiveBytes = auxTraceRecursiveSize;
 
     // Allocate large GPU buffers with a single malloc per GPU
@@ -452,12 +467,12 @@ void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uin
         // Set up pointers to different sections of the memory block
         uint64_t offset = 0;
                 
-        // Auxiliary trace buffers (non-recursive)
+        // Auxiliary trace buffers (non-recursive), one size class each
         for (int j = 0; j < d_buffers->n_streams; ++j) {
             d_buffers->d_aux_trace[i][j] = gpuMemoryBlock + offset;
-            offset += auxTraceArea;
+            offset += d_buffers->aux_trace_sizes[j];
         }
-        
+
         // Auxiliary trace buffers (recursive)
         for (int j = 0; j < d_buffers->n_recursive_streams; ++j) {
             d_buffers->d_aux_traceAggregation[i][j] = gpuMemoryBlock + offset;
@@ -484,13 +499,21 @@ void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uin
     zklog.info("All GPU memory allocations successful");
 }
 
-uint64_t gen_device_streams_gpu(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, uint64_t maxSizeProverBuffer, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity) {
-    
+// `auxTraceSizes`: field elements per non-recursive stream, largest class first (plan_stream_layout).
+uint64_t gen_device_streams_gpu(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, const uint64_t *auxTraceSizes, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity) {
+
     DeviceCommitBuffers *d_buffers = (DeviceCommitBuffers *)d_buffers_;
     d_buffers->n_streams = n_streams;
     d_buffers->n_recursive_streams = n_recursive_streams;
     d_buffers->n_total_streams = d_buffers->n_gpus * (d_buffers->n_streams + d_buffers->n_recursive_streams);
-    
+
+    // Retained for the whole run: the memory carve below and every stream selection read it.
+    free(d_buffers->aux_trace_sizes);
+    d_buffers->aux_trace_sizes = (uint64_t *)malloc(n_streams * sizeof(uint64_t));
+    for (uint64_t j = 0; j < n_streams; ++j) {
+        d_buffers->aux_trace_sizes[j] = auxTraceSizes[j];
+    }
+
     // Allocate d_aux_trace arrays now that we know stream counts
     for (uint32_t i = 0; i < d_buffers->n_gpus; i++) {
         d_buffers->d_aux_trace[i] = (gl64_t **)malloc(n_streams * sizeof(gl64_t*));
@@ -510,11 +533,15 @@ uint64_t gen_device_streams_gpu(void *d_buffers_, uint64_t n_streams, uint64_t n
         uint64_t gpu_stream_start = i * (d_buffers->n_streams + d_buffers->n_recursive_streams);
 
         for (uint64_t j = 0; j < d_buffers->n_streams; j++) {
-            d_buffers->streamsData[gpu_stream_start + j].initialize(maxProofSize, d_buffers->my_gpu_ids[i], j, false, merkleTreeArity);
+            StreamData &sd = d_buffers->streamsData[gpu_stream_start + j];
+            sd.initialize(maxProofSize, d_buffers->my_gpu_ids[i], j, false, merkleTreeArity);
+            sd.auxTraceCapacity = auxTraceSizes[j];
         }
 
         for (uint64_t j = 0; j < d_buffers->n_recursive_streams; j++) {
-            d_buffers->streamsData[gpu_stream_start + d_buffers->n_streams + j].initialize(maxProofSize, d_buffers->my_gpu_ids[i], j, true, merkleTreeArity);
+            StreamData &sd = d_buffers->streamsData[gpu_stream_start + d_buffers->n_streams + j];
+            sd.initialize(maxProofSize, d_buffers->my_gpu_ids[i], j, true, merkleTreeArity);
+            sd.auxTraceCapacity = maxSizeProverBufferAggregation;
         }
     }
 
@@ -649,6 +676,8 @@ void free_device_buffers_gpu(void *d_buffers_)
     gStreamCommitBuffers.compare_exchange_strong(expected, nullptr, std::memory_order_acq_rel);
     free(d_buffers->d_aux_trace);
     free(d_buffers->d_aux_traceAggregation);
+    free(d_buffers->aux_trace_sizes);
+    d_buffers->aux_trace_sizes = nullptr;
     free(d_buffers->d_constPols);
     free(d_buffers->d_constPolsAggregation);
     free(d_buffers->pinned_buffer);
@@ -1586,7 +1615,10 @@ uint64_t commit_witness_gpu(void *pSetupCtx_, void *params_, uint64_t instanceId
     sd.airgroupId = airgroupId;
     sd.airId = airId;
     sd.proofType = "witness";
-    sd.witnessResident = true;
+    // A stream sized for the contributions footprint can be too small for this air's proof, and a
+    // resident witness pins gen_proof here (skip_recalculation). Only claim residency if the proof fits;
+    // otherwise the instance takes the normal recompute path and re-uploads its trace.
+    sd.witnessResident = sd.auxTraceCapacity >= setupCtx->starkInfo.mapTotalN;
 
     proofman_sumcheck_set_context(instanceId, airgroupId, airId);
 
@@ -2102,7 +2134,7 @@ void configure_stream_commit_slots_gpu(void *d_buffers_, uint64_t nSlots, uint64
     // kernel accesses and the carve log readable.
     slotBytes = (slotBytes + ((1ull << 20) - 1)) & ~((1ull << 20) - 1);
 
-    uint64_t totalAuxTraceSize = d_buffers->n_streams * d_buffers->auxTraceBytes;
+    uint64_t totalAuxTraceSize = d_buffers->auxTraceTotalBytes;
     uint64_t constAggOffsetBytes =
         totalAuxTraceSize + d_buffers->n_recursive_streams * d_buffers->auxTraceRecursiveBytes;
     if (nSlots * slotBytes > constAggOffsetBytes) {
@@ -2124,10 +2156,18 @@ void configure_stream_commit_slots_gpu(void *d_buffers_, uint64_t nSlots, uint64
     for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
         StreamData &sd = d_buffers->streamsData[i];
         if (d_buffers->gpus_g2l[sd.gpuId] != 0) continue;
-        uint64_t start = sd.recursive
-                             ? totalAuxTraceSize + sd.localStreamId * d_buffers->auxTraceRecursiveBytes
-                             : sd.localStreamId * d_buffers->auxTraceBytes;
-        uint64_t end = start + (sd.recursive ? d_buffers->auxTraceRecursiveBytes : d_buffers->auxTraceBytes);
+        // Sizes differ per stream, so the offset is a prefix sum of the carve, not localStreamId * size.
+        uint64_t start, end;
+        if (sd.recursive) {
+            start = totalAuxTraceSize + sd.localStreamId * d_buffers->auxTraceRecursiveBytes;
+            end = start + d_buffers->auxTraceRecursiveBytes;
+        } else {
+            start = 0;
+            for (uint32_t j = 0; j < sd.localStreamId; ++j) {
+                start += d_buffers->aux_trace_sizes[j] * sizeof(Goldilocks::Element);
+            }
+            end = start + d_buffers->aux_trace_sizes[sd.localStreamId] * sizeof(Goldilocks::Element);
+        }
         sd.overlapsStreamCommitRegion =
             start < constAggOffsetBytes && end > d_buffers->streamCommitFloorBytes;
         if (sd.overlapsStreamCommitRegion) {
@@ -2394,6 +2434,36 @@ static const AirInstanceInfo *requestedAirInstance(DeviceCommitBuffers* d_buffer
     return byType->second[0];
 }
 
+static uint64_t largestBasicCapacity(DeviceCommitBuffers* d_buffers){
+    uint64_t largest = 0;
+    for (uint32_t j = 0; j < d_buffers->n_streams; ++j) {
+        largest = std::max(largest, d_buffers->aux_trace_sizes[j]);
+    }
+    return largest;
+}
+
+// Aux-trace elements this launch needs, 0 when the air is not registered (see requirementFor).
+// Always full mapTotalN, even for a "witness" (contributions) launch. Sizing those by the regions the
+// commit touches looked safe and is not: besides cm1/mt1 the commit also writes const, custom_fixed,
+// publics, airgroupvalues, airvalues and proofvalues, so a stream sized below mapTotalN lets those
+// writes run past its slice into the next stream's buffer -- observed as a contribution-challenge
+// mismatch, not a crash. Any narrower bound must cover every one of those sections.
+// Under-counts compressor/recursive launches by their trace, which only ever land on classes the
+// Rust carve floored high enough (plan_stream_layout), so they always fit.
+static uint64_t requiredAuxTrace(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint64_t airId, const std::string &proofType){
+    const AirInstanceInfo *air = requestedAirInstance(d_buffers, airgroupId, airId, proofType);
+    if (air == nullptr || air->setupCtx == nullptr) return 0;
+    return air->setupCtx->starkInfo.mapTotalN;
+}
+
+// What `stream` must hold for this launch. An unknown requirement falls back to the largest class on
+// the sized non-recursive pool (the old uniform placement); the recursive pool is one size, so
+// holding it to that guess would leave a forced recursive request with no eligible stream at all.
+static uint64_t requirementFor(DeviceCommitBuffers* d_buffers, const StreamData &stream, uint64_t known){
+    if (known != 0) return known;
+    return stream.recursive ? 0 : largestBasicCapacity(d_buffers);
+}
+
 // One non-blocking scan+pick+reserve pass (the body of selectStream's old while-loop).
 // Returns a reserved streamId (status=1), or UINT32_MAX if none is free right now. Lets the
 // Rust scheduler drive stream assignment; selectStream just retries this in a loop.
@@ -2409,6 +2479,11 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
     const uint64_t wantAux = slotUsable
         ? wantAir->setupCtx->starkInfo.mapOffsets[std::make_pair("const", false)] : 0;
     const bool wantAgg = !(proofType == "basic" || proofType == "witness");
+    // Streams come in size classes, so a free one is only a candidate when its buffer holds this launch.
+    const uint64_t needAux = requiredAuxTrace(d_buffers, airgroupId, airId, proofType);
+    auto fitsCapacity = [&](const StreamData &sd) {
+        return sd.auxTraceCapacity >= requirementFor(d_buffers, sd, needAux);
+    };
     auto isWarm = [&](const StreamData &sd, bool drained) {
         if (!(sd.status==3 || drained)) return false;
         if (sd.airgroupId == airgroupId && sd.airId == airId && sd.proofType == proofType) return true;
@@ -2419,13 +2494,27 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
     uint32_t countUnusedStreams[d_buffers->n_gpus];
     int streamIdxGPU[d_buffers->n_gpus];
     bool warmFoundGPU[d_buffers->n_gpus];
+    bool unusedFoundGPU[d_buffers->n_gpus];
 
     for( uint32_t i = 0; i < d_buffers->n_gpus; i++){
         countUnusedStreams[i] = 0;
         countFreeStreamsGPU[i] = 0;
         streamIdxGPU[i] = -1;
         warmFoundGPU[i] = false;
+        unusedFoundGPU[i] = false;
     }
+
+    // Tightest fit first, so larger classes stay free for the airs with nowhere else to go. Only free
+    // streams are compared, so a busy tight class never idles the big one. Within a class: warm, then unused.
+    auto betterCandidate = [&](uint32_t cand, int best, bool candWarm, bool candUnused,
+                               bool bestWarm, bool bestUnused) {
+        if (best < 0) return true;
+        const uint64_t candCap = d_buffers->streamsData[cand].auxTraceCapacity;
+        const uint64_t bestCap = d_buffers->streamsData[best].auxTraceCapacity;
+        if (candCap != bestCap) return candCap < bestCap;
+        if (candWarm != bestWarm) return candWarm;
+        return candUnused && !bestUnused;
+    };
 
     bool someFree = false;
 
@@ -2453,29 +2542,24 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
                     // Ran to completion but not yet harvested: free to take, and its
                     // const-tree is still loaded. Queried once and reused by the warm test.
                     const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
-                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained) {
+                    if ((d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained)
+                        && fitsCapacity(d_buffers->streamsData[i])) {
                         uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
 
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
                         }
-                        // status==0 is deliberately absent: the only path to it
+                        // status==0 is deliberately absent from isWarm: the only path to it
                         // (reset_device_streams_gpu) calls invalidateContext() first, so the
-                        // key comparison below can never match an unused stream anyway.
+                        // key comparison there can never match an unused stream anyway.
                         bool warm = isWarm(d_buffers->streamsData[i], drained);
-                        if (warm) {
-                            // Sticky warm choice: keep the stream already holding these fixed
-                            // columns so reuse_constants hits; not clobbered by a later free
-                            // stream (the bug that killed affinity).
+                        bool unused = d_buffers->streamsData[i].status==0;
+                        if (betterCandidate(i, streamIdxGPU[gpuLocalId], warm, unused,
+                                            warmFoundGPU[gpuLocalId], unusedFoundGPU[gpuLocalId])) {
                             streamIdxGPU[gpuLocalId] = i;
-                            warmFoundGPU[gpuLocalId] = true;
-                        } else if (!warmFoundGPU[gpuLocalId]) {
-                            // No warm stream yet: prefer an unused (cold, no eviction) stream,
-                            // else any free one.
-                            if (d_buffers->streamsData[i].status==0 || streamIdxGPU[gpuLocalId] == -1) {
-                                streamIdxGPU[gpuLocalId] = i;
-                            }
+                            warmFoundGPU[gpuLocalId] = warm;
+                            unusedFoundGPU[gpuLocalId] = unused;
                         }
                         someFree = true;
                         streams_locked[i] = true;
@@ -2501,29 +2585,24 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
                     // Ran to completion but not yet harvested: free to take, and its
                     // const-tree is still loaded. Queried once and reused by the warm test.
                     const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
-                    if (d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained) {
+                    if ((d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained)
+                        && fitsCapacity(d_buffers->streamsData[i])) {
                         uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
 
                         countFreeStreamsGPU[gpuLocalId]++;
                         if(d_buffers->streamsData[i].status==0){
                             countUnusedStreams[gpuLocalId]++;
                         }
-                        // status==0 is deliberately absent: the only path to it
+                        // status==0 is deliberately absent from isWarm: the only path to it
                         // (reset_device_streams_gpu) calls invalidateContext() first, so the
-                        // key comparison below can never match an unused stream anyway.
+                        // key comparison there can never match an unused stream anyway.
                         bool warm = isWarm(d_buffers->streamsData[i], drained);
-                        if (warm) {
-                            // Sticky warm choice: keep the stream already holding these fixed
-                            // columns so reuse_constants hits; not clobbered by a later free
-                            // stream (the bug that killed affinity).
+                        bool unused = d_buffers->streamsData[i].status==0;
+                        if (betterCandidate(i, streamIdxGPU[gpuLocalId], warm, unused,
+                                            warmFoundGPU[gpuLocalId], unusedFoundGPU[gpuLocalId])) {
                             streamIdxGPU[gpuLocalId] = i;
-                            warmFoundGPU[gpuLocalId] = true;
-                        } else if (!warmFoundGPU[gpuLocalId]) {
-                            // No warm stream yet: prefer an unused (cold, no eviction) stream,
-                            // else any free one.
-                            if (d_buffers->streamsData[i].status==0 || streamIdxGPU[gpuLocalId] == -1) {
-                                streamIdxGPU[gpuLocalId] = i;
-                            }
+                            warmFoundGPU[gpuLocalId] = warm;
+                            unusedFoundGPU[gpuLocalId] = unused;
                         }
                         someFree = true;
                         streams_locked[i] = true;
@@ -2562,9 +2641,33 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
 // Blocking wrapper: retry the scan until a stream is reserved. Used by the paths that
 // select internally (contributions/commit/setup, and one-off recursive launches).
 uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint64_t airId, std::string proofType, bool recursive, bool force_recursive){
-    for (;;) {
+    for (uint64_t spins = 0;; ++spins) {
         uint32_t s = reserve_best_stream_scan(d_buffers, airgroupId, airId, proofType, recursive, force_recursive);
         if (s != UINT32_MAX) return s;
+        // Two very different causes spin here: no stream is large enough (permanent -- this would
+        // spin forever), or every eligible stream is merely busy (transient, and a sign the class is
+        // under-provisioned). Reported once; both keep retrying.
+        if (spins == 20000) {
+            const uint64_t need = requiredAuxTrace(d_buffers, airgroupId, airId, proofType);
+            uint32_t eligible = 0;
+            uint64_t largest = 0;
+            for (uint32_t i = 0; i < d_buffers->n_total_streams; ++i) {
+                const StreamData &sd = d_buffers->streamsData[i];
+                if (force_recursive && !sd.recursive) continue;
+                largest = std::max(largest, sd.auxTraceCapacity);
+                if (sd.auxTraceCapacity >= requirementFor(d_buffers, sd, need)) eligible++;
+            }
+            const double gb = sizeof(Goldilocks::Element) / (1024.0 * 1024.0 * 1024.0);
+            const std::string what = proofType + " [" + std::to_string(airgroupId) + ":" +
+                                     std::to_string(airId) + "] (needs " + std::to_string(need * gb) + " GB)";
+            if (eligible == 0) {
+                zklog.error("selectStream: " + what + " exceeds every stream -- largest holds " +
+                            std::to_string(largest * gb) + " GB, so this can never be placed");
+            } else {
+                zklog.warning("selectStream: " + what + " starved 6s behind " + std::to_string(eligible) +
+                              " eligible stream(s) -- that class may be under-provisioned");
+            }
+        }
         std::this_thread::sleep_for(std::chrono::microseconds(300));
     }
 }
@@ -2576,16 +2679,34 @@ uint32_t reserve_best_stream_nonblock_gpu(void* d_buffers_, uint64_t airgroupId,
     return reserve_best_stream_scan(d_buffers, airgroupId, airId, std::string(proofType), recursive, force_recursive);
 }
 
+// Is some other free non-recursive stream on this GPU a tighter fit for `need` than `cap`? Advisory:
+// statuses are read unlocked, so a wrong answer costs a cold scan or one oversized placement, no more.
+static bool tighterFreeStreamExists(DeviceCommitBuffers* d_buffers, uint64_t need, uint64_t cap, uint32_t self, uint32_t gpuId){
+    for (uint32_t i = 0; i < d_buffers->n_total_streams; ++i) {
+        if (i == self) continue;
+        const StreamData &sd = d_buffers->streamsData[i];
+        if (sd.recursive || sd.gpuId != gpuId) continue;
+        if (sd.auxTraceCapacity < need || sd.auxTraceCapacity >= cap) continue;
+        const uint32_t status = sd.status.load(std::memory_order_relaxed);
+        if (status == 0 || status == 3) return true;
+    }
+    return false;
+}
+
 // Warm-affinity fast path: reserve `streamId` IFF free right now (and a recursive stream
 // for a forced request). Returns 1 on success, 0 otherwise. Same lock order as
 // reserve_best_stream_scan (gsel, then per-stream try_lock) so they can't deadlock.
-uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, bool force_recursive){
+uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, uint64_t airgroupId, uint64_t airId, char* proofType, bool force_recursive){
     DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
     if (streamId >= d_buffers->n_total_streams) return 0;
     StreamData& sd = d_buffers->streamsData[streamId];
     // A forced recursive launch must stay on a recursive stream; refuse otherwise so
     // the caller falls back to the cold scan.
     if (force_recursive && !sd.recursive) return 0;
+    // Warm is worthless if the launch does not fit; the cold scan will find a class that does.
+    const uint64_t known = requiredAuxTrace(d_buffers, airgroupId, airId, std::string(proofType));
+    const uint64_t need = requirementFor(d_buffers, sd, known);
+    if (sd.auxTraceCapacity < need) return 0;
     const uint32_t firstGpuId = d_buffers->my_gpu_ids[0];
     if (d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire) && sd.gpuId == firstGpuId) return 0;
 
@@ -2597,6 +2718,14 @@ uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, bool fo
     }
     bool free = sd.status==0 || sd.status==3 || (sd.status==2 && cudaEventQuery(sd.end_event) == cudaSuccess);
     if (!free) { sd.mutex_stream_selection.unlock(); return 0; }
+    // Warm but too roomy: taking it would park this launch on a stream some larger air may be the
+    // only user of. Refuse, and let the scan apply its tightest-fit rule. Sized pool only -- the
+    // recursive streams are one class, and comparing them against basic ones just loses affinity.
+    if (!sd.recursive && sd.auxTraceCapacity > need
+        && tighterFreeStreamExists(d_buffers, need, sd.auxTraceCapacity, streamId, sd.gpuId)) {
+        sd.mutex_stream_selection.unlock();
+        return 0;
+    }
     reserveStreamLocked(d_buffers, streamId);
     sd.mutex_stream_selection.unlock();
     return 1;
@@ -2637,7 +2766,6 @@ void reserveStream(DeviceCommitBuffers* d_buffers, uint32_t streamId){
     reserveStreamLocked(d_buffers, streamId);
     d_buffers->streamsData[streamId].mutex_stream_selection.unlock();
 }
-
 void closeStreamTimer(TimerGPU &timer, uint64_t instance_id, uint64_t airgroup_id, uint64_t air_id, bool isProve) {
     TimerSyncAndLogAllGPU(timer, instance_id, airgroup_id, air_id);
     TimerSyncCategoriesGPU(timer);

--- a/pil2-stark/src/api/starks_api.hpp
+++ b/pil2-stark/src/api/starks_api.hpp
@@ -132,7 +132,7 @@ extern "C" {
     uint32_t reserve_best_stream_nonblock(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
     // Central arbiter warm fast path: reserve streamId iff it is free right now.
     // Returns 1 on success, 0 otherwise.
-    uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, bool force_recursive);
+    uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, uint64_t airgroupId, uint64_t airId, char *proofType, bool force_recursive);
     // Give back a reservation made by either call above without launching on the stream.
     void release_stream_reservation(void *d_buffers_, uint32_t streamId);
     void add_publics_aggregation(void *pProof, uint64_t offset, void *pPublics, uint64_t nPublicsAggregation);
@@ -195,8 +195,8 @@ extern "C" {
     void free_device_buffers_recursivef(void *d_buffers);
     void load_device_const_pols(uint64_t airgroupId, uint64_t airId, uint64_t initial_offset, void *d_buffers, char *constFilename, uint64_t constSize, char *constTreeFilename, uint64_t constTreeSize, char* proofType, bool onlyFirstGPU, bool alreadyLoaded);
     void load_device_setup(uint64_t airgroupId, uint64_t airId, char *proofType, void *pSetupCtx_, void *d_buffers_, void *verkeyRoot_,  void *packedInfo);
-    uint64_t gen_device_streams(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, uint64_t maxSizeProverBuffer, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
-    void alloc_device_large_buffers(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
+    uint64_t gen_device_streams(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, const uint64_t *auxTraceSizes, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
+    void alloc_device_large_buffers(void *d_buffers_, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
     void get_instances_ready(void *d_buffers, int64_t* instances_ready);
     void reset_device_streams(void *d_buffers_);
     uint64_t check_device_memory(uint32_t node_rank, uint32_t node_size);

--- a/pil2-stark/src/api/starks_backend.cpp
+++ b/pil2-stark/src/api/starks_backend.cpp
@@ -47,7 +47,7 @@ void get_stream_proofs_gpu(void *d_buffers_);
 void get_stream_proofs_non_blocking_gpu(void *d_buffers_);
 void get_stream_id_proof_gpu(void *d_buffers_, uint64_t streamId);
 uint32_t reserve_best_stream_nonblock_gpu(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
-uint32_t reserve_stream_if_free_gpu(void *d_buffers_, uint32_t streamId, bool force_recursive);
+uint32_t reserve_stream_if_free_gpu(void *d_buffers_, uint32_t streamId, uint64_t airgroupId, uint64_t airId, char *proofType, bool force_recursive);
 void release_stream_reservation_gpu(void *d_buffers_, uint32_t streamId);
 uint64_t gen_recursive_proof_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
 void *gen_recursive_proof_final_gpu(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
@@ -60,8 +60,8 @@ void *gen_device_buffers_recursivef_gpu(void *pSetupCtx_, uint64_t proverBufferS
 void free_device_buffers_recursivef_gpu(void *d_buffers);
 void load_device_const_pols_gpu(uint64_t airgroupId, uint64_t airId, uint64_t initial_offset, void *d_buffers, char *constFilename, uint64_t constSize, char *constTreeFilename, uint64_t constTreeSize, char* proofType, bool onlyFirstGPU, bool alreadyLoaded);
 void load_device_setup_gpu(uint64_t airgroupId, uint64_t airId, char *proofType, void *pSetupCtx_, void *d_buffers_, void *verkeyRoot_, void *packedInfo);
-uint64_t gen_device_streams_gpu(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, uint64_t maxSizeProverBuffer, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
-void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
+uint64_t gen_device_streams_gpu(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, const uint64_t *auxTraceSizes, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
+void alloc_device_large_buffers_gpu(void *d_buffers_, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
 void get_instances_ready_gpu(void *d_buffers, int64_t* instances_ready);
 void reset_device_streams_gpu(void *d_buffers_);
 uint64_t check_device_memory_gpu(uint32_t node_rank, uint32_t node_size);
@@ -324,10 +324,10 @@ uint32_t reserve_best_stream_nonblock(void *d_buffers_, uint64_t airgroupId, uin
     return backend->reserve_best_stream_nonblock(d_buffers_, airgroupId, airId, proofType, recursive, force_recursive);
 }
 
-uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, bool force_recursive) {
+uint32_t reserve_stream_if_free(void *d_buffers_, uint32_t streamId, uint64_t airgroupId, uint64_t airId, char *proofType, bool force_recursive) {
     auto backend = active_backend.load(std::memory_order_acquire);
     if (!backend->reserve_stream_if_free) return 0;
-    return backend->reserve_stream_if_free(d_buffers_, streamId, force_recursive);
+    return backend->reserve_stream_if_free(d_buffers_, streamId, airgroupId, airId, proofType, force_recursive);
 }
 
 // Symmetric to the two reserve entries above: hand a reservation back when the caller failed
@@ -409,14 +409,14 @@ void load_device_setup(uint64_t airgroupId, uint64_t airId, char *proofType, voi
     backend->load_device_setup(airgroupId, airId, proofType, pSetupCtx_, d_buffers_, verkeyRoot_, packedInfo);
 }
 
-uint64_t gen_device_streams(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, uint64_t maxSizeProverBuffer, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity) {
+uint64_t gen_device_streams(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, const uint64_t *auxTraceSizes, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity) {
     auto backend = active_backend.load(std::memory_order_acquire);
-    return backend->gen_device_streams ? backend->gen_device_streams(d_buffers_, n_streams, n_recursive_streams, maxSizeProverBuffer, maxSizeProverBufferAggregation, maxProofSize, merkleTreeArity) : 1;
+    return backend->gen_device_streams ? backend->gen_device_streams(d_buffers_, n_streams, n_recursive_streams, auxTraceSizes, maxSizeProverBufferAggregation, maxProofSize, merkleTreeArity) : 1;
 }
 
-void alloc_device_large_buffers(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation) {
+void alloc_device_large_buffers(void *d_buffers_, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation) {
     auto backend = active_backend.load(std::memory_order_acquire);
-    if (backend->alloc_device_large_buffers) backend->alloc_device_large_buffers(d_buffers_, auxTraceArea, auxTraceRecursiveArea, totalConstPols, totalConstPolsAggregation);
+    if (backend->alloc_device_large_buffers) backend->alloc_device_large_buffers(d_buffers_, auxTraceRecursiveArea, totalConstPols, totalConstPolsAggregation);
 }
 
 void get_instances_ready(void *d_buffers, int64_t* instances_ready) {

--- a/pil2-stark/src/api/starks_backend.hpp
+++ b/pil2-stark/src/api/starks_backend.hpp
@@ -35,7 +35,7 @@ struct StarksBackend {
     // backend has no streams, so these stay nullptr and the dispatchers return
     // "nothing reserved" (UINT32_MAX / 0).
     uint32_t (*reserve_best_stream_nonblock)(void *d_buffers_, uint64_t airgroupId, uint64_t airId, char *proofType, bool recursive, bool force_recursive);
-    uint32_t (*reserve_stream_if_free)(void *d_buffers_, uint32_t streamId, bool force_recursive);
+    uint32_t (*reserve_stream_if_free)(void *d_buffers_, uint32_t streamId, uint64_t airgroupId, uint64_t airId, char *proofType, bool force_recursive);
     void (*release_stream_reservation)(void *d_buffers_, uint32_t streamId);
     uint64_t (*gen_recursive_proof)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, uint64_t* proofBuffer, char *proof_file, bool vadcop, void *d_buffers, char *constPolsPath, char *constTreePath, char *proofType, bool force_recursive_stream, char *recurser_id, uint64_t streamId_);
     void *(*gen_recursive_proof_final)(void *pSetupCtx, uint64_t airgroupId, uint64_t airId, uint64_t instanceId, void* witness, void* aux_trace, void *pConstPols, void *pConstTree, void* pPublicInputs, char* proof_file, uint64_t proverBufferSize, void* d_buffers);
@@ -57,8 +57,8 @@ struct StarksBackend {
     void (*free_device_buffers_recursivef)(void *d_buffers);
     void (*load_device_const_pols)(uint64_t airgroupId, uint64_t airId, uint64_t initial_offset, void *d_buffers, char *constFilename, uint64_t constSize, char *constTreeFilename, uint64_t constTreeSize, char* proofType, bool onlyFirstGPU, bool alreadyLoaded);
     void (*load_device_setup)(uint64_t airgroupId, uint64_t airId, char *proofType, void *pSetupCtx_, void *d_buffers_, void *verkeyRoot_, void *packedInfo);
-    uint64_t (*gen_device_streams)(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, uint64_t maxSizeProverBuffer, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
-    void (*alloc_device_large_buffers)(void *d_buffers_, uint64_t auxTraceArea, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
+    uint64_t (*gen_device_streams)(void *d_buffers_, uint64_t n_streams, uint64_t n_recursive_streams, const uint64_t *auxTraceSizes, uint64_t maxSizeProverBufferAggregation, uint64_t maxProofSize, uint64_t merkleTreeArity);
+    void (*alloc_device_large_buffers)(void *d_buffers_, uint64_t auxTraceRecursiveArea, uint64_t totalConstPols, uint64_t totalConstPolsAggregation);
     void (*get_instances_ready)(void *d_buffers, int64_t* instances_ready);
     void (*reset_device_streams)(void *d_buffers_);
     uint64_t (*check_device_memory)(uint32_t node_rank, uint32_t node_size);

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cu
@@ -19,10 +19,6 @@ static bool copy_direct_registered_h2d_if_enabled(const void *src, void *dst, ui
     // Only take the fast path when src is host memory the driver can DMA directly.
     if (attrs.type != cudaMemoryTypeHost) return false;
 
-    // No cudaStreamSynchronize: the caller gates reuse of src (the pool-pinned trace buffer) on
-    // trace_copy_event, recorded by the caller right after this returns (wait_trace_h2d_done).
-    // Syncing here would serialize the copy against the LDE/Merkle work (measured ~9.5s vs ~8.7s
-    // contributions).
     CHECKCUDAERR(cudaMemcpyAsync(dst, src, total_size, cudaMemcpyHostToDevice, stream));
     return true;
 }

--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -402,6 +402,9 @@ struct StreamData{
     // (only ever set on first-GPU streams -- slots exist only there)
     bool overlapsStreamCommitRegion = false;
 
+    // Field elements in this stream's slice of the unified buffer: a proof fits only when mapTotalN does.
+    uint64_t auxTraceCapacity = 0;
+
 #ifdef USE_CUDA_GRAPH
     std::unique_ptr<CudaGraphCache> graph_cache;
 #endif
@@ -612,6 +615,8 @@ struct DeviceCommitBuffers
     uint32_t n_total_streams;
     uint32_t n_streams;
     uint32_t n_recursive_streams;
+    // Aux trace elements per non-recursive stream, largest class first; length n_streams. Owned here.
+    uint64_t *aux_trace_sizes = nullptr;
     std::mutex *mutex_pinned;
     StreamData *streamsData;
 
@@ -630,9 +635,9 @@ struct DeviceCommitBuffers
     uint64_t streamCommitSlots = 0;
     uint64_t streamCommitSlotBytes = 0;
     uint64_t streamCommitFloorBytes = UINT64_MAX;
-    // Per-stream aux-trace byte sizes (basic / recursive), stashed at
-    // allocation for configure_stream_commit_slots' overlap computation.
-    uint64_t auxTraceBytes = 0;
+    // Stashed at allocation for configure_stream_commit_slots' overlap computation. Non-recursive
+    // streams differ in size, so only their total is meaningful; per-stream offsets are prefix sums.
+    uint64_t auxTraceTotalBytes = 0;
     uint64_t auxTraceRecursiveBytes = 0;
     cudaStream_t *streamCommitStreams = nullptr;  // [streamCommitSlots], first GPU
     // Shared-hold of the overlapped legacy streams: the first in-flight slot

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -25,6 +25,22 @@ use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::atomic::Ordering;
 use std::sync::{LazyLock, Mutex, RwLock};
 
+/// Releases an admission slot on drop. A witness thread that panics would otherwise leak one, and a
+/// leaked slot permanently blocks its air once the cap is reached — the admission loop then spins.
+struct SlotGuard {
+    in_flight: Arc<Mutex<HashMap<(usize, usize), usize>>>,
+    key: (usize, usize),
+}
+
+impl Drop for SlotGuard {
+    fn drop(&mut self) {
+        // Recover from poison rather than panic inside a drop during unwind.
+        if let Some(n) = self.in_flight.lock().unwrap_or_else(|e| e.into_inner()).get_mut(&self.key) {
+            *n = n.saturating_sub(1);
+        }
+    }
+}
+
 /// Master switch for per-proof debug logging of airgroup values, stage roots, and the
 /// challenge/contribution dump (`print_challenges`). Off by default; enable with
 /// `PROOFMAN_DEBUG_CHALLENGES=1` (matching PROOFMAN_SUMCHECK: any other value, or unset,
@@ -4517,102 +4533,161 @@ where
         let cancellation_info_clone = self.cancellation_info.clone();
         let n_threads_witness = self.num_threads_per_witness;
         let witness_start_time_clone = witness_start_time.clone();
-        let witness_handler = if !minimal_memory && (self.pctx.gpu || stats) {
-            Some(std::thread::spawn(move || loop {
-                let instance_id = if let Ok(id) = witness_rx_priority.try_recv() {
-                    id
-                } else {
-                    crossbeam_channel::select! {
-                        recv(witness_rx_priority) -> msg => match msg {
-                            Ok(id) => id,
-                            Err(_) => break,
-                        },
-                        recv(witness_rx) -> msg => match msg {
-                            Ok(id) if id == usize::MAX => break,
-                            Ok(id) => id,
-                            Err(_) => break,
-                        },
-                        default(std::time::Duration::from_millis(5)) => {
+        let sctx_admission = self.sctx.clone();
+        let class_sizes = self.pctx.basic_stream_sizes.clone();
+        let n_classes = class_sizes.len();
+        let witness_handler =
+            if !minimal_memory && (self.pctx.gpu || stats) {
+                // Ready instances waiting to be admitted, priority-first, and how many slots each air
+                // currently holds. Taking straight off the channels would be pure FIFO with no choice;
+                // pooling is what lets `witness_slot_cap` hold back an air that can only drain on one
+                // stream so the slots it would have taken go to work the other streams can run.
+                // Two pools, not one queue: the priority pool is always scanned first, so a priority
+                // instance outranks every normal one however late it arrives, while arrival order is kept
+                // within each pool. That is all the two channels mean now — a ranking hint, no longer a
+                // queue-jump able to take every slot.
+                let mut pending_priority: std::collections::VecDeque<usize> = std::collections::VecDeque::new();
+                let mut pending: std::collections::VecDeque<usize> = std::collections::VecDeque::new();
+                let in_flight: Arc<Mutex<HashMap<(usize, usize), usize>>> = Arc::new(Mutex::new(HashMap::new()));
+                let mut arrivals_done = false;
+                Some(std::thread::spawn(move || loop {
+                    // Take everything available without committing to any of it yet.
+                    while let Ok(id) = witness_rx_priority.try_recv() {
+                        pending_priority.push_back(id);
+                    }
+                    while let Ok(id) = witness_rx.try_recv() {
+                        if id == usize::MAX {
+                            arrivals_done = true;
+                        } else {
+                            pending.push_back(id);
+                        }
+                    }
+
+                    // 0 = unknown (CPU, or an air the carve does not know): never held back.
+                    let eligible_of = |id: usize| -> usize {
+                        let Ok(key) = pctx_clone.dctx_get_instance_info(id) else { return 0 };
+                        let need =
+                            sctx_admission.get_setup(key.0, key.1).map(|s| s.prover_buffer_size as usize).unwrap_or(0);
+                        crate::eligible_stream_count(need, &class_sizes)
+                    };
+                    let admissible = |id: usize, held: &HashMap<(usize, usize), usize>| -> bool {
+                        let Ok(key) = pctx_clone.dctx_get_instance_info(id) else {
+                            return true; // unknown air: never hold back work we cannot reason about
+                        };
+                        let cap = crate::witness_slot_cap(eligible_of(id), n_classes);
+                        held.get(&key).copied().unwrap_or(0) < cap
+                    };
+                    // First admissible, priority pool first. Not reordered by scarcity: that starved the
+                    // streams flexible work feeds (83% -> 71% busy). The cap alone is the lever.
+                    let chosen: Option<(bool, usize)> = {
+                        let held = in_flight.lock().unwrap();
+                        pending_priority
+                            .iter()
+                            .position(|&id| admissible(id, &held))
+                            .map(|pos| (true, pos))
+                            .or_else(|| pending.iter().position(|&id| admissible(id, &held)).map(|pos| (false, pos)))
+                    };
+
+                    let instance_id = match chosen.and_then(|(is_priority, pos)| {
+                        if is_priority {
+                            pending_priority.remove(pos)
+                        } else {
+                            pending.remove(pos)
+                        }
+                    }) {
+                        Some(id) => id,
+                        None => {
+                            // Nothing admissible. Exit only once no more can arrive and nothing is queued;
+                            // otherwise wait briefly for a slot to free or a new arrival.
                             if cancellation_info_clone.read_recover().token.is_cancelled() {
                                 break;
                             }
+                            if arrivals_done && pending.is_empty() && pending_priority.is_empty() {
+                                break;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(1));
                             continue;
-                        },
+                        }
+                    };
+
+                    if let Some(witness_start_time_clone) = &witness_start_time_clone {
+                        if witness_start_time_clone.read().unwrap().is_none() {
+                            *witness_start_time_clone.write().unwrap() = Some(std::time::Instant::now());
+                        }
                     }
-                };
 
-                if let Some(witness_start_time_clone) = &witness_start_time_clone {
-                    if witness_start_time_clone.read().unwrap().is_none() {
-                        *witness_start_time_clone.write().unwrap() = Some(std::time::Instant::now());
-                    }
-                }
-
-                let (airgroup_id, air_id) = match pctx_clone.dctx_get_instance_info(instance_id) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        cancellation_info_clone.write_recover().cancel(Some(e));
-                        break;
-                    }
-                };
-
-                let tx_threads_clone: Sender<()> = tx_threads_clone.clone();
-                let wcm = wcm_clone.clone();
-                let memory_handler_clone = memory_handler_clone.clone();
-
-                let witness_done_clone = witness_done_clone.clone();
-                for _ in 0..n_threads_witness {
-                    loop {
-                        if cancellation_info_clone.read_recover().token.is_cancelled() {
+                    let (airgroup_id, air_id) = match pctx_clone.dctx_get_instance_info(instance_id) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            cancellation_info_clone.write_recover().cancel(Some(e));
                             break;
                         }
-                        match rx_threads_clone.recv_timeout(std::time::Duration::from_millis(1)) {
-                            Ok(_) | Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
-                            Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
-                        }
-                    }
-                }
+                    };
 
-                if cancellation_info_clone.read_recover().token.is_cancelled() {
-                    break;
-                }
+                    // Held until the witness thread finishes: the span this air occupies a slot.
+                    *in_flight.lock().unwrap().entry((airgroup_id, air_id)).or_insert(0) += 1;
+                    let slot = SlotGuard { in_flight: in_flight.clone(), key: (airgroup_id, air_id) };
 
-                let pctx_clone = pctx_clone.clone();
-                let gpu = pctx_clone.gpu;
-                let cancellation_info_clone = cancellation_info_clone.clone();
-                let handle = std::thread::spawn(move || {
-                    timer_start_debug!(GENERATING_WC, "GENERATING_WC_{} [{}:{}]", instance_id, airgroup_id, air_id);
-                    if let Err(e) =
-                        wcm.calculate_witness(1, &[instance_id], n_threads_witness, memory_handler_clone.as_ref())
-                    {
-                        cancellation_info_clone.write_recover().cancel(Some(e));
-                    }
-                    Self::try_send_threads(&tx_threads_clone, n_threads_witness, &cancellation_info_clone);
-                    timer_stop_and_log_debug!(
-                        GENERATING_WC,
-                        "GENERATING_WC_{} [{}:{}]",
-                        instance_id,
-                        airgroup_id,
-                        air_id
-                    );
-                    witness_done_clone.increment();
-                    if stats {
-                        let (is_shared_buffer, witness_buffer) = pctx_clone.free_instance_traces(instance_id);
-                        if is_shared_buffer {
-                            if let Err(e) = memory_handler_clone.release_buffer(witness_buffer) {
-                                cancellation_info_clone.write_recover().cancel(Some(e));
+                    let tx_threads_clone: Sender<()> = tx_threads_clone.clone();
+                    let wcm = wcm_clone.clone();
+                    let memory_handler_clone = memory_handler_clone.clone();
+
+                    let witness_done_clone = witness_done_clone.clone();
+                    for _ in 0..n_threads_witness {
+                        loop {
+                            if cancellation_info_clone.read_recover().token.is_cancelled() {
+                                break;
+                            }
+                            match rx_threads_clone.recv_timeout(std::time::Duration::from_millis(1)) {
+                                Ok(_) | Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                                Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
                             }
                         }
                     }
-                });
-                if !stats && !gpu {
-                    handle.join().unwrap();
-                } else {
-                    witness_handles_clone.lock().unwrap().push(handle);
-                }
-            }))
-        } else {
-            None
-        };
+
+                    if cancellation_info_clone.read_recover().token.is_cancelled() {
+                        break;
+                    }
+
+                    let pctx_clone = pctx_clone.clone();
+                    let gpu = pctx_clone.gpu;
+                    let cancellation_info_clone = cancellation_info_clone.clone();
+                    let handle = std::thread::spawn(move || {
+                        timer_start_debug!(GENERATING_WC, "GENERATING_WC_{} [{}:{}]", instance_id, airgroup_id, air_id);
+                        if let Err(e) =
+                            wcm.calculate_witness(1, &[instance_id], n_threads_witness, memory_handler_clone.as_ref())
+                        {
+                            cancellation_info_clone.write_recover().cancel(Some(e));
+                        }
+                        Self::try_send_threads(&tx_threads_clone, n_threads_witness, &cancellation_info_clone);
+                        // Free the slot before the counter so admission can refill immediately.
+                        drop(slot);
+                        timer_stop_and_log_debug!(
+                            GENERATING_WC,
+                            "GENERATING_WC_{} [{}:{}]",
+                            instance_id,
+                            airgroup_id,
+                            air_id
+                        );
+                        witness_done_clone.increment();
+                        if stats {
+                            let (is_shared_buffer, witness_buffer) = pctx_clone.free_instance_traces(instance_id);
+                            if is_shared_buffer {
+                                if let Err(e) = memory_handler_clone.release_buffer(witness_buffer) {
+                                    cancellation_info_clone.write_recover().cancel(Some(e));
+                                }
+                            }
+                        }
+                    });
+                    if !stats && !gpu {
+                        handle.join().unwrap();
+                    } else {
+                        witness_handles_clone.lock().unwrap().push(handle);
+                    }
+                }))
+            } else {
+                None
+            };
         (Arc::new(Mutex::new(witness_handler)), witness_handles)
     }
 

--- a/proofman/src/scheduler.rs
+++ b/proofman/src/scheduler.rs
@@ -245,8 +245,10 @@ impl<F: PrimeField64> RecursiveScheduler<F> {
 
         // Pass 1 — REUSE: a stream already holding this key, free right now.
         for &key in candidates {
+            let (ag, air, t) = key;
+            let type_str: &'static str = t.into();
             for (&s, &k) in self.stream_warm.iter() {
-                if k == key && reserve_stream_if_free_c(d, s as u32, force_recursive) {
+                if k == key && reserve_stream_if_free_c(d, s as u32, ag as u64, air as u64, type_str, force_recursive) {
                     return Some((key, StreamReservation::new(self.d_buffers, s as u32)));
                 }
             }
@@ -348,6 +350,20 @@ pub fn recover_drained_witnesses<F: PrimeField64 + Send + Sync + 'static>(
         }
     }
     recovered
+}
+
+/// Basic GPU streams that can host an air needing `need` elements. 0 = unknown (CPU: empty carve).
+pub fn eligible_stream_count(need: usize, class_sizes: &[usize]) -> usize {
+    class_sizes.iter().filter(|&&s| s >= need).count()
+}
+
+/// Witness slots an air may hold: one per stream it can drain on, plus one ready. Uncapped when it fits
+/// every class (capping those starves the streams they feed) or when eligibility is unknown.
+pub fn witness_slot_cap(eligible: usize, n_classes: usize) -> usize {
+    if eligible == 0 || n_classes == 0 || eligible >= n_classes {
+        return usize::MAX;
+    }
+    eligible + 1
 }
 
 /// Sort key for the basic-proof schedule: `priority_tier` (front-load stored / has-compressor
@@ -595,6 +611,41 @@ mod drain_tests {
         s.queues.clear(); // drop the queued witness instead of draining it
         assert!(h.reset().is_err(), "a dropped witness permanently shrinks its pool");
         let _ = F::ZERO; // keep the Field import honest across backends
+    }
+}
+
+#[cfg(test)]
+mod admission_tests {
+    use super::{eligible_stream_count, witness_slot_cap};
+
+    /// Measured carve: one 7.42 GB class and two 6.24 GB (MiB).
+    const CLASSES: [usize; 3] = [7598, 6390, 6390];
+
+    #[test]
+    fn eligibility_matches_the_measured_carve() {
+        assert_eq!(eligible_stream_count(7598, &CLASSES), 1, "7.42 GB air: large class only");
+        assert_eq!(eligible_stream_count(6133, &CLASSES), 3, "5.99 GB air: all three");
+        assert_eq!(eligible_stream_count(9000, &CLASSES), 0, "bigger than any class");
+    }
+
+    /// 8 slots = 24 cores / 3 threads per witness, 3 classes.
+    #[test]
+    fn a_confined_air_gets_one_slot_per_stream_plus_a_prefetch() {
+        assert_eq!(witness_slot_cap(1, 3), 2);
+        assert_eq!(witness_slot_cap(2, 3), 3);
+    }
+
+    #[test]
+    fn an_air_that_fits_everywhere_is_uncapped() {
+        assert_eq!(witness_slot_cap(3, 3), usize::MAX);
+        assert_eq!(witness_slot_cap(8, 8), usize::MAX);
+    }
+
+    #[test]
+    fn unknown_eligibility_never_blocks() {
+        assert_eq!(eligible_stream_count(6133, &[]), 0);
+        assert_eq!(witness_slot_cap(0, 3), usize::MAX);
+        assert_eq!(witness_slot_cap(1, 0), usize::MAX);
     }
 }
 

--- a/provers/starks-lib-c/bindings_starks.rs
+++ b/provers/starks-lib-c/bindings_starks.rs
@@ -460,6 +460,9 @@ extern "C" {
     pub fn reserve_stream_if_free(
         d_buffers_: *mut ::std::os::raw::c_void,
         streamId: u32,
+        airgroupId: u64,
+        airId: u64,
+        proofType: *mut ::std::os::raw::c_char,
         force_recursive: bool,
     ) -> u32;
 
@@ -663,7 +666,7 @@ extern "C" {
         d_buffers_: *mut ::std::os::raw::c_void,
         nStreams: u64,
         nStreamsRecursive: u64,
-        maxSizeProverBuffer: u64,
+        auxTraceSizes: *const u64,
         maxSizeProverBufferAggregation: u64,
         maxProofSize: u64,
         merkle_tree_arity: u64,
@@ -671,7 +674,6 @@ extern "C" {
 
     pub fn alloc_device_large_buffers(
         d_buffers_: *mut ::std::os::raw::c_void,
-        auxTraceArea: u64,
         auxTraceRecursiveArea: u64,
         totalConstPols: u64,
         totalConstPolsAggregation: u64,

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -1097,9 +1097,20 @@ pub fn reserve_best_stream_nonblock_c(
     unsafe { reserve_best_stream_nonblock(d_buffers, airgroup_id, air_id, proof_type_ptr, recursive, force_recursive) }
 }
 
-/// Scheduler warm fast path: reserve `stream_id` iff it is free right now. Returns true on success.
-pub fn reserve_stream_if_free_c(d_buffers: *mut c_void, stream_id: u32, force_recursive: bool) -> bool {
-    unsafe { reserve_stream_if_free(d_buffers, stream_id, force_recursive) != 0 }
+/// Scheduler warm fast path: reserve `stream_id` iff it is free right now *and* its buffer size
+/// class holds this air. Returns true on success.
+pub fn reserve_stream_if_free_c(
+    d_buffers: *mut c_void,
+    stream_id: u32,
+    airgroup_id: u64,
+    air_id: u64,
+    proof_type: &str,
+    force_recursive: bool,
+) -> bool {
+    let proof_type_name = CString::new(proof_type).unwrap();
+    let proof_type_ptr = proof_type_name.as_ptr() as *mut std::os::raw::c_char;
+
+    unsafe { reserve_stream_if_free(d_buffers, stream_id, airgroup_id, air_id, proof_type_ptr, force_recursive) != 0 }
 }
 
 /// Scheduler: give back a reservation the caller never launched on. A reserved stream reads as busy
@@ -1448,12 +1459,10 @@ pub fn free_device_buffers_recursivef_c(d_buffers: *mut c_void) {
     unsafe { free_device_buffers_recursivef(d_buffers) }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn gen_device_streams_c(
     d_buffers: *mut ::std::os::raw::c_void,
-    n_streams: u64,
+    aux_trace_sizes: &[u64],
     n_recursive_streams: u64,
-    max_size_buffer: u64,
     max_size_buffer_aggregation: u64,
     max_pinned_proof_size: u64,
     merkle_tree_arity: u64,
@@ -1461,9 +1470,9 @@ pub fn gen_device_streams_c(
     unsafe {
         gen_device_streams(
             d_buffers,
-            n_streams,
+            aux_trace_sizes.len() as u64,
             n_recursive_streams,
-            max_size_buffer,
+            aux_trace_sizes.as_ptr(),
             max_size_buffer_aggregation,
             max_pinned_proof_size,
             merkle_tree_arity,
@@ -1473,19 +1482,12 @@ pub fn gen_device_streams_c(
 
 pub fn alloc_device_large_buffers_c(
     d_buffers: *mut ::std::os::raw::c_void,
-    aux_trace_area: u64,
     aux_trace_recursive_area: u64,
     const_pols_area: u64,
     const_pols_aggregation_area: u64,
 ) {
     unsafe {
-        alloc_device_large_buffers(
-            d_buffers,
-            aux_trace_area,
-            aux_trace_recursive_area,
-            const_pols_area,
-            const_pols_aggregation_area,
-        );
+        alloc_device_large_buffers(d_buffers, aux_trace_recursive_area, const_pols_area, const_pols_aggregation_area);
     }
 }
 

--- a/witness/src/witness_manager.rs
+++ b/witness/src/witness_manager.rs
@@ -8,6 +8,13 @@ use crate::WitnessComponent;
 use libloading::Library;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// Dedup while keeping the caller's order. The filters below used to iterate a `HashSet`, discarding
+/// the caller's dispatch order and varying it run to run.
+fn dedup_preserving_order(ids: &[usize]) -> Vec<usize> {
+    let mut seen = HashSet::with_capacity(ids.len());
+    ids.iter().copied().filter(|id| seen.insert(*id)).collect()
+}
+
 pub const MAX_COMPONENTS: usize = 1000;
 
 pub struct WitnessManager<F: PrimeField64> {
@@ -108,13 +115,12 @@ impl<F: PrimeField64> WitnessManager<F> {
 
     pub fn debug(&self, instance_ids: &[usize], debug_info: &DebugInfo) -> ProofmanResult<()> {
         if debug_info.std_mode.name == ModeName::Debug {
+            let unique = dedup_preserving_order(instance_ids);
             for (idx, component) in self.components.read().unwrap().iter().enumerate() {
-                let ids_hash_set: HashSet<usize> = instance_ids.iter().cloned().collect();
-
-                let instance_ids_filtered: Vec<usize> = ids_hash_set
+                let instance_ids_filtered: Vec<usize> = unique
                     .iter()
                     .filter(|id| self.components_instance_ids[idx].read().unwrap().contains(id))
-                    .cloned() // turn &&usize → usize
+                    .cloned()
                     .collect();
 
                 if !instance_ids_filtered.is_empty() {
@@ -137,12 +143,11 @@ impl<F: PrimeField64> WitnessManager<F> {
         n_cores: usize,
         buffer_pool: &dyn BufferPool<F>,
     ) -> ProofmanResult<()> {
+        let unique = dedup_preserving_order(instance_ids);
         for (idx, component) in self.components.read().unwrap().iter().enumerate() {
-            let ids_hash_set: HashSet<usize> = instance_ids.iter().cloned().collect();
-
             let mut instance_ids_filtered = Vec::new();
 
-            for id in &ids_hash_set {
+            for id in &unique {
                 if self.components_instance_ids[idx].read().unwrap().contains(id)
                     && (self.pctx.dctx_is_my_process_instance(*id)? || self.pctx.dctx_is_table(*id))
                     && !self.pctx.dctx_is_instance_calculated(*id)
@@ -185,12 +190,11 @@ impl<F: PrimeField64> WitnessManager<F> {
         n_cores: usize,
         buffer_pool: &dyn BufferPool<F>,
     ) -> ProofmanResult<()> {
+        let unique = dedup_preserving_order(instance_ids);
         for (idx, component) in self.components.read().unwrap().iter().enumerate() {
-            let ids_hash_set: HashSet<usize> = instance_ids.iter().cloned().collect();
-
             let mut instance_ids_filtered = Vec::new();
 
-            for id in &ids_hash_set {
+            for id in &unique {
                 if self.components_instance_ids[idx].read().unwrap().contains(id)
                     && (self.pctx.dctx_is_my_process_instance(*id)? || self.pctx.dctx_is_table(*id))
                     && self.pctx.dctx_try_mark_instance_calculated(*id)


### PR DESCRIPTION
Cut the per-GPU aux-trace budget into size classes instead of sizing every stream to the largest air, and bound how much of the witness pipeline any single air can occupy.

Carve:
- plan_stream_layout cuts the budget into a large and a regular class sized from the per-air requirements rather than uniformly. Streams carry per-class capacities and selection only considers a stream that can hold the launch.
- A second class must earn its place: collapse to one uniform class when the split buys no extra stream and the sizes are within UNIFORM_COLLAPSE_RATIO. The uniform candidate carried size 0 and so lost every tie, meaning a split was taken even when it bought nothing -- which confined the largest air to a single stream for its whole run.
- selectStream now distinguishes a launch no stream can ever hold from one merely starved behind busy streams. The two need different responses, and reporting starvation as impossible sent us hunting a capacity bug.

Witness admission:
- calc_witness_handler pools ready instances instead of consuming them FIFO, so admission can choose. Priority stays a ranking hint rather than an unbounded queue-jump able to take every slot.
- Per-air slot cap derived from stream eligibility (witness_slot_cap): an air that can only drain on a subset of the streams gets one slot per eligible stream plus one prefetch, while airs that fit everywhere stay uncapped -- capping those starves the streams they feed. Aggregate basic-stream occupancy went 77% -> 96% on a 3-stream carve.
- SlotGuard releases a slot on drop so a panicking witness thread cannot leak one and wedge its air permanently behind the cap.

The per-component witness filters collected into a HashSet and iterated that, discarding the caller's dispatch order and varying it between runs. Preserve the order and dedup explicitly.