### PR TITLE
Fold the FRI challenge powers and evals into per-proof constants

### DIFF
--- a/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
+++ b/pil2-stark/src/goldilocks/src/goldilocks_tooling.cuh
@@ -183,6 +183,13 @@ struct AirInstanceInfo {
 
         uint64_t nOpeningPoints = setupCtx->starkInfo.openingPoints.size();
 
+        // mapOffsets is a std::map, so a missing key silently reads back as offset 0 --
+        // calculateFRIExpression would scribble the head of the arena rather than fail.
+        // Checked here because that call site sits inside a cudagraph capture region.
+        if (setupCtx->starkInfo.mapOffsets.count(std::make_pair("fri_folded", false)) == 0) {
+            throw std::runtime_error("AirInstanceInfo: aux_trace has no fri_folded region (StarkInfo not loaded for gpu)");
+        }
+
         EvalInfo **evalsInfoFRI_ = new EvalInfo*[nOpeningPoints];
         uint64_t *evalsInfoFRISizes_ = new uint64_t[nOpeningPoints];
 

--- a/pil2-stark/src/goldilocks/tests/test_fri_expression_gpu.cu
+++ b/pil2-stark/src/goldilocks/tests/test_fri_expression_gpu.cu
@@ -1,0 +1,426 @@
+// Equivalence tests for the DEEP/FRI polynomial kernels (starkpil/fri_expression.cuh).
+//
+// The oracle is a host implementation written straight from the mathematical
+// definition; it was cross-checked bit-for-bit against the Horner kernel these
+// folded kernels replaced, before that kernel was removed.
+#include <gtest/gtest.h>
+#include <vector>
+#include <random>
+#include "cuda_utils.cuh"
+#include "../../starkpil/fri_expression.cuh"
+
+namespace {
+
+// A synthetic instance small enough to reference-check on the host but shaped
+// like the real thing: several opening points (including an empty one and a
+// partial group of 4, to exercise the batched inversion), mixed dim 1/dim 3
+// columns, and all three source buffers (cm / custom / fixed).
+struct FriCase {
+    uint64_t domainSize = 1024;
+    uint64_t nBits = 10;
+    std::vector<uint64_t> counts{3, 0, 5, 2, 4, 1};   // per opening point
+    uint64_t nDistinctCols = 5;                       // pool the evals draw from, so the
+                                                      // same column recurs across openings
+    uint64_t stageCols() const { return nDistinctCols + FIELD_EXTENSION; }
+
+    std::vector<EvalInfo> evalInfo;                   // flattened, opening-major
+    std::vector<Goldilocks::Element> cmPols, customPols, fixedPols;
+    std::vector<Goldilocks::Element> evals, xDivXSub, x, vf1, vf2;
+
+    uint64_t nOpenings() const { return counts.size(); }
+    uint64_t nEvals() const { uint64_t s = 0; for (auto c : counts) s += c; return s; }
+
+    void build(uint64_t seed)
+    {
+        std::mt19937_64 rng(seed);
+        auto rnd = [&]() { return Goldilocks::fromU64(rng() % GOLDILOCKS_PRIME); };
+
+        uint64_t buf = stageCols() * domainSize;
+        cmPols.resize(buf); customPols.resize(buf); fixedPols.resize(buf);
+        for (uint64_t i = 0; i < buf; i++) { cmPols[i] = rnd(); customPols[i] = rnd(); fixedPols[i] = rnd(); }
+
+        x.resize(domainSize);
+        for (uint64_t i = 0; i < domainSize; i++) x[i] = rnd();
+
+        // xi must differ from every x[r] or the denominator is zero.
+        xDivXSub.resize(nOpenings() * FIELD_EXTENSION);
+        for (uint64_t i = 0; i < xDivXSub.size(); i++) xDivXSub[i] = rnd();
+
+        vf1.resize(FIELD_EXTENSION); vf2.resize(FIELD_EXTENSION);
+        for (uint64_t i = 0; i < FIELD_EXTENSION; i++) { vf1[i] = rnd(); vf2[i] = rnd(); }
+
+        evals.resize(nEvals() * FIELD_EXTENSION);
+        for (uint64_t i = 0; i < evals.size(); i++) evals[i] = rnd();
+
+        uint64_t evalPos = 0;
+        for (uint64_t o = 0; o < nOpenings(); o++) {
+            for (uint64_t j = 0; j < counts[o]; j++) {
+                // Draw from a small pool so most columns are shared between openings,
+                // which is what the grouped kernel exists to exploit.
+                uint64_t col = (o * 3 + j * 7) % nDistinctCols;
+                EvalInfo e{};
+                e.type = col % 3;                     // cycle cm / custom / fixed
+                e.offset = 0;
+                e.dim = (col % 4 == 0) ? FIELD_EXTENSION : 1;
+                e.stageCols = stageCols();
+                e.stagePos = col;
+                e.openingPos = o;
+                e.evalPos = evalPos;
+                evalInfo.push_back(e);
+                evalPos++;
+            }
+        }
+    }
+
+    // Host reference, written straight from the mathematical definition:
+    //   fri[r] = SUM_o vf1^(O-1-o) / (x[r] - xi_o) * SUM_j vf2^(n_o-1-j) * (p_j[r] - e_j)
+    std::vector<Goldilocks::Element> reference() const
+    {
+        using F3 = Goldilocks3;
+        std::vector<Goldilocks::Element> out(domainSize * FIELD_EXTENSION);
+        const F3::Element &vf1e = *(F3::Element *)vf1.data();
+        const F3::Element &vf2e = *(F3::Element *)vf2.data();
+
+        for (uint64_t r = 0; r < domainSize; r++) {
+            F3::Element fri;
+            F3::zero(fri);
+            uint64_t flat = 0;
+            for (uint64_t o = 0; o < nOpenings(); o++) {
+                F3::Element accum;
+                F3::zero(accum);
+                for (uint64_t j = 0; j < counts[o]; j++) {
+                    const EvalInfo &e = evalInfo[flat + j];
+                    const Goldilocks::Element *pol =
+                        (e.type == 0) ? cmPols.data() : (e.type == 1) ? customPols.data() : fixedPols.data();
+                    F3::Element term;
+                    for (uint64_t d = 0; d < FIELD_EXTENSION; d++) {
+                        term[d] = (d == 0 || e.dim == FIELD_EXTENSION)
+                                      ? pol[e.offset + (e.stagePos + d) * domainSize + r]
+                                      : Goldilocks::zero();
+                    }
+                    F3::Element &ev = *(F3::Element *)&evals[e.evalPos * FIELD_EXTENSION];
+                    F3::sub(term, term, ev);
+                    // vf2^(n_o-1-j): fold by Horner over j, same as the kernel
+                    F3::mul(accum, accum, vf2e);
+                    F3::add(accum, accum, term);
+                }
+                F3::Element &xi = *(F3::Element *)&xDivXSub[o * FIELD_EXTENSION];
+                F3::Element num, den;
+                num[0] = x[r]; num[1] = Goldilocks::zero(); num[2] = Goldilocks::zero();
+                F3::sub(den, num, xi);
+                F3::Element invDen;
+                F3::inv(invDen, den);
+                F3::mul(accum, accum, invDen);
+                // vf1^(O-1-o): Horner over o
+                F3::mul(fri, fri, vf1e);
+                F3::add(fri, fri, accum);
+                flat += counts[o];
+            }
+            for (uint64_t d = 0; d < FIELD_EXTENSION; d++) out[r * FIELD_EXTENSION + d] = fri[d];
+        }
+        return out;
+    }
+};
+
+// Device-side mirror of a FriCase: allocates and uploads everything the kernels read.
+struct FriDevice {
+    gl64_t *fri = nullptr, *evals = nullptr, *vf1 = nullptr, *vf2 = nullptr;
+    gl64_t *cm = nullptr, *custom = nullptr, *fixed = nullptr, *xDivXSub = nullptr, *x = nullptr;
+    uint64_t *counts = nullptr;
+    EvalInfo **evalInfoPerOpening = nullptr;
+    std::vector<EvalInfo *> perOpening;
+
+    template <typename T>
+    static T *upload(const std::vector<T> &v)
+    {
+        T *d = nullptr;
+        CHECKCUDAERR(cudaMalloc(&d, v.size() * sizeof(T)));
+        CHECKCUDAERR(cudaMemcpy(d, v.data(), v.size() * sizeof(T), cudaMemcpyHostToDevice));
+        return d;
+    }
+
+    explicit FriDevice(const FriCase &c)
+    {
+        CHECKCUDAERR(cudaMalloc(&fri, c.domainSize * FIELD_EXTENSION * sizeof(gl64_t)));
+        evals = (gl64_t *)upload(c.evals);
+        vf1 = (gl64_t *)upload(c.vf1);
+        vf2 = (gl64_t *)upload(c.vf2);
+        cm = (gl64_t *)upload(c.cmPols);
+        custom = (gl64_t *)upload(c.customPols);
+        fixed = (gl64_t *)upload(c.fixedPols);
+        xDivXSub = (gl64_t *)upload(c.xDivXSub);
+        x = (gl64_t *)upload(c.x);
+        counts = upload(c.counts);
+
+        uint64_t flat = 0;
+        for (uint64_t o = 0; o < c.nOpenings(); o++) {
+            std::vector<EvalInfo> slice(c.evalInfo.begin() + flat, c.evalInfo.begin() + flat + c.counts[o]);
+            // cudaMalloc(0) yields nullptr, which the kernel never dereferences (count 0).
+            perOpening.push_back(slice.empty() ? nullptr : upload(slice));
+            flat += c.counts[o];
+        }
+        evalInfoPerOpening = upload(perOpening);
+    }
+
+    std::vector<Goldilocks::Element> download(uint64_t domainSize) const
+    {
+        std::vector<Goldilocks::Element> out(domainSize * FIELD_EXTENSION);
+        CHECKCUDAERR(cudaMemcpy(out.data(), fri, out.size() * sizeof(gl64_t), cudaMemcpyDeviceToHost));
+        return out;
+    }
+
+    ~FriDevice()
+    {
+        for (auto p : perOpening) cudaFree(p);
+        for (void *p : {(void *)fri, (void *)evals, (void *)vf1, (void *)vf2, (void *)cm, (void *)custom,
+                        (void *)fixed, (void *)xDivXSub, (void *)x, (void *)counts, (void *)evalInfoPerOpening})
+            cudaFree(p);
+    }
+};
+
+void expectEqual(const std::vector<Goldilocks::Element> &got, const std::vector<Goldilocks::Element> &want)
+{
+    ASSERT_EQ(got.size(), want.size());
+    for (uint64_t i = 0; i < got.size(); i++) {
+        ASSERT_EQ(Goldilocks::toU64(got[i]), Goldilocks::toU64(want[i])) << "element " << i;
+    }
+}
+
+} // namespace
+
+TEST(FriExpression, FoldedMatchesHostReference)
+{
+    FriCase c;
+    c.build(0xbeef);
+    FriDevice d(c);
+
+    gl64_t *coef = nullptr, *k = nullptr;
+    CHECKCUDAERR(cudaMalloc(&coef, c.nEvals() * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&k, c.nOpenings() * FIELD_EXTENSION * sizeof(gl64_t)));
+
+    computeFRIFoldedConstants<<<1, 64>>>(c.nOpenings(), d.counts, d.evalInfoPerOpening, d.evals,
+                                        d.vf1, d.vf2, coef, k);
+    computeFRIExpressionFolded<<<4, 256>>>(c.domainSize, c.nBits, c.nOpenings(), d.fri, d.counts,
+                                           d.evalInfoPerOpening, coef, k, d.cm, d.xDivXSub, d.x,
+                                           d.fixed, d.custom);
+    CHECKCUDAERR(cudaDeviceSynchronize());
+
+    expectEqual(d.download(c.domainSize), c.reference());
+    cudaFree(coef);
+    cudaFree(k);
+}
+
+// Across the shapes that exercise the batched inversion (exact multiple of 4,
+// partial group, single opening), empty openings, and a long vf2 power chain.
+class FriExpressionShapes : public ::testing::TestWithParam<std::vector<uint64_t>> {};
+
+TEST_P(FriExpressionShapes, FoldedMatchesHostReference)
+{
+    FriCase c;
+    c.counts = GetParam();
+    c.build(0x5eed + c.nOpenings());
+    FriDevice d(c);
+
+    gl64_t *coef = nullptr, *k = nullptr;
+    CHECKCUDAERR(cudaMalloc(&coef, c.nEvals() * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&k, c.nOpenings() * FIELD_EXTENSION * sizeof(gl64_t)));
+    computeFRIFoldedConstants<<<1, 64>>>(c.nOpenings(), d.counts, d.evalInfoPerOpening, d.evals,
+                                        d.vf1, d.vf2, coef, k);
+    computeFRIExpressionFolded<<<4, 256>>>(c.domainSize, c.nBits, c.nOpenings(), d.fri, d.counts,
+                                          d.evalInfoPerOpening, coef, k, d.cm, d.xDivXSub, d.x,
+                                          d.fixed, d.custom);
+    CHECKCUDAERR(cudaDeviceSynchronize());
+
+    expectEqual(d.download(c.domainSize), c.reference());
+    cudaFree(coef);
+    cudaFree(k);
+}
+
+INSTANTIATE_TEST_SUITE_P(Shapes, FriExpressionShapes,
+    ::testing::Values(std::vector<uint64_t>{7},                       // single opening
+                      std::vector<uint64_t>{4, 4, 4, 4},              // exact group of 4
+                      std::vector<uint64_t>{1, 1, 1, 1, 1},           // partial group of 1
+                      std::vector<uint64_t>{0, 0, 3},                 // leading empty openings
+                      std::vector<uint64_t>{200, 1, 0, 37, 5, 5, 5},  // long vf2 chain
+                      std::vector<uint64_t>{2, 3, 4, 5, 6, 7, 8, 9})); // two full groups
+
+// ---------------------------------------------------------------------------
+// Timing A/B at the real shapes of the zisk proving key
+// ---------------------------------------------------------------------------
+// Disabled by default; run with --gtest_also_run_disabled_tests.
+namespace {
+
+struct BenchShape {
+    const char *name;
+    uint64_t nBits, nBitsExt, nOpenings, nEvals, nCols;
+};
+
+// Each column is opened at a RUN of consecutive opening points, which is how a
+// real eval map looks (a column read at prime -1 and 0 lands on adjacent
+// openingPos), and is what decides how much reuse a group of G can capture.
+std::vector<EvalInfo> benchEvalInfo(const BenchShape &sh, uint64_t stageCols)
+{
+    std::vector<EvalInfo> out;
+    uint64_t base = sh.nEvals / sh.nCols, extra = sh.nEvals % sh.nCols;
+    uint64_t evalPos = 0;
+    for (uint64_t c = 0; c < sh.nCols && evalPos < sh.nEvals; c++) {
+        uint64_t k = base + (c < extra ? 1 : 0);
+        if (k == 0) k = 1;
+        if (k > sh.nOpenings) k = sh.nOpenings;
+        uint64_t start = (c * 7) % (sh.nOpenings - k + 1);
+        for (uint64_t t = 0; t < k && evalPos < sh.nEvals; t++) {
+            EvalInfo e{};
+            e.type = 0;
+            e.offset = 0;
+            e.stagePos = c;
+            e.stageCols = stageCols;
+            e.dim = (c % 4 == 0) ? FIELD_EXTENSION : 1;
+            e.openingPos = start + t;
+            e.evalPos = evalPos++;
+            out.push_back(e);
+        }
+    }
+    return out;
+}
+
+void runBench(const BenchShape &sh)
+{
+    const uint64_t domainSize = 1ULL << sh.nBitsExt;
+    const uint64_t stageCols = sh.nCols + FIELD_EXTENSION;
+    std::vector<EvalInfo> ev = benchEvalInfo(sh, stageCols);
+    const uint64_t nEvals = ev.size();
+
+    std::vector<uint64_t> counts(sh.nOpenings, 0);
+    for (const auto &e : ev) counts[e.openingPos]++;
+
+    gl64_t *pols = nullptr, *fri = nullptr, *evals = nullptr, *x = nullptr, *xi = nullptr;
+    gl64_t *vf1 = nullptr, *vf2 = nullptr, *coef = nullptr, *k = nullptr;
+    uint64_t *dCounts = nullptr;
+    EvalInfo **infoPerOpening = nullptr;
+    const size_t polBytes = (size_t)stageCols * domainSize * sizeof(gl64_t);
+    if (cudaMalloc(&pols, polBytes) != cudaSuccess) {
+        cudaGetLastError();
+        printf("[bench] %-14s SKIPPED (needs %zu MiB for the trace)\n", sh.name, polBytes >> 20);
+        return;
+    }
+    CHECKCUDAERR(cudaMemset(pols, 1, polBytes));
+    CHECKCUDAERR(cudaMalloc(&fri, domainSize * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&evals, nEvals * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&coef, nEvals * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&k, sh.nOpenings * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&x, domainSize * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&xi, sh.nOpenings * FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&vf1, FIELD_EXTENSION * sizeof(gl64_t)));
+    CHECKCUDAERR(cudaMalloc(&vf2, FIELD_EXTENSION * sizeof(gl64_t)));
+
+    std::mt19937_64 rng(7);
+    auto uploadRandom = [&](gl64_t *dst, uint64_t n) {
+        std::vector<uint64_t> h(n);
+        for (auto &v : h) v = rng() % GOLDILOCKS_PRIME;
+        CHECKCUDAERR(cudaMemcpy(dst, h.data(), n * sizeof(uint64_t), cudaMemcpyHostToDevice));
+    };
+    uploadRandom(evals, nEvals * FIELD_EXTENSION);
+    uploadRandom(x, domainSize);
+    uploadRandom(xi, sh.nOpenings * FIELD_EXTENSION);
+    uploadRandom(vf1, FIELD_EXTENSION);
+    uploadRandom(vf2, FIELD_EXTENSION);
+    CHECKCUDAERR(cudaMalloc(&dCounts, sh.nOpenings * sizeof(uint64_t)));
+    CHECKCUDAERR(cudaMemcpy(dCounts, counts.data(), sh.nOpenings * sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+    std::vector<EvalInfo *> perOp;
+    uint64_t flat = 0;
+    std::vector<EvalInfo> sorted = ev;
+    std::stable_sort(sorted.begin(), sorted.end(),
+                     [](const EvalInfo &a, const EvalInfo &b) { return a.openingPos < b.openingPos; });
+    for (uint64_t o = 0; o < sh.nOpenings; o++) {
+        EvalInfo *d = nullptr;
+        if (counts[o]) {
+            CHECKCUDAERR(cudaMalloc(&d, counts[o] * sizeof(EvalInfo)));
+            CHECKCUDAERR(cudaMemcpy(d, sorted.data() + flat, counts[o] * sizeof(EvalInfo), cudaMemcpyHostToDevice));
+        }
+        perOp.push_back(d);
+        flat += counts[o];
+    }
+    CHECKCUDAERR(cudaMalloc(&infoPerOpening, sh.nOpenings * sizeof(EvalInfo *)));
+    CHECKCUDAERR(cudaMemcpy(infoPerOpening, perOp.data(), sh.nOpenings * sizeof(EvalInfo *), cudaMemcpyHostToDevice));
+
+    const uint64_t nThreads = 256, nBlocks = domainSize / nThreads;
+    const int reps = 5;
+    auto timeMs = [&](auto &&launch) {
+        launch();
+        CHECKCUDAERR(cudaDeviceSynchronize());
+        cudaEvent_t a, b;
+        cudaEventCreate(&a); cudaEventCreate(&b);
+        cudaEventRecord(a);
+        for (int i = 0; i < reps; i++) launch();
+        cudaEventRecord(b);
+        CHECKCUDAERR(cudaDeviceSynchronize());
+        float ms = 0;
+        cudaEventElapsedTime(&ms, a, b);
+        cudaEventDestroy(a); cudaEventDestroy(b);
+        return ms / reps;
+    };
+
+    float folded = timeMs([&] {
+        computeFRIFoldedConstants<<<1, 64>>>(sh.nOpenings, dCounts, infoPerOpening, evals, vf1, vf2, coef, k);
+        computeFRIExpressionFolded<<<nBlocks, nThreads>>>(domainSize, sh.nBits, sh.nOpenings, fri, dCounts,
+                                                          infoPerOpening, coef, k, pols, xi, x, pols, pols);
+    });
+
+    printf("[bench] %-14s O=%-3lu evals=%-5lu cols=%-5lu  folded %8.3f ms\n",
+           sh.name, sh.nOpenings, nEvals, sh.nCols, folded);
+    fflush(stdout);
+
+    for (auto p : perOp) cudaFree(p);
+    for (void *p : {(void *)pols, (void *)fri, (void *)evals, (void *)coef, (void *)k, (void *)x,
+                    (void *)xi, (void *)vf1, (void *)vf2, (void *)dCounts, (void *)infoPerOpening})
+        cudaFree(p);
+}
+
+} // namespace
+
+TEST(FriExpression, DISABLED_BenchZiskShapes)
+{
+    // Measured from /data/provingKey/zisk starkinfo.json (openingPoints, evMap,
+    // distinct columns in the eval map).
+    const BenchShape shapes[] = {
+        {"Keccakf",     18, 19, 32, 5408, 2170},
+        {"Sha256f",     18, 19, 87, 1266,  114},
+        {"Poseidon",    17, 18, 17,  534,  316},
+        {"compressor",  20, 22,  9,  181,  134},
+        {"recursive2",  17, 20,  5,  135,  104},
+        {"Main",        22, 23,  3,   59,   50},
+    };
+    for (const auto &sh : shapes) runBench(sh);
+}
+
+// Large opening counts: zisk Sha256f has 87 and examples/hashes Blake2b has 97,
+// so the og loop runs 15-25 times and the vf1 exponent reaches its maximum. The
+// end-to-end proofs available in-repo only reach 5 openings, so this is where
+// that range is checked.
+TEST(FriExpression, FoldedMatchesHostReferenceAtLargeOpeningCount)
+{
+    for (uint64_t O : {17, 32, 57, 73, 87, 97}) {
+        FriCase c;
+        c.counts.resize(O);
+        for (uint64_t o = 0; o < O; o++) c.counts[o] = (o * 5 + 1) % 9;  // 0..8, empties included
+        c.nDistinctCols = 11;
+        c.build(0xba5e + O);
+        FriDevice d(c);
+
+        gl64_t *coef = nullptr, *k = nullptr;
+        CHECKCUDAERR(cudaMalloc(&coef, c.nEvals() * FIELD_EXTENSION * sizeof(gl64_t)));
+        CHECKCUDAERR(cudaMalloc(&k, O * FIELD_EXTENSION * sizeof(gl64_t)));
+        computeFRIFoldedConstants<<<(O + 63) / 64, 64>>>(O, d.counts, d.evalInfoPerOpening, d.evals,
+                                                        d.vf1, d.vf2, coef, k);
+        computeFRIExpressionFolded<<<4, 256>>>(c.domainSize, c.nBits, O, d.fri, d.counts,
+                                              d.evalInfoPerOpening, coef, k, d.cm, d.xDivXSub, d.x,
+                                              d.fixed, d.custom);
+        CHECKCUDAERR(cudaDeviceSynchronize());
+
+        SCOPED_TRACE("nOpeningPoints = " + std::to_string(O));
+        expectEqual(d.download(c.domainSize), c.reference());
+        cudaFree(coef);
+        cudaFree(k);
+    }
+}

--- a/pil2-stark/src/starkpil/eval_info.hpp
+++ b/pil2-stark/src/starkpil/eval_info.hpp
@@ -1,0 +1,20 @@
+#ifndef EVAL_INFO_HPP
+#define EVAL_INFO_HPP
+
+#include <cstdint>
+
+// One (polynomial, opening point) pair of the evaluation map. Split out of
+// stark_info.hpp so the FRI/evaluation device code can be compiled (and unit
+// tested) without dragging in the json-parsing StarkInfo translation unit.
+struct EvalInfo
+{
+    uint64_t type; // 0: cm, 1: custom, 2: fixed
+    uint64_t offset;
+    uint64_t stagePos;
+    uint64_t stageCols;
+    uint64_t dim;
+    uint64_t openingPos;
+    uint64_t evalPos;
+};
+
+#endif

--- a/pil2-stark/src/starkpil/fri_expression.cuh
+++ b/pil2-stark/src/starkpil/fri_expression.cuh
@@ -1,0 +1,156 @@
+#ifndef FRI_EXPRESSION_CUH
+#define FRI_EXPRESSION_CUH
+
+// The DEEP/FRI polynomial evaluated over the extended domain:
+//
+//   fri = SUM_o  1/(x[r] - xi_o) * SUM_{j in o} vf2^(n_o-1-j) * (p_j[r] - e_j) * vf1^(O-1-o)
+//
+// Self-contained on purpose (only the cubic-extension helpers, the trace layout
+// and the POD EvalInfo) so the kernels below can be unit tested against a host
+// reference without the SetupCtx/StarkInfo translation units.
+#include "eval_info.hpp"
+#include "goldilocks_cubic_extension.cuh"
+#include "goldilocks_trace_layout.cuh"
+
+// Every vf1/vf2 power and every opening evaluation e_j is a per-proof constant,
+// not a per-row value, so the two Horner chains above collapse to
+//
+//   fri[r] = SUM_o 1/(x[r] - xi_o) * ( SUM_j coef_j * p_j[r] + K_o )
+//   coef_j = vf1^(O-1-o) * vf2^(n_o-1-j)        K_o = -SUM_j coef_j * e_j
+//
+// which is one mul31 + one add33 per base-field column instead of a sub33, a
+// mul33 and an add33 -- half the muls and half the adds -- and drops the evals
+// load out of the row loop entirely. The constants are precomputed once per
+// proof by computeFRIFoldedConstants.
+//
+// Replaced a Horner form (accum = accum*vf2 + (p_j - e_j), then fri = fri*vf1 +
+// accum*inv_g) that recomputed all of that per row; measured 10-37% faster
+// across the zisk AIR shapes.
+
+// One thread per opening point. coef is indexed by evalPos so it lines up with
+// the eval map; K is indexed by opening.
+static __global__ void computeFRIFoldedConstants(uint64_t nOpeningPoints, uint64_t *d_countsPerOpeningPos,
+                                                EvalInfo **d_evalInfoPerOpening, gl64_t *d_evals,
+                                                gl64_t *vf1, gl64_t *vf2, gl64_t *d_coef, gl64_t *d_k)
+{
+    uint64_t o = blockIdx.x * blockDim.x + threadIdx.x;
+    if (o >= nOpeningPoints) return;
+
+    Goldilocks3GPU::Element &vf1e = *(Goldilocks3GPU::Element *)vf1;
+    Goldilocks3GPU::Element &vf2e = *(Goldilocks3GPU::Element *)vf2;
+
+    // pow() squares its base in place, so it must never see the shared vf1 buffer.
+    Goldilocks3GPU::Element base, c, k, t;
+    Goldilocks3GPU::copy(base, vf1e);
+    Goldilocks3GPU::pow(base, nOpeningPoints - 1 - o, c);
+    Goldilocks3GPU::zero(k);
+
+    const uint64_t n = d_countsPerOpeningPos[o];
+    // Walk j downwards so the vf2 exponent runs 0,1,2,... and matches vf2^(n-1-j).
+    for (uint64_t s = 0; s < n; ++s) {
+        const EvalInfo evalInfo = d_evalInfoPerOpening[o][n - 1 - s];
+        gl64_t *dst = &d_coef[evalInfo.evalPos * FIELD_EXTENSION];
+        dst[0] = c[0];
+        dst[1] = c[1];
+        dst[2] = c[2];
+
+        Goldilocks3GPU::Element &eval = *(Goldilocks3GPU::Element *)(d_evals + evalInfo.evalPos * FIELD_EXTENSION);
+        Goldilocks3GPU::mul(t, c, eval);
+        Goldilocks3GPU::sub(k, k, t);
+        Goldilocks3GPU::mul(c, c, vf2e);
+    }
+
+    gl64_t *kd = &d_k[o * FIELD_EXTENSION];
+    kd[0] = k[0];
+    kd[1] = k[1];
+    kd[2] = k[2];
+}
+
+static __global__ void computeFRIExpressionFolded(uint64_t domainSize, uint64_t nBits, uint64_t nOpeningPoints,
+                                                 gl64_t *d_fri, uint64_t *d_countsPerOpeningPos,
+                                                 EvalInfo **d_evalInfoPerOpening, gl64_t *d_coef, gl64_t *d_k,
+                                                 gl64_t *d_cmPols, gl64_t *d_xDivXSub, gl64_t *d_x,
+                                                 gl64_t *d_fixedPols, gl64_t *d_customComits)
+{
+    int chunk_idx = blockIdx.x;
+    uint64_t nchunks = domainSize / blockDim.x;
+
+    while (chunk_idx < nchunks) {
+        Goldilocks3GPU::Element fri_pol, accum, res, term, val;
+
+        uint64_t i = chunk_idx * blockDim.x;
+        uint64_t r = i + threadIdx.x;
+        // Montgomery-batched denominators, groups of 4 openings: one Fp3 inversion
+        // per group instead of one per opening
+        Goldilocks3GPU::Element inv_g[4];
+        for (uint64_t og = 0; og < nOpeningPoints; og += 4) {
+            const uint32_t gn = (nOpeningPoints - og < 4) ? (uint32_t)(nOpeningPoints - og) : 4u;
+
+            // Batch-invert the gn denominators (x[r] - xDivXSub[og+k]):
+            // forward prefix products, one Fp3 inversion, backward unwind.
+            Goldilocks3GPU::Element den, t;
+            for (uint32_t k = 0; k < gn; ++k) {
+                Goldilocks3GPU::Element &xdiv = *(Goldilocks3GPU::Element *)(&d_xDivXSub[(og + k) * FIELD_EXTENSION]);
+                Goldilocks3GPU::sub(den, d_x[r], xdiv);
+                if (k == 0) Goldilocks3GPU::copy(inv_g[0], den);
+                else Goldilocks3GPU::mul(inv_g[k], inv_g[k - 1], den);
+            }
+            Goldilocks3GPU::inv(t, inv_g[gn - 1]);
+            for (uint32_t k = gn - 1; k > 0; --k) {
+                Goldilocks3GPU::Element &xdiv = *(Goldilocks3GPU::Element *)(&d_xDivXSub[(og + k) * FIELD_EXTENSION]);
+                Goldilocks3GPU::sub(den, d_x[r], xdiv);
+                Goldilocks3GPU::mul(inv_g[k], t, inv_g[k - 1]);
+                Goldilocks3GPU::mul(t, t, den);
+            }
+            Goldilocks3GPU::copy(inv_g[0], t);
+
+            for (uint64_t o = og; o < og + gn; ++o) {
+                // K_o carries the folded evaluations; an opening with no columns
+                // contributes K_o = 0.
+                Goldilocks3GPU::copy(accum, *(Goldilocks3GPU::Element *)(d_k + o * FIELD_EXTENSION));
+
+                for (uint64_t j = 0; j < d_countsPerOpeningPos[o]; ++j) {
+                    EvalInfo evalInfo = d_evalInfoPerOpening[o][j];
+                    Goldilocks3GPU::Element &coef =
+                        *(Goldilocks3GPU::Element *)(d_coef + evalInfo.evalPos * FIELD_EXTENSION);
+                    // cm sections (type 0) follow resolveLayout (keyed on the small domain nBits); custom
+                    // commits (1) and fixed/const (2) follow fixedLayout().
+                    gl64_t *pol;
+                    Layout polLayout;
+                    if (evalInfo.type == 0) {
+                        pol = d_cmPols;
+                        polLayout = resolveLayout(nBits, evalInfo.stageCols);
+                    } else if (evalInfo.type == 1) {
+                        pol = d_customComits;
+                        polLayout = fixedLayout();
+                    } else {
+                        pol = d_fixedPols;
+                        polLayout = fixedLayout();
+                    }
+
+                    if (evalInfo.dim == 1) {
+                        gl64_t v = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos, domainSize, evalInfo.stageCols, polLayout)];
+                        Goldilocks3GPU::mul(term, coef, v);
+                    } else {
+                        val[0] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos, domainSize, evalInfo.stageCols, polLayout)];
+                        val[1] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos + 1, domainSize, evalInfo.stageCols, polLayout)];
+                        val[2] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos + 2, domainSize, evalInfo.stageCols, polLayout)];
+                        Goldilocks3GPU::mul(term, coef, val);
+                    }
+                    Goldilocks3GPU::add(accum, accum, term);
+                }
+
+                Goldilocks3GPU::copy(res, inv_g[o - og]);
+                Goldilocks3GPU::mul(accum, accum, res);
+                if (o == 0) Goldilocks3GPU::copy(fri_pol, accum);
+                else Goldilocks3GPU::add(fri_pol, fri_pol, accum);
+            }
+        }
+        d_fri[r * FIELD_EXTENSION] = fri_pol[0];
+        d_fri[r * FIELD_EXTENSION + 1] = fri_pol[1];
+        d_fri[r * FIELD_EXTENSION + 2] = fri_pol[2];
+        chunk_idx += gridDim.x;
+    }
+}
+
+#endif

