### PR TITLE
ntt: fuse the coset spread into the batched LDE

### DIFF
--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -1777,7 +1777,7 @@ uint64_t commit_witness_gpu(void *pSetupCtx_, void *params_, uint64_t instanceId
 
     PROOFMAN_SUMCHECK("contrib_before_lde", d_aux_trace + offset_src, N * nCols, stream);
     auto commitLdeBody = [&] {
-        ntt.LDE(d_aux_trace, offset_dst, d_aux_trace, offset_src, nBits, nBitsExt, nCols, timer, stream, true, (gl64_t*)pNodes);
+        ntt.LDE(d_aux_trace, offset_dst, d_aux_trace, offset_src, nBits, nBitsExt, nCols, timer, stream, true, (gl64_t*)pNodes, setupCtx->starkInfo.getNumNodesMT(NExtended));
         TimerStartCategoryGPU(timer, MERKLE_TREE);
         // cm1 contribution commit: read the extended trace in the layout the LDE wrote (resolveLayout on
         // the small domain). When tiled AIRs existed, hardcoding ColMajor here made the tiled contribution
@@ -1908,7 +1908,7 @@ void write_custom_commit_gpu(void* root, uint64_t arity, uint64_t nBits, uint64_
     Goldilocks::Element *pNodes = (Goldilocks::Element *)&d_customCommitsTree[nCols * NExtended];
     // The small-domain pols were copied to the host above, so preserve_src=false is fine even where
     // the serial flow runs its iNTT in place on d_customCommitsPols.
-    ntt.ldeColMajor((gl64_t *)d_customCommitsTree, (gl64_t *)d_customCommitsPols, nBits, nBitsExt, nCols, stream, false, (gl64_t *)pNodes);
+    ntt.ldeColMajor((gl64_t *)d_customCommitsTree, (gl64_t *)d_customCommitsPols, nBits, nBitsExt, nCols, stream, false, (gl64_t *)pNodes, mt.numNodes);
     buildMerkleTreeGPU(arity, (uint64_t*)pNodes, (uint64_t*)d_customCommitsTree, nCols, 1ULL << nBitsExt, fixedLayout(), stream);
 
     cudaMemcpy(customCommitsTree, d_customCommitsTree, treeSize * sizeof(Goldilocks::Element), cudaMemcpyDeviceToHost);
@@ -1967,7 +1967,7 @@ void calculate_const_tree_gpu(void *pStarkInfo, void *pConstPolsAddress, void *p
     Goldilocks::Element *pNodes = d_fixedTree + starkInfo.nConstants * NExtended;
     // Const tree uses fixedLayout() (ColMajor). d_fixedPols is a throwaway copy of the host const
     // pols, so preserve_src=false is fine even where the serial flow runs its iNTT in place on it.
-    ntt.ldeColMajor((gl64_t *)d_fixedTree, (gl64_t *)d_fixedPols, starkInfo.starkStruct.nBits, starkInfo.starkStruct.nBitsExt, starkInfo.nConstants, stream, false, (gl64_t *)pNodes);
+    ntt.ldeColMajor((gl64_t *)d_fixedTree, (gl64_t *)d_fixedPols, starkInfo.starkStruct.nBits, starkInfo.starkStruct.nBitsExt, starkInfo.nConstants, stream, false, (gl64_t *)pNodes, mt.numNodes);
     buildMerkleTreeGPU(starkInfo.starkStruct.merkleTreeArity, (uint64_t*)pNodes, (uint64_t*)d_fixedTree, starkInfo.nConstants, 1ULL << starkInfo.starkStruct.nBitsExt, fixedLayout(), stream);
 
     Goldilocks::Element *pConstTreeAddress = (Goldilocks::Element *)pConstTreeAddress_;

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
@@ -737,10 +737,9 @@ __device__ __forceinline__ gl64_t nttCosetLoadVal_(const gl64_t *src,
 
 // DIT (decimation-in-time) step: bit-reversed input order, natural output -- the
 // forward NTT of the LDE. gridDim.y selects the column (stride col_stride elements).
-// coset_load (stage-0, non-coalesced, single-column launches only): loads come from
-// nttCosetLoadVal_(d_csrc, ...) instead of d_inout -- see ldeColMajor's serial path.
-// With it, stage 0 never READS d_inout at all (only writes it), so the launch is
-// hazard-free even when d_csrc is disjoint scratch and d_inout aliases the source.
+// coset_load (stage-0, non-coalesced launches only): loads come from the caller's compact
+// iNTT result (d_csrc, column stride csrc_stride) rather than d_inout, so stage 0 only ever
+// WRITES d_inout -- hazard-free provided d_csrc is disjoint from the written columns.
 template<int z_count, bool coalesced = false, bool coset_load = false>
 __launch_bounds__(768, 1) __global__
 void nttDitColMajorKernel(const uint32_t radix, const uint32_t lg_domain_size,
@@ -751,9 +750,11 @@ void nttDitColMajorKernel(const uint32_t radix, const uint32_t lg_domain_size,
                           const gl64_t *d_radix6, const gl64_t *d_radixX,
                           bool is_intt, const uint64_t domain_inv,
                           const gl64_t *d_csrc, const gl64_t (*d_cosetPows)[NTT_WIN_SIZE],
-                          uint32_t lg_blowup)
+                          uint32_t lg_blowup, size_t csrc_stride)
 {
     gl64_t *d_inout = d_base + (size_t)blockIdx.y * col_stride;
+    if constexpr (coset_load)
+        d_csrc += (size_t)blockIdx.y * csrc_stride;
     extern __shared__ int nttShm[];
     gl64_t *shared_exchange = reinterpret_cast<gl64_t *>(nttShm);
 
@@ -1090,100 +1091,6 @@ void nttDifColMajorKernel(const uint32_t radix, const uint32_t lg_domain_size,
     }
 }
 
-// Coset spread: reads the iNTT result (bit-reversed order), multiplies by
-// gen^bit_rev(idx) from the windowed coset-power table, writes to out[idx<<blowup]
-// and zero-fills the blowup gaps (out = the destination column). in/out must be disjoint.
-// One launch spreads the SOURCE coefficients with index in [lo, hi): it reads
-// front positions [lo, hi) and writes output positions [lo*blowup, hi*blowup).
-// The driver picks lo = hi/blowup, so the writes span exactly [hi, hi*blowup):
-// they begin precisely where this launch's own reads end, and land on the region
-// the PREVIOUS (higher) window already consumed -- the driver walks windows
-// descending (hi = N, N/b, N/b^2, ...), with the launch boundary as the sync.
-// Everything still unread ([0, lo)) lies strictly below all writes, so the whole
-// spread runs in place with NO scratch. The lowest window ([0, hi), hi <= TPB)
-// overlaps its own reads (position 0 -> 0) and is handled by
-// nttCosetSpreadHeadKernel: one block per column, read-all / sync / write.
-// gridDim.y = column.
-__global__ void nttCosetSpreadKernel(gl64_t *out, const gl64_t *in,
-                                     const gl64_t (*cosetPows)[NTT_WIN_SIZE],
-                                     uint32_t lg_domain_size, uint32_t lg_blowup,
-                                     uint32_t lo, uint32_t hi,
-                                     size_t outColStride, size_t inColStride)
-{
-    uint32_t domain_size = 1u << lg_domain_size;
-    uint32_t idx = lo + blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= hi || idx >= domain_size)
-        return;
-    out += (size_t)blockIdx.y * outColStride;
-    in  += (size_t)blockIdx.y * inColStride;
-
-    uint32_t blowup = 1u << lg_blowup;
-    gl64_t r = in[idx];
-
-    uint32_t pow = nttBitRev(idx, lg_domain_size);
-    // coset root = gen^pow, assembled from the windowed powers
-    gl64_t root = cosetPows[0][pow % NTT_WIN_SIZE];
-    #pragma unroll
-    for (int o = 1; o < NTT_WIN_NUM; o++) {
-        uint32_t w = (pow >> (o * NTT_LG_WIN)) % NTT_WIN_SIZE;
-        if (w)
-            root *= cosetPows[o][w];
-    }
-    r = r * root;
-
-    size_t base = (size_t)idx << lg_blowup;
-    out[base] = r;
-    gl64_t zero = gl64_t(uint64_t(0));
-    for (uint32_t j = 1; j < blowup; j++)
-        out[base + j] = zero;
-}
-
-// Final spread window [0, hi), hi <= blockDim.x: writes [0, hi*blowup) overlap
-// the reads, so one block per column reads everything to registers, syncs, and
-// only then writes. gridDim.y = column, in == out (column front).
-__global__ void nttCosetSpreadHeadKernel(gl64_t *col,
-                                         const gl64_t (*cosetPows)[NTT_WIN_SIZE],
-                                         uint32_t lg_domain_size, uint32_t lg_blowup,
-                                         uint32_t hi, size_t colStride)
-{
-    col += (size_t)blockIdx.y * colStride;
-    uint32_t idx = threadIdx.x;
-    gl64_t r;
-    if (idx < hi)
-        r = col[idx];
-    __syncthreads();
-    if (idx >= hi)
-        return;
-    uint32_t blowup = 1u << lg_blowup;
-    uint32_t pow = nttBitRev(idx, lg_domain_size);
-    gl64_t root = cosetPows[0][pow % NTT_WIN_SIZE];
-    #pragma unroll
-    for (int o = 1; o < NTT_WIN_NUM; o++) {
-        uint32_t w = (pow >> (o * NTT_LG_WIN)) % NTT_WIN_SIZE;
-        if (w)
-            root *= cosetPows[o][w];
-    }
-    r = r * root;
-    size_t base = (size_t)idx << lg_blowup;
-    col[base] = r;
-    gl64_t zero = gl64_t(uint64_t(0));
-    for (uint32_t j = 1; j < blowup; j++)
-        col[base + j] = zero;
-}
-
-// Copy a chunk's source columns into the TAIL N elements of each destination
-// column (the iNTT then runs in place on the tails; src is never written).
-__global__ void nttCopyToDestinationTailsKernel(gl64_t *dst_base, const gl64_t *src_base,
-                                    uint32_t lg_n, size_t dst_stride)
-{
-    const size_t N = (size_t)1 << lg_n;
-    const gl64_t *src = src_base + (size_t)blockIdx.y * N;
-    gl64_t *dst = dst_base + (size_t)blockIdx.y * dst_stride + (dst_stride - N);
-    for (size_t i = blockIdx.x * (size_t)blockDim.x + threadIdx.x; i < N;
-         i += (size_t)gridDim.x * blockDim.x)
-        dst[i] = src[i];
-}
-
 // In-place bit-reversal permutation of each column (gridDim.y selects the column).
 // Each (i, rev(i)) pair is swapped once, by its lower-indexed side. Combined with a
 // DIT run this forms the NN-order (natural in -> natural out) transform.
@@ -1362,12 +1269,13 @@ struct NttRun {
     cudaStream_t s;
     bool dit;              // true = DIT (rev->nat, the NTT), false = DIF (nat->rev, the iNTT)
     int stage = 0;         // internal cursor, set by run() -- callers omit it
-    // Fused coset-spread load (LDE serial path): when set, the FIRST DIT launch
-    // reads nttCosetLoadVal_(cosetSrc, ...) instead of d_base. cosetSrc must be
-    // disjoint from the output column and ncols must be 1.
+    // Fused coset-spread load: when set, the FIRST DIT launch reads
+    // nttCosetLoadVal_(cosetSrc + col * cosetStride, ...) instead of d_base.
+    // cosetSrc must be a region disjoint from the ncols output columns.
     const gl64_t *cosetSrc = nullptr;
     const gl64_t (*cosetPows)[NTT_WIN_SIZE] = nullptr;
     uint32_t lgBlowup = 0;
+    size_t cosetStride = 0;
 
     void step(int iterations)
     {
@@ -1400,16 +1308,16 @@ struct NttRun {
             const bool fuse = (cosetSrc != nullptr) && (stage == 0);
             if (num_blocks < (uint32_t)Z) {
                 if (fuse)
-                    nttDitColMajorKernel<1, false, true><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup);
+                    nttDitColMajorKernel<1, false, true><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup, cosetStride);
                 else
-                    nttDitColMajorKernel<1><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0);
+                    nttDitColMajorKernel<1><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             } else if (stage == 0 || lg < 12) {
                 if (fuse)
-                    nttDitColMajorKernel<4, false, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup);
+                    nttDitColMajorKernel<4, false, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup, cosetStride);
                 else
-                    nttDitColMajorKernel<4><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0);
+                    nttDitColMajorKernel<4><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             } else {
-                nttDitColMajorKernel<4, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0);
+                nttDitColMajorKernel<4, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             }
             stage += iterations;
         } else {
@@ -1472,14 +1380,14 @@ uint32_t nttL2ChunkCols(size_t colBytes, uint64_t nCols)
 
 } // anonymous namespace
 
-// ColMajor LDE: iNTT(N) -> coset spread -> NTT(NExt) per column. Columns are
-// processed in L2-sized chunks with column-batched kernel launches; when the
-// chunk degenerates to a single column (large domains, already occupancy-
-// saturated) the driver switches to the cheaper scratch-staged serial flow,
-// which avoids the batched flow's extra tail->scratch staging copy.
+// ColMajor LDE: iNTT(N) -> coset spread -> NTT(NExt), over L2-sized column chunks.
+// Each chunk stages its iNTT compactly (stride N) and fuses the coset spread into the forward
+// transform's first launch, so the blowup-1 zeros per element are never materialized -- at
+// blowup 8 that padding was 7/8 of the widest array in the LDE.
 void NTTGoldilocksGPU::ldeColMajor(gl64_t *d_dst_, gl64_t *d_src_,
                                    uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
-                                   cudaStream_t stream, bool preserve_src, gl64_t *preserve_scratch)
+                                   cudaStream_t stream, bool preserve_src, gl64_t *preserve_scratch,
+                                   size_t scratch_elems)
 {
     if (nCols == 0 || nBits == 0)
         return;
@@ -1492,127 +1400,71 @@ void NTTGoldilocksGPU::ldeColMajor(gl64_t *d_dst_, gl64_t *d_src_,
     size_t Next = (size_t)1 << nBitsExt;
     uint32_t lg_blowup = (uint32_t)(nBitsExt - nBits);
 
-    // Queried per call: cudaGetDevice is a thread-local read and the attribute lookup
-    // costs ~1us -- noise next to a millisecond-scale LDE, and it keeps this free of
-    // shared mutable state.
-    int dev = 0, l2Bytes = 0;
-    CHECKCUDAERR(cudaGetDevice(&dev));
-    if (cudaDeviceGetAttribute(&l2Bytes, cudaDevAttrL2CacheSize, dev) != cudaSuccess || l2Bytes <= 0)
-        l2Bytes = 32 << 20;
-    uint32_t chunk = (uint32_t)(((size_t)l2Bytes * 3 / 5) / (Next * sizeof(gl64_t)));
-    if (chunk > nCols) chunk = (uint32_t)nCols;
+    // A chunk stages its iNTT into chunk*N of scratch, so a caller-supplied region can only
+    // narrow the chunk; a caller that states no capacity gets a right-sized allocation below.
+    uint32_t chunk = nttL2ChunkCols(Next * sizeof(gl64_t), nCols);
+    const bool caller_scratch = preserve_scratch != nullptr && scratch_elems >= N;
+    if (caller_scratch)
+        chunk = (uint32_t)std::min<size_t>(chunk, scratch_elems / N);
 
-    // src may alias dst (constPolsAliasTree). Both flows then write columns high-to-low so a
-    // column's output never lands on a source not yet read. 
+    // src may alias dst (constPolsAliasTree); chunks then descend so a chunk's writes stay
+    // above the sources still to be read.
     const bool overlaps = d_src_ < d_dst_ + (size_t)nCols * Next && d_dst_ < d_src_ + (size_t)nCols * N;
     if (overlaps && d_src_ != d_dst_) {
         printf("[NTT] ERROR: ldeColMajor overlapping src/dst require equal bases (src-dst = %lld elements)\n",
                (long long)(d_src_ - d_dst_));
         abort();
     }
-    // An aliased src lives inside dst: the spread necessarily destroys it, so preserve_src cannot
-    // be honored (callers pass preserve_src=false for aliased airs -- see extendAndMerkelizeFixed).
+    // An aliased src lives inside dst, so the extension necessarily destroys it.
     if (overlaps && preserve_src) {
         printf("[NTT] ERROR: ldeColMajor cannot preserve a src that aliases dst\n");
         abort();
     }
 
-    // Scratch is only for the SERIAL flow (preserve src, or an aliased column that would
-    // otherwise overwrite its own input). The batched flow spreads in place via the
-    // column-front staging + descending windows below -- zero extra memory.
-    gl64_t *scratch = preserve_scratch;
+    // Scratch is only needed by chunks that stage (see stage below); it holds one chunk's
+    // compact iNTT result.
+    const size_t need = (size_t)chunk * N;
+    gl64_t *scratch = caller_scratch ? preserve_scratch : nullptr;
     bool own_scratch = false;
-    if (scratch == nullptr && (preserve_src || overlaps) && chunk < 2) {
-        CHECKCUDAERR(cudaMallocAsync(&scratch, N * sizeof(gl64_t), stream));
-        own_scratch = true;
+    if (preserve_src || overlaps) {
+        // The fused DIT reads scratch while writing dst, and the staging copy reads src while
+        // writing scratch, so scratch must overlap neither. Callers pass a window of a shared
+        // arena that is disjoint only by layout arithmetic -- check rather than trust it.
+        if (scratch != nullptr &&
+            ((scratch < d_dst_ + (size_t)nCols * Next && d_dst_ < scratch + need) ||
+             (scratch < d_src_ + (size_t)nCols * N    && d_src_ < scratch + need))) {
+            printf("[NTT] ERROR: ldeColMajor scratch (%zu elements) overlaps src or dst\n", need);
+            abort();
+        }
+        if (scratch == nullptr) {
+            CHECKCUDAERR(cudaMallocAsync(&scratch, need * sizeof(gl64_t), stream));
+            own_scratch = true;
+        }
     }
 
-    uint32_t sthr = 256;
+    for (uint32_t c0 = (uint32_t)nCols; c0 > 0; ) {
+        uint32_t nc = std::min(chunk, c0);
+        c0 -= nc;
+        gl64_t *dchunk = d_dst_ + (size_t)c0 * Next;
+        gl64_t *csrc = d_src_ + (size_t)c0 * N;
 
-    if (chunk >= 2) {
-        // batched: copy chunk cols to the destination-column tails -> batched DIF-iNTT
-        // -> per-column spread (tail -> scratch -> dest column) -> batched DIT-NTT.
-        // Chunks descend so a chunk's writes stay above the sources still to be read. Only the
-        // tail copy touches src, so the transforms stay batched under aliasing.
-        uint32_t nChunks = (uint32_t)((nCols + chunk - 1) / chunk);
-        for (uint32_t k = nChunks; k-- > 0; ) {
-            uint32_t c0 = k * chunk;
-            uint32_t nc = (c0 + chunk <= nCols) ? chunk : (uint32_t)(nCols - c0);
-            gl64_t *dchunk = d_dst_ + (size_t)c0 * Next;
-
-            uint32_t cblk = (uint32_t)std::min<size_t>((N + 255) / 256, 4096);
-            if (overlaps) {
-                // Per column, descending: one gridDim.y launch copies all columns at once, and at
-                // blowup 2 the tail of column c IS source column 2c+1 -- a race with itself.
-                for (uint32_t c = nc; c-- > 0; ) {
-                    nttCopyToDestinationTailsKernel<<<dim3(cblk, 1), 256, 0, stream>>>(
-                        dchunk + (size_t)c * Next, d_src_ + (size_t)(c0 + c) * N, (uint32_t)nBits, Next);
-                }
-            } else {
-                nttCopyToDestinationTailsKernel<<<dim3(cblk, nc), 256, 0, stream>>>(dchunk, d_src_ + (size_t)c0 * N,
-                                                                       (uint32_t)nBits, Next);
-            }
-            CHECKCUDAERR(cudaGetLastError());
-
-            NttRun{dchunk + (Next - N), Next, nc, (int)nBits, true, ti, stream, false}.run();
-
-            // Stage every column's iNTT tail into the (dead) column FRONT with one
-            // in-buffer strided copy (rows disjoint since blowup >= 2), then spread
-            // the whole chunk with descending write-safe windows: window
-            // [hi/blowup, hi) writes [hi, hi*blowup), never touching an unread
-            // front. Zero scratch; replaces nc serialized memcpy+launch pairs
-            // (measured 7% SM issue / 49% memory-latency stalls on those).
-            CHECKCUDAERR(cudaMemcpy2DAsync(dchunk, Next * sizeof(gl64_t),
-                                           dchunk + (Next - N), Next * sizeof(gl64_t),
-                                           N * sizeof(gl64_t), nc,
-                                           cudaMemcpyDeviceToDevice, stream));
-            {
-                uint32_t hi = (uint32_t)N;
-                while (hi > sthr) {
-                    uint32_t lo = hi >> lg_blowup;
-                    uint32_t wblk = (hi - lo + sthr - 1) / sthr;
-                    nttCosetSpreadKernel<<<dim3(wblk, nc), sthr, 0, stream>>>(dchunk, dchunk,
-                        (const gl64_t(*)[NTT_WIN_SIZE])tf.cosetPows, (uint32_t)nBits, lg_blowup,
-                        lo, hi, Next, Next);
-                    hi = lo;
-                }
-                nttCosetSpreadHeadKernel<<<dim3(1, nc), sthr, 0, stream>>>(dchunk,
-                    (const gl64_t(*)[NTT_WIN_SIZE])tf.cosetPows, (uint32_t)nBits, lg_blowup,
-                    hi, Next);
-            }
-            CHECKCUDAERR(cudaGetLastError());
-
-            NttRun{dchunk, Next, nc, (int)nBitsExt, false, tf, stream, true}.run();
+        // Stage when src must survive, or when this chunk's output covers its own input -- the
+        // fused first launch would then read the addresses it is writing, which ordering cannot
+        // fix. Under aliasing only the lowest chunks are affected; the rest run in place.
+        if (preserve_src || (overlaps && (size_t)c0 * Next < (size_t)(c0 + nc) * N)) {
+            CHECKCUDAERR(cudaMemcpyAsync(scratch, csrc, (size_t)nc * N * sizeof(gl64_t),
+                                         cudaMemcpyDeviceToDevice, stream));
+            csrc = scratch;
         }
-    } else {
-        // serial per column: iNTT (on scratch, or in place on src when the caller
-        // allows trashing it) -> DIT-NTT on the destination column with the coset
-        // spread fused into its first launch.
 
-        for (uint32_t c = nCols; c-- > 0; ) {
-            gl64_t *srcCol = d_src_ + (size_t)c * N;
-            gl64_t *dstCol = d_dst_ + (size_t)c * Next;
-            gl64_t *inttCol = srcCol;
-            // Stage when a column's output covers its own input (c = 0 under equal
-            // bases): the fused stage-0 load reads inttCol while the same launch
-            // writes dstCol, the same addresses. Ordering cannot fix that, so the
-            // iNTT result is bounced through scratch; all other columns run in place.
-            bool self_overlap = srcCol < dstCol + Next && dstCol < srcCol + N;
-            if (preserve_src || self_overlap) {
-                CHECKCUDAERR(cudaMemcpyAsync(scratch, srcCol, N * sizeof(gl64_t),
-                                             cudaMemcpyDeviceToDevice, stream));
-                inttCol = scratch;
-            }
-            NttRun{inttCol, N, 1, (int)nBits, true, ti, stream, false}.run();
-            // Coset spread fused into the NTT's first launch: it reads the compact
-            // iNTT result (inttCol, disjoint from dstCol -- self_overlap staged it
-            // through scratch above) and materializes the spread values on the fly.
-            NttRun fwd{dstCol, Next, 1, (int)nBitsExt, false, tf, stream, true};
-            fwd.cosetSrc = inttCol;
-            fwd.cosetPows = (const gl64_t(*)[NTT_WIN_SIZE])tf.cosetPows;
-            fwd.lgBlowup = lg_blowup;
-            fwd.run();
-        }
+        NttRun{csrc, N, nc, (int)nBits, true, ti, stream, false}.run();
+
+        NttRun fwd{dchunk, Next, nc, (int)nBitsExt, false, tf, stream, true};
+        fwd.cosetSrc = csrc;
+        fwd.cosetPows = (const gl64_t(*)[NTT_WIN_SIZE])tf.cosetPows;
+        fwd.lgBlowup = lg_blowup;
+        fwd.cosetStride = N;
+        fwd.run();
     }
 
     if (own_scratch)
@@ -1757,7 +1609,7 @@ void NTTGoldilocksGPU::LDE(gl64_t* d_dst, uint64_t offset_dst,
                            gl64_t* d_src, uint64_t offset_src,
                            uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
                            TimerGPU &timer, cudaStream_t stream, bool preserve_src,
-                           gl64_t* preserve_scratch){
+                           gl64_t* preserve_scratch, size_t scratch_elems){
 
     if (nCols == 0 || nBits == 0)
     {
@@ -1773,7 +1625,7 @@ void NTTGoldilocksGPU::LDE(gl64_t* d_dst, uint64_t offset_dst,
     gl64_t *d_dst_ = &d_dst[offset_dst];
     gl64_t *d_src_ = &d_src[offset_src];
 
-    ldeColMajor(d_dst_, d_src_, nBits, nBitsExt, nCols, stream, preserve_src, preserve_scratch);
+    ldeColMajor(d_dst_, d_src_, nBits, nBitsExt, nCols, stream, preserve_src, preserve_scratch, scratch_elems);
     TimerStopCategoryGPU(timer, NTT);
 }
 

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
@@ -1380,10 +1380,9 @@ uint32_t nttL2ChunkCols(size_t colBytes, uint64_t nCols)
 
 } // anonymous namespace
 
-// ColMajor LDE: iNTT(N) -> coset spread -> NTT(NExt), over L2-sized column chunks.
-// Each chunk stages its iNTT compactly (stride N) and fuses the coset spread into the forward
-// transform's first launch, so the blowup-1 zeros per element are never materialized -- at
-// blowup 8 that padding was 7/8 of the widest array in the LDE.
+// ColMajor LDE: iNTT(N) -> coset spread -> NTT(NExt), over L2-sized column chunks. Each chunk
+// stages its iNTT compactly (stride N) and fuses the coset spread into the forward transform's
+// first launch, so the blowup-1 zeros per element are never materialized.
 void NTTGoldilocksGPU::ldeColMajor(gl64_t *d_dst_, gl64_t *d_src_,
                                    uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
                                    cudaStream_t stream, bool preserve_src, gl64_t *preserve_scratch,
@@ -1400,16 +1399,19 @@ void NTTGoldilocksGPU::ldeColMajor(gl64_t *d_dst_, gl64_t *d_src_,
     size_t Next = (size_t)1 << nBitsExt;
     uint32_t lg_blowup = (uint32_t)(nBitsExt - nBits);
 
-    // A chunk stages its iNTT into chunk*N of scratch, so a caller-supplied region can only
-    // narrow the chunk; a caller that states no capacity gets a right-sized allocation below.
     uint32_t chunk = nttL2ChunkCols(Next * sizeof(gl64_t), nCols);
-    const bool caller_scratch = preserve_scratch != nullptr && scratch_elems >= N;
-    if (caller_scratch)
-        chunk = (uint32_t)std::min<size_t>(chunk, scratch_elems / N);
+    const uint32_t blowup = 1u << lg_blowup;
+
+    // Integer addresses: relational comparison of pointers into different allocations is
+    // unspecified in C++, and these regions are separate allocations in general.
+    auto rangesOverlap = [](const gl64_t *a, size_t aElems, const gl64_t *b, size_t bElems) {
+        uintptr_t a0 = (uintptr_t)a, b0 = (uintptr_t)b;
+        return a0 < b0 + bElems * sizeof(gl64_t) && b0 < a0 + aElems * sizeof(gl64_t);
+    };
 
     // src may alias dst (constPolsAliasTree); chunks then descend so a chunk's writes stay
     // above the sources still to be read.
-    const bool overlaps = d_src_ < d_dst_ + (size_t)nCols * Next && d_dst_ < d_src_ + (size_t)nCols * N;
+    const bool overlaps = rangesOverlap(d_src_, (size_t)nCols * N, d_dst_, (size_t)nCols * Next);
     if (overlaps && d_src_ != d_dst_) {
         printf("[NTT] ERROR: ldeColMajor overlapping src/dst require equal bases (src-dst = %lld elements)\n",
                (long long)(d_src_ - d_dst_));
@@ -1421,37 +1423,52 @@ void NTTGoldilocksGPU::ldeColMajor(gl64_t *d_dst_, gl64_t *d_src_,
         abort();
     }
 
-    // Scratch is only needed by chunks that stage (see stage below); it holds one chunk's
-    // compact iNTT result.
-    const size_t need = (size_t)chunk * N;
-    gl64_t *scratch = caller_scratch ? preserve_scratch : nullptr;
+    // Scratch holds a staged chunk's compact iNTT result. Narrowing the batch to fit the
+    // caller's region beats allocating one: the prover sizes its arenas to the last byte.
+    gl64_t *scratch = (preserve_scratch != nullptr && scratch_elems >= N) ? preserve_scratch : nullptr;
     bool own_scratch = false;
+    uint32_t stage_cols = 1;
     if (preserve_src || overlaps) {
-        // The fused DIT reads scratch while writing dst, and the staging copy reads src while
-        // writing scratch, so scratch must overlap neither. Callers pass a window of a shared
-        // arena that is disjoint only by layout arithmetic -- check rather than trust it.
-        if (scratch != nullptr &&
-            ((scratch < d_dst_ + (size_t)nCols * Next && d_dst_ < scratch + need) ||
-             (scratch < d_src_ + (size_t)nCols * N    && d_src_ < scratch + need))) {
-            printf("[NTT] ERROR: ldeColMajor scratch (%zu elements) overlaps src or dst\n", need);
-            abort();
-        }
+        size_t cap = scratch != nullptr ? scratch_elems : (size_t)chunk * N;
         if (scratch == nullptr) {
-            CHECKCUDAERR(cudaMallocAsync(&scratch, need * sizeof(gl64_t), stream));
+            static bool warned = false;   // on a prover path this allocates against a full arena
+            if (!warned) {
+                warned = true;
+                printf("[NTT] WARNING: ldeColMajor staging without caller scratch\n");
+            }
+            CHECKCUDAERR(cudaMallocAsync(&scratch, cap * sizeof(gl64_t), stream));
             own_scratch = true;
+        }
+        // preserve_src stages every chunk, so the region caps the width; under aliasing the loop
+        // tapers to a single staged column, so N suffices.
+        if (preserve_src) stage_cols = (uint32_t)std::min<size_t>(chunk, cap / N);
+        const size_t staged = (size_t)stage_cols * N;
+        // The DIT reads scratch while writing dst and the copy reads src, so it must overlap
+        // neither -- and that holds only by arena-layout arithmetic.
+        if (rangesOverlap(scratch, staged, d_dst_, (size_t)nCols * Next) ||
+            rangesOverlap(scratch, staged, d_src_, (size_t)nCols * N)) {
+            printf("[NTT] ERROR: ldeColMajor scratch (%zu elements) overlaps src or dst\n", staged);
+            abort();
         }
     }
 
-    for (uint32_t c0 = (uint32_t)nCols; c0 > 0; ) {
-        uint32_t nc = std::min(chunk, c0);
-        c0 -= nc;
+    for (uint32_t hi = (uint32_t)nCols; hi > 0; ) {
+        uint32_t nc = std::min(chunk, hi);
+        if (preserve_src) {
+            nc = std::min(nc, stage_cols);
+        } else if (overlaps) {
+            // A chunk's writes cover src columns [c0*blowup, (c0+nc)*blowup), already consumed
+            // once c0*(blowup-1) >= nc; take the widest nc that holds, else the last column.
+            uint32_t safe = (uint32_t)((uint64_t)hi * (blowup - 1) / blowup);
+            if (safe < nc) nc = safe != 0 ? safe : 1;
+        }
+        uint32_t c0 = hi - nc;
+        hi = c0;
         gl64_t *dchunk = d_dst_ + (size_t)c0 * Next;
         gl64_t *csrc = d_src_ + (size_t)c0 * N;
 
-        // Stage when src must survive, or when this chunk's output covers its own input -- the
-        // fused first launch would then read the addresses it is writing, which ordering cannot
-        // fix. Under aliasing only the lowest chunks are affected; the rest run in place.
-        if (preserve_src || (overlaps && (size_t)c0 * Next < (size_t)(c0 + nc) * N)) {
+        // Stage when src must survive, or when a chunk's output covers its own input.
+        if (preserve_src || (overlaps && (uint64_t)c0 * (blowup - 1) < nc)) {
             CHECKCUDAERR(cudaMemcpyAsync(scratch, csrc, (size_t)nc * N * sizeof(gl64_t),
                                          cudaMemcpyDeviceToDevice, stream));
             csrc = scratch;

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cuh
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cuh
@@ -138,11 +138,13 @@ public:
     // LDE runs the in-house ColMajor engine (ldeColMajor). The backends are also exposed directly so
     // tests/benches can run a given size through any path and compare (identical logical output on
     // each backend's own storage layout -- see test_ntt_gpu equivalence test).
+    // preserve_scratch/scratch_elems: scratch the LDE may trash, and its capacity in elements
+    // (0 = unstated, and the LDE allocates its own). A bigger region lets it batch wider.
     void LDE(gl64_t* d_dst, uint64_t offset_dst,
              gl64_t* d_src, uint64_t offset_src,
              uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
              TimerGPU &timer, cudaStream_t stream, bool preserve_src = false,
-             gl64_t* preserve_scratch = nullptr);
+             gl64_t* preserve_scratch = nullptr, size_t scratch_elems = 0);
 
     // legacy tiled backend: ColMajorTiled in/out, pure kernels (graph-capturable). d_src_/d_dst_ disjoint.
     void ldeTiled(gl64_t* d_dst_, gl64_t* d_src_, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
@@ -150,7 +152,8 @@ public:
 
     // In-house ColMajor LDE
     void ldeColMajor(gl64_t* d_dst_, gl64_t* d_src_, uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,
-                 cudaStream_t stream, bool preserve_src = false, gl64_t* preserve_scratch = nullptr);
+                 cudaStream_t stream, bool preserve_src = false, gl64_t* preserve_scratch = nullptr,
+                 size_t scratch_elems = 0);
 
     // computeQ runs the in-house ColMajor engine (computeQColMajor). Backends exposed directly for
     // tests/benches.

--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cuh
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cuh
@@ -140,6 +140,9 @@ public:
     // each backend's own storage layout -- see test_ntt_gpu equivalence test).
     // preserve_scratch/scratch_elems: scratch the LDE may trash, and its capacity in elements
     // (0 = unstated, and the LDE allocates its own). A bigger region lets it batch wider.
+    // preserve_src=false means d_src IS OVERWRITTEN: the iNTT runs in place on src (coefficients),
+    // so callers that read src again afterwards must pass preserve_src=true. Do not rely on the old
+    // batched-flow behaviour where src happened to survive.
     void LDE(gl64_t* d_dst, uint64_t offset_dst,
              gl64_t* d_src, uint64_t offset_src,
              uint64_t nBits, uint64_t nBitsExt, uint64_t nCols,

--- a/pil2-stark/src/goldilocks/src/stream_commit.cu
+++ b/pil2-stark/src/goldilocks/src/stream_commit.cu
@@ -450,7 +450,7 @@ int64_t streamCommitPacked(gl64_t *slotBase, const StreamCommitDims &dims,
         CHECKCUDAERR(cudaGetLastError());
         // In-place spread: src == dst base (equal-base aliasing path);
         // preserve_src must be false under aliasing.
-        ntt.ldeColMajor(d_rate, d_rate, dims.nBits, dims.nBitsExt, cc, stream, false, d_scratch);
+        ntt.ldeColMajor(d_rate, d_rate, dims.nBits, dims.nBitsExt, cc, stream, false, d_scratch, N);
         if (b3)
             scBlake3AbsorbChunkKernel<<<ablk, SC_TPB, 0, stream>>>(
                 d_rate, d_cap, cc, k == 0, k == nChunks - 1, NExt);

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -365,7 +365,9 @@ void extendAndMerkelize_inplace(uint64_t step, SetupCtx& setupCtx, MerkleTreeGL*
         {
             // Stage label carries the commit step (cm1, cm2, ...) so each is distinguishable in the log.
             PROOFMAN_SUMCHECK("proof_before_lde_cm%u", src + offset_src, ((uint64_t)1 << setupCtx.starkInfo.starkStruct.nBits) * nCols, stream, (unsigned)step);
-            ntt.LDE(dst, offset_dst, src, offset_src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, timer, stream, true, (gl64_t*)pNodes);
+            // pNodes is free scratch until the merkelize below fills it; its capacity lets the
+            // LDE stage a wider column chunk.
+            ntt.LDE(dst, offset_dst, src, offset_src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, timer, stream, true, (gl64_t*)pNodes, setupCtx.starkInfo.getNumNodesMT(NExtended));
             PROOFMAN_SUMCHECK("proof_after_lde_cm%u", dst + offset_dst, (uint64_t)NExtended * nCols, stream, (unsigned)step);
             TimerStartCategoryGPU(timer, MERKLE_TREE);
             buildMerkleTreeGPU(setupCtx.starkInfo.starkStruct.merkleTreeArity, (uint64_t*)pNodes, (uint64_t*)(dst + offset_dst), nCols, NExtended, resolveLayout(setupCtx.starkInfo.starkStruct.nBits, nCols), stream);
@@ -395,7 +397,7 @@ void extendAndMerkelizeFixed(SetupCtx& setupCtx, Goldilocks::Element *d_fixedPol
     // Const sections are stored fixedLayout() (ColMajor); the Merkle build reads dst in that
     // layout. pNodes is free scratch: above the LDE's writes, filled by the merkelize below.
     TimerStartCategoryGPU(timer, NTT);
-    ntt.ldeColMajor((gl64_t *)dst, (gl64_t *)src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, stream, preserve_src, (gl64_t *)pNodes);
+    ntt.ldeColMajor((gl64_t *)dst, (gl64_t *)src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, stream, preserve_src, (gl64_t *)pNodes, setupCtx.starkInfo.getNumNodesMT(NExtended));
     TimerStopCategoryGPU(timer, NTT);
     TimerStartCategoryGPU(timer, MERKLE_TREE);
     buildMerkleTreeGPU(setupCtx.starkInfo.starkStruct.merkleTreeArity, (uint64_t*)pNodes, (uint64_t*)dst, nCols, NExtended, fixedLayout(), stream);

--- a/pil2-stark/src/starkpil/starks_gpu_bn128.cu
+++ b/pil2-stark/src/starkpil/starks_gpu_bn128.cu
@@ -286,7 +286,10 @@ void extendAndMerkelize_bn128_gpu(uint64_t step, SetupCtx& setupCtx, MerkleTreeB
     if (nCols > 0)
     {
         NTTGoldilocksGPU ntt;
-        ntt.LDE(dst, offset_dst, src, offset_src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, timer, stream);
+        // preserve_src: the stage src (N domain) is read again by the stage-2 witness/im-pols expressions and must survive.
+        // The tree nodes are only written by merkletreeTiles after the LDE, so they serve as the staging scratch.
+        size_t scratch_elems = (size_t)tree_size * sizeof(PoseidonBN128GPU::FrElement) / sizeof(gl64_t);
+        ntt.LDE(dst, offset_dst, src, offset_src, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, nCols, timer, stream, /*preserve_src=*/true, (gl64_t*)pNodes, scratch_elems);
         TimerStartCategoryGPU(timer, MERKLE_TREE);
         PoseidonBN128GPU::merkletreeTiles(pNodes, (uint64_t*)pSource, nCols, NExtended, setupCtx.starkInfo.starkStruct.merkleTreeArity, setupCtx.starkInfo.starkStruct.merkleTreeCustom, stream);
         TimerStopCategoryGPU(timer, MERKLE_TREE);


### PR DESCRIPTION
The batched LDE built the zero-padded coefficient array in memory before the forward NTT — one real value plus `blowup-1` zeros per coefficient, all of which the first butterfly pass then read straight back. At blowup 4 that padding is three quarters of the widest array in the LDE; at blowup 8, seven eighths.

This fuses the coset spread into the forward transform so the padding is never materialized. Output is **bit-identical**.

## The waste

`nttCosetSpreadKernel` wrote the padding out literally:

```cpp
size_t base = (size_t)idx << lg_blowup;
out[base] = r;                        // the one real value
gl64_t zero = gl64_t(uint64_t(0));
for (uint32_t j = 1; j < blowup; j++)
    out[base + j] = zero;             // blowup-1 zeros
```

For Blake3 (`nBits` 19 → 21) that is a 16 MB array per column of which 12 MB is zeros, written and then read again. The spread kernel alone was **6.6 ms of a 33.3 ms** NTT budget.

## Root cause: one missing stride

The serial path already avoided all of this via `nttCosetLoadVal_`, which produces the spread value on demand. The *only* thing keeping the batched path off it was a missing column offset in `nttDitColMajorKernel`:

```cpp
gl64_t *d_inout = d_base + blockIdx.y * col_stride;   // output: per column ✓
// d_csrc: no blockIdx.y offset -> correct for single-column launches only
```

Hence the old `ncols must be 1` restriction. Adding `csrc_stride` and staging each chunk's iNTT into compact (stride `N`) scratch makes the fused load work for a whole batch of columns.

## What changed

| before (5 steps per chunk) | after (3 steps) |
| --- | --- |
| copy `src` → destination column **tails** (stride `N_ext`) | copy `src` → compact scratch (stride `N`) |
| iNTT in the tails | iNTT on the scratch |
| `memcpy2D` tail → column front | — |
| spread: 6 window kernels + head kernel | *fused into the forward NTT's first launch* |
| forward NTT (reads the zeros back) | forward NTT |

Removed: `nttCosetSpreadKernel`, `nttCosetSpreadHeadKernel`, `nttCopyToDestinationTailsKernel`, and the tail→front `cudaMemcpy2DAsync`. Staging at stride `N` instead of into the destination tails at stride `N_ext` also keeps the iNTT's working set to `chunk*N`, so it stays L2-resident.

## Simplification

With the spread fused, the batched and serial flows performed the *same three steps*, so the two branches collapse into a single chunk loop where serial is just `nc == 1`. The staging decision becomes one per-chunk test:

```cpp
if (preserve_src || (overlaps && (size_t)c0 * Next < (size_t)(c0 + nc) * N))
```

At `nc == 1` this reduces to `c0 == 0` — exactly the old per-column `self_overlap` — and it generalizes: under `src`/`dst` aliasing only the lowest chunks now stage, instead of every chunk. The L2 chunk width comes from the existing `nttL2ChunkCols` helper rather than a re-implementation of it.

Net **+82 / −225** lines.

## Safety

The fused load reads scratch while writing the destination column, so scratch must be disjoint from both `src` and `dst`. Two things guard that:

- `LDE`/`ldeColMajor` gain `scratch_elems`, so a caller declares its scratch capacity and the chunk width is clamped to what actually fits. At the call sites the bound is `StarkInfo::getNumNodesMT` — the same function that *sizes* that region in `setMapOffsets`, so the bound cannot drift from the layout.
- The disjointness itself holds only by arena-layout arithmetic (`mt2` ends at or below `cm2(false)`), so it is **checked at runtime** rather than assumed.

## Measurements (RTX 5090)

`prove-air`, blowup 4 — this is where the proof is the critical path:

| AIR | NTT before | NTT after | Δ | whole proof |
| --- | --- | --- | --- | --- |
| Blake3 (`nBits` 19→21) | 33.3 ms | **24.3 ms** | **−27%** | 88.5 → **79.5 ms** (−10%) |
| Blake2b (blowup 2) | 3.4 ms | 3.35 ms | flat | — |
| Sha2 (blowup 2) | 2.9 ms | 2.8 ms | flat | — |

ZisK ethproof (`--gpu --asm`), two runs per side, binaries verified by symbol:

| metric | baseline (min/max/mean) | after (min/max/mean) | Δ mean |
| --- | --- | --- | --- |
| **NTT** | 21.061 / 21.362 / **21.212 s** | 19.259 / 19.621 / **19.440 s** | **−8.4%** |
| └ Keccakf | 4.620 / 4.972 / 4.796 s | 3.322 / 3.359 / 3.341 s | **−30%** |
| GPU total | 74.632 / 75.177 / 74.905 s | 73.076 / 75.042 / 74.059 s | −1.1% |
| wall clock | 37.942 / 38.657 / 38.299 s | 37.482 / 38.051 / 37.767 s | −1.4% |

The NTT ranges do not overlap, with ~0.3 s spread inside each group.

**ZisK wall clock is essentially unchanged, and that is expected**: its proving window is witness-generation bound — `CALCULATING_WITNESS` covers 27.9 s of the 29.6 s `GENERATING_INNER_PROOFS` window, and the phase ends only ~1.4 s after the last witness. The GPU is waiting on the CPU there, so removing GPU work cannot shorten the critical path. Categories this change cannot touch (`MERKLE_TREE`, `GRINDING`) drift by ±0.4 s run to run, which is the noise floor to keep in mind for any per-AIR number here.

Blowup-2 AIRs large enough that `chunk` degenerates to 1 (`Main`, `Mem`, `Binary`) are unaffected — they already took the fused path. `recursive2` is blowup 8 and should see the largest relative win, but it is not isolated here: recursive proofs reuse the originating instance's air id in their timer header, so they cannot be separated from the log.

## Testing

- 45/45 goldilocks GPU tests, including the LDE-vs-CPU equivalence sweep across `nBits`/`nCols` and the `src`/`dst` aliasing test — the two things this refactor could break.
- `prove-air` + verify green on Blake3, Blake2b, Sha2.
- Full ZisK ethproof pipeline, 4 runs.