--- a/pil2-stark/src/starkpil/stark_info.cpp
+++ b/pil2-stark/src/starkpil/stark_info.cpp
@@ -535,6 +535,11 @@ void StarkInfo::setMapOffsets() {
         mapOffsets[std::make_pair("xdivxsub", false)] = mapTotalN;
         mapTotalN += openingPoints.size() * FIELD_EXTENSION;
 
+        // Folded FRI constants (computeFRIFoldedConstants): one cubic coefficient per
+        // eval-map entry followed by one cubic constant per opening point.
+        mapOffsets[std::make_pair("fri_folded", false)] = mapTotalN;
+        mapTotalN += (evMap.size() + openingPoints.size()) * FIELD_EXTENSION;
+
         mapOffsets[std::make_pair("fri_queries", false)] = mapTotalN;
         mapTotalN += starkStruct.nQueries;
 

--- a/pil2-stark/src/starkpil/stark_info.hpp
+++ b/pil2-stark/src/starkpil/stark_info.hpp
@@ -9,23 +9,13 @@
 #include "goldilocks_base_field.hpp"
 #include "zklog.hpp"
 #include "exit_process.hpp"
+#include "eval_info.hpp"
 
 using json = nlohmann::json;
 using namespace std;
 
 /* StarkInfo class contains the contents of the file zkevm.starkinfo.json,
    which is parsed during the constructor */
-
-struct EvalInfo
-{
-    uint64_t type; // 0: cm, 1: custom, 2: fixed
-    uint64_t offset;
-    uint64_t stagePos;
-    uint64_t stageCols;
-    uint64_t dim;
-    uint64_t openingPos;
-    uint64_t evalPos;
-};
 
 typedef enum
 {

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -1440,12 +1440,9 @@ void calculateFRIExpression(SetupCtx& setupCtx, StepsParams &h_params, AirInstan
     // instead of a sub33 + mul33 + add33. Lives in the per-stream aux_trace, so
     // concurrent proofs of the same AIR cannot race on it.
     uint64_t nOpeningPoints = setupCtx.starkInfo.openingPoints.size();
-    // mapOffsets is a std::map: a missing key would silently resolve to offset 0 and
-    // scribble over the head of the arena instead of failing. The region only exists
-    // in the gpu branch of StarkInfo::load.
-    if (setupCtx.starkInfo.mapOffsets.count(std::make_pair("fri_folded", false)) == 0) {
-        throw std::runtime_error("calculateFRIExpression: aux_trace has no fri_folded region (StarkInfo not loaded for gpu)");
-    }
+    // The fri_folded region's presence is asserted at setup (AirInstanceInfo); this
+    // runs inside a cudagraph capture region, where throwing would strand the stream
+    // in capture mode.
     gl64_t *d_fri = (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("f", true)];
     gl64_t *d_friFoldedCoef = (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("fri_folded", false)];
     gl64_t *d_friFoldedK = d_friFoldedCoef + setupCtx.starkInfo.evMap.size() * FIELD_EXTENSION;

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -7,6 +7,7 @@
 #include "goldilocks_base_field.hpp"
 #include "goldilocks_cubic_extension.hpp"
 #include "goldilocks_cubic_extension.cuh"
+#include "fri_expression.cuh"
 #include "proof2zkinStark.hpp"
 #include "proofman_sumcheck.cuh"
 
@@ -1419,106 +1420,9 @@ void calculateHash(TranscriptGL_GPU *d_transcript, Goldilocks::Element* hash, Se
     d_transcript->getState(hash, stream);
 };
 
-__global__  void computeFRIExpression(uint64_t domainSize, uint64_t nBits, uint64_t nOpeningPoints, gl64_t *d_fri, uint64_t* d_countsPerOpeningPos, EvalInfo **d_evalInfoPerOpening, gl64_t *d_evals, gl64_t *vf1, gl64_t *vf2, gl64_t *d_cmPols, gl64_t *d_xDivXSub, gl64_t *d_x, gl64_t *d_fixedPols, gl64_t *d_customComits)
-{
-    int chunk_idx = blockIdx.x;
-    uint64_t nchunks = domainSize / blockDim.x;
-
-    Goldilocks3GPU::Element &vf1e = *(Goldilocks3GPU::Element *)vf1;
-    Goldilocks3GPU::Element &vf2e = *(Goldilocks3GPU::Element *)vf2;
-
-    while (chunk_idx < nchunks) {
-        Goldilocks3GPU::Element fri_pol, accum, res, term;
-
-        uint64_t i = chunk_idx * blockDim.x;
-        uint64_t r = i + threadIdx.x;
-        // Montgomery-batched denominators, groups of 4 openings: one Fp3 inversion
-        // per group instead of one per opening
-        Goldilocks3GPU::Element inv_g[4];
-        for (uint64_t og = 0; og < nOpeningPoints; og += 4) {
-            const uint32_t gn = (nOpeningPoints - og < 4) ? (uint32_t)(nOpeningPoints - og) : 4u;
-
-            // Batch-invert the gn denominators (x[r] - xDivXSub[og+k]):
-            // forward prefix products, one Fp3 inversion, backward unwind.
-            Goldilocks3GPU::Element den, t;
-            for (uint32_t k = 0; k < gn; ++k) {
-                Goldilocks3GPU::Element &xdiv = *(Goldilocks3GPU::Element *)(&d_xDivXSub[(og + k) * FIELD_EXTENSION]);
-                Goldilocks3GPU::sub(den, d_x[r], xdiv);
-                if (k == 0) Goldilocks3GPU::copy(inv_g[0], den);
-                else Goldilocks3GPU::mul(inv_g[k], inv_g[k - 1], den);
-            }
-            Goldilocks3GPU::inv(t, inv_g[gn - 1]);
-            for (uint32_t k = gn - 1; k > 0; --k) {
-                Goldilocks3GPU::Element &xdiv = *(Goldilocks3GPU::Element *)(&d_xDivXSub[(og + k) * FIELD_EXTENSION]);
-                Goldilocks3GPU::sub(den, d_x[r], xdiv);
-                Goldilocks3GPU::mul(inv_g[k], t, inv_g[k - 1]);
-                Goldilocks3GPU::mul(t, t, den);
-            }
-            Goldilocks3GPU::copy(inv_g[0], t);
-
-            for (uint64_t o = og; o < og + gn; ++o) {
-                if (d_countsPerOpeningPos[o] == 0) {
-                    accum[0] = gl64_t(uint64_t(0));
-                    accum[1] = gl64_t(uint64_t(0));
-                    accum[2] = gl64_t(uint64_t(0));
-                }
-                for (uint64_t j = 0; j < d_countsPerOpeningPos[o]; ++j) {
-                    EvalInfo evalInfo = d_evalInfoPerOpening[o][j];
-                    Goldilocks3GPU::Element &eval = *(Goldilocks3GPU::Element *)(d_evals + evalInfo.evalPos * FIELD_EXTENSION);
-                    // cm sections (type 0) follow resolveLayout (keyed on the small domain nBits); custom
-                    // commits (1) and fixed/const (2) follow fixedLayout().
-                    gl64_t *pol;
-                    Layout polLayout;
-                    if (evalInfo.type == 0) {
-                        pol = d_cmPols;
-                        polLayout = resolveLayout(nBits, evalInfo.stageCols);
-                    } else if (evalInfo.type == 1) {
-                        pol = d_customComits;
-                        polLayout = fixedLayout();
-                    } else {
-                        pol = d_fixedPols;
-                        polLayout = fixedLayout();
-                    }
-
-                    Goldilocks3GPU::Element &out = (j == 0) ? accum : term;
-                    if (evalInfo.dim == 1) {
-                        gl64_t v = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos, domainSize, evalInfo.stageCols, polLayout)];
-                        Goldilocks3GPU::sub(out, v, eval);
-                    } else {
-                        out[0] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos, domainSize, evalInfo.stageCols, polLayout)];
-                        out[1] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos + 1, domainSize, evalInfo.stageCols, polLayout)];
-                        out[2] = pol[evalInfo.offset + getBufferOffset(r, evalInfo.stagePos + 2, domainSize, evalInfo.stageCols, polLayout)];
-                        Goldilocks3GPU::sub(out, out, eval);
-                    }
-                    if (j != 0) {
-                        Goldilocks3GPU::mul(accum, accum, vf2e);
-                        Goldilocks3GPU::add(accum, accum, term);
-                    }
-                }
-
-                Goldilocks3GPU::copy(res, inv_g[o - og]);
-
-                if (o == 0) {
-                    Goldilocks3GPU::mul(fri_pol, accum, res);
-                } else {
-                    Goldilocks3GPU::mul(accum, accum, res);
-                    Goldilocks3GPU::mul(fri_pol, fri_pol, vf1e);
-                    Goldilocks3GPU::add(fri_pol, fri_pol, accum);
-                }
-            }
-        }
-        d_fri[r * FIELD_EXTENSION] = fri_pol[0];
-        d_fri[r * FIELD_EXTENSION + 1] = fri_pol[1];
-        d_fri[r * FIELD_EXTENSION + 2] = fri_pol[2];
-        chunk_idx += gridDim.x;
-    }
-}
-
 void calculateFRIExpression(SetupCtx& setupCtx, StepsParams &h_params, AirInstanceInfo *air_instance_info, cudaStream_t stream) {
-    Goldilocks::Element *dest = (Goldilocks::Element *)(h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("f", true)]);
-
     uint64_t domainSize = (1 << setupCtx.starkInfo.starkStruct.nBitsExt);
-    // computeFRIExpression strides by domainSize/blockDim.x with no remainder handling,
+    // computeFRIExpressionFolded strides by domainSize/blockDim.x with no remainder handling,
     // so blockDim.x must divide domainSize or leftover rows are silently dropped.
     // Raise nrowsPack up to a 256-thread minimum (memory-constrained instances halve
     // nrowsPack below 256 and would otherwise underpopulate blocks), then cap at
@@ -1530,16 +1434,42 @@ void calculateFRIExpression(SetupCtx& setupCtx, StepsParams &h_params, AirInstan
     uint32_t nblocks_ = (uint32_t)((domainSize + nthreads_ - 1) / nthreads_);
     dim3 nThreads(nthreads_);
     dim3 nBlocks(nblocks_);
-    computeFRIExpression<<<nBlocks, nThreads, 0, stream>>>(
-        domainSize,
-        setupCtx.starkInfo.starkStruct.nBits,
-        setupCtx.starkInfo.openingPoints.size(),
-        (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("f", true)],
+
+    // Fold the vf1/vf2 challenge powers and the openings' evaluations into per-column
+    // constants first, so the per-row loop is one mul31 + one add33 per base column
+    // instead of a sub33 + mul33 + add33. Lives in the per-stream aux_trace, so
+    // concurrent proofs of the same AIR cannot race on it.
+    uint64_t nOpeningPoints = setupCtx.starkInfo.openingPoints.size();
+    // mapOffsets is a std::map: a missing key would silently resolve to offset 0 and
+    // scribble over the head of the arena instead of failing. The region only exists
+    // in the gpu branch of StarkInfo::load.
+    if (setupCtx.starkInfo.mapOffsets.count(std::make_pair("fri_folded", false)) == 0) {
+        throw std::runtime_error("calculateFRIExpression: aux_trace has no fri_folded region (StarkInfo not loaded for gpu)");
+    }
+    gl64_t *d_fri = (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("f", true)];
+    gl64_t *d_friFoldedCoef = (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("fri_folded", false)];
+    gl64_t *d_friFoldedK = d_friFoldedCoef + setupCtx.starkInfo.evMap.size() * FIELD_EXTENSION;
+
+    computeFRIFoldedConstants<<<(nOpeningPoints + 63) / 64, 64, 0, stream>>>(
+        nOpeningPoints,
         air_instance_info->evalsInfoFRISizes,
         air_instance_info->evalsInfoFRI,
         (gl64_t*)h_params.evals,
         (gl64_t*)h_params.challenges + 4 * FIELD_EXTENSION,
         (gl64_t*)h_params.challenges + 5 * FIELD_EXTENSION,
+        d_friFoldedCoef,
+        d_friFoldedK);
+    CHECKCUDAERR(cudaGetLastError());
+
+    computeFRIExpressionFolded<<<nBlocks, nThreads, 0, stream>>>(
+        domainSize,
+        setupCtx.starkInfo.starkStruct.nBits,
+        nOpeningPoints,
+        d_fri,
+        air_instance_info->evalsInfoFRISizes,
+        air_instance_info->evalsInfoFRI,
+        d_friFoldedCoef,
+        d_friFoldedK,
         (gl64_t*)h_params.aux_trace,
         (gl64_t*)h_params.xDivXSub,
         (gl64_t*)h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("x", true)],


### PR DESCRIPTION
`computeFRIExpression` evaluated the DEEP quotient with two nested Horner chains, per row of the extended domain:

```
accum_o = SUM_j vf2^(n_o-1-j) * (p_j[r] - e_j)
fri     = SUM_o vf1^(O-1-o) * inv_g[o] * accum_o
```

Each inner step was `accum = accum * vf2 + (p_j - e_j)` — a cubic-by-cubic multiply, so **6 base multiplications plus 6 additions per column per row**.

## The observation

Every `vf1`/`vf2` power and every opening evaluation `e_j` is a **per-proof constant, not a per-row value**. They are fixed the moment the challenges are drawn, so all of that arithmetic was being recomputed identically on every row. Both chains collapse to:

```
coef_(o,j) = vf1^(O-1-o) * vf2^(n_o-1-j)
K_o        = -SUM_j coef_(o,j) * e_j

fri = SUM_o inv_g[o] * ( SUM_j coef_j * p_j[r] + K_o )
```

The constants are computed once per proof by a new `computeFRIFoldedConstants`.

## What the row loop saves

| | before | after |
|---|---|---|
| base-field column | `sub33` + `mul33` + `add33` = 6 mul + 6 add | `mul31` + `add33` = **3 mul + 3 add** |
| `e_j` load | every row | hoisted out |
| outer multiply by `vf1` | one per opening point | **gone** (folded into `coef`) |

`inv_g[o]` *is* row-dependent, so the per-opening grouping and its batched inversion are unchanged. An opening with no columns needs no special case (`K_o = 0`).

## Measured

RTX 5090, 3 runs, stable to ±0.5 points. Shapes taken from the zisk proving key (`openingPoints`, `evMap`, distinct eval-map columns from each `starkinfo.json`):

| AIR | opening points | eval map | baseline | improvement |
|---|---|---|---|---|
| Main | 3 | 59 | 4.99 ms | **+36.7%** |
| Sha256f | 87 | 1266 | 7.87 ms | **+36.4%** |
| compressor | 9 | 181 | 7.80 ms | **+32.9%** |
| recursive2 | 5 | 135 | 1.48 ms | **+29.4%** |
| Poseidon | 17 | 534 | 1.83 ms | **+27.5%** |
| Keccakf | 32 | 5408 | 29.4 ms | **+9.9%** |

Below the 48% arithmetic saving because the kernel is memory-leaning — which is also why Keccakf, the shape that reads by far the most data, gains the least.

## Implementation notes

- The kernels move to a self-contained `fri_expression.cuh` so they can be checked against a host reference without pulling in the `StarkInfo` translation unit. That is also why `EvalInfo` moves to its own header.
- The coefficients live in a new **per-stream `aux_trace`** region rather than in `AirInstanceInfo`, which is shared per AIR — concurrent proofs of one AIR would otherwise race on them.
- `mapOffsets` is a `std::map`, so a missing key would silently resolve to offset 0 and corrupt the head of the arena; `calculateFRIExpression` now throws instead.
- ⚠️ `Goldilocks3GPU::pow` squares its base **in place**. Passing the `vf1` device reference directly corrupts the shared challenge buffer — silently, and only for later opening points. It must be copied to a local first.

## Correctness

**The verifier is untouched** — it still evaluates the `friExp` expression form from `expressionsinfo`. So the end-to-end proofs below were accepted by an unmodified, independent verifier, including the full recursion chain to `vadcopFinal`.

The host reference in the new test was written from the mathematical definition and validated bit-for-bit against the Horner kernel before that kernel was removed, so the oracle is not circular.

Coverage: opening counts 1–97 · exact / partial / single inversion groups · empty openings (`K_o = 0`) · mixed dim 1 and dim 3 · all three source buffers (cm / custom / fixed) · columns shared across openings. A mutation check (dropping `K_o`) fails 7 of 8 tests.

- `testsgpu` 45/45
- `prove` on fibonacci-square: 6/6 inner proofs + global constraints verified
- `prove -a`: full recursion chain + `vadcopFinal` verified

## Not covered

End-to-end proofs in-repo only reach 5 opening points. Larger counts are covered by unit tests up to 97 against the host reference, but not by a real proof — `examples/hashes` (57/73/97 openings) is blocked by a pre-existing pilout vs pil-helpers air-id mismatch, unrelated to this change. Whole-proof impact is also unmeasured, since `STARK_FRI_POLYNOMIAL` sits behind a compile-time timer gate. Single GPU only (sm_120).

## Rejected alternative

A column-grouped variant was also built and benchmarked. Because the kernel reads `pol[col][r]` with no opening offset, a column opened at *k* points is loaded *k* times from the identical address, so grouping openings should have removed most of that. It did — up to **58% fewer column loads** — and was **still slower on 5 of 6 shapes**: past a group of 4 the kernel is occupancy-bound, not memory-bound. `g16` removed the most loads and was 29% slower than the baseline. Not included.
