### PR TITLE
Feature/exps q optimizer

### DIFF
--- a/cli/src/commands/gen_exps.rs
+++ b/cli/src/commands/gen_exps.rs
@@ -40,6 +40,11 @@ pub struct GenExpsCmd {
     /// Requires --keep-dir. For inspection / parity checks.
     #[clap(long)]
     pub emit_only: bool,
+
+    /// Disable the Q IR optimizer (CSE, Horner→powers, scheduling); emit the
+    /// expression exactly as the setup wrote it. For A/B comparisons.
+    #[clap(long)]
+    pub no_opt: bool,
 }
 
 impl GenExpsCmd {
@@ -53,6 +58,7 @@ impl GenExpsCmd {
             stark_src: self.stark_src.clone(),
             keep_dir: self.keep_dir.clone(),
             dry_run: self.emit_only,
+            optimize: !self.no_opt,
         };
         let summary = generate_all(&self.proving_key, &cfg)?;
         tracing::info!(

--- a/setup/exps-codegen/src/autotune.rs
+++ b/setup/exps-codegen/src/autotune.rs
@@ -18,13 +18,38 @@ const BIG_START_CHUNK: usize = 250; // autotuner start chunk for AIRs with > BIG
 /// Max STACK (spill) bytes across an object's per-arch entries. 0 = no spill;
 /// -1 = cuobjdump could not be run (the caller bails with actionable guidance).
 fn max_stack(obj: &Path) -> i64 {
-    let out = match std::process::Command::new("cuobjdump").arg("-res-usage").arg(obj).output() {
-        Ok(o) => o,
-        Err(_) => return -1,
-    };
+    let out =
+        match std::process::Command::new(crate::toolchain::cuda_bin("cuobjdump")).arg("-res-usage").arg(obj).output() {
+            Ok(o) => o,
+            Err(_) => return -1,
+        };
     let text = String::from_utf8_lossy(&out.stdout);
-    let re = Regex::new(r"STACK:(\d+)").unwrap();
-    re.captures_iter(&text).filter_map(|c| c[1].parse::<i64>().ok()).max().unwrap_or(0)
+    // Per function: the once-per-launch table kernel (`*_pow`, one thread runs
+    // the hoisted-invariants program straight-line) may spill freely; its
+    // stack must not gate the per-row chunk kernels -- it made the autotuner
+    // reject Main at every chunk size ("still spills at CHUNK_MIN").
+    // names are mangled: `..._powPK11StepsParams...` (table kernel) vs
+    // `..._c12PK11StepsParams...` (chunk kernels) / `..._kernelPK...`
+    let re_fn = Regex::new(r"Function\s+(\S+?):\s*$").unwrap();
+    let re_pow = Regex::new(r"_pow(?:PK|P\d|\(|:|\s|$)").unwrap();
+    let re_st = Regex::new(r"STACK:(\d+)").unwrap();
+    let mut best = 0i64;
+    let mut skip = false;
+    for line in text.lines() {
+        if let Some(c) = re_fn.captures(line) {
+            skip = re_pow.is_match(&c[1]);
+            continue;
+        }
+        if skip {
+            continue;
+        }
+        if let Some(c) = re_st.captures(line) {
+            if let Ok(v) = c[1].parse::<i64>() {
+                best = best.max(v);
+            }
+        }
+    }
+    best
 }
 
 /// Returns the largest chunk size (halving from the start size) that compiles
@@ -52,6 +77,7 @@ fn tune_inner(
     out_dir: &Path,
 ) -> anyhow::Result<Option<usize>> {
     let mut chunk = n_ops.min(if n_ops > BIG_OPS { BIG_START_CHUNK } else { CHUNK_MAX });
+    let mut last_spill: Option<usize> = None;
     while chunk >= CHUNK_MIN {
         let plan = plan_chunks(ir, chunk, sym)?;
         let files = emit_air(ir, &plan, sym);
@@ -84,13 +110,86 @@ fn tune_inner(
         }
         let st = stacks.into_iter().max().unwrap_or(0);
         eprintln!("  [tune] {sym} chunk={chunk} ({} TUs) -> STACK={st}", files.len());
-        if st == 0 {
-            for obj in &objs {
+        // A single-kernel AIR (chunk covers every op) may keep a few bytes of
+        // local memory: splitting it in two costs a launch plus cross-chunk
+        // slots, which measured worse (VirtualTableZisk1: 8-byte spill at 280
+        // ops -> 2 chunks -> +30% kernel time). Chunked kernels stay at zero.
+        const SINGLE_SPILL_TOL: i64 = 32;
+        if st == 0 || (chunk >= n_ops && st <= SINGLE_SPILL_TOL) {
+            // Halving overshoots: a 24-byte spill at 512 used to cost Poseidon half
+            // its chunk (and doubled its cross-chunk slots). Bisect upward between
+            // this clean size and the last spilling one; keep the largest clean.
+            let (best_chunk, best_objs) = refine_up(tc, ir, sym, probe, chunk, last_spill, objs)?;
+            for obj in &best_objs {
                 let _ = std::fs::copy(obj, out_dir.join(obj.file_name().unwrap()));
             }
-            return Ok(Some(chunk));
+            return Ok(Some(best_chunk));
         }
+        last_spill = Some(chunk);
         chunk /= 2;
     }
     Ok(None)
+}
+
+/// Bisection between a clean chunk `lo` and a spilling `hi` (None = `lo` was the
+/// first probe, nothing above it to try). Returns the largest clean chunk found
+/// and its compiled objects (the probe dir is shared, so objects are re-emitted
+/// for the winner when a larger probe overwrote them).
+fn refine_up(
+    tc: &Toolchain,
+    ir: &Ir,
+    sym: &str,
+    probe: &Path,
+    lo: usize,
+    hi: Option<usize>,
+    lo_objs: Vec<PathBuf>,
+) -> anyhow::Result<(usize, Vec<PathBuf>)> {
+    let compile_at = |chunk: usize| -> anyhow::Result<(Option<i64>, Vec<PathBuf>)> {
+        let plan = plan_chunks(ir, chunk, sym)?;
+        let files = emit_air(ir, &plan, sym);
+        let objs: Vec<PathBuf> =
+            files.iter().map(|(fname, _)| probe.join(fname.strip_suffix(".cu").unwrap().to_string() + ".o")).collect();
+        for (fname, text) in &files {
+            std::fs::write(probe.join(fname), text)?;
+        }
+        let results: Vec<(bool, String)> = files
+            .par_iter()
+            .zip(&objs)
+            .map(|((fname, _), obj)| tc.compile_tu(&probe.join(fname), obj, Some(probe)))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        if results.iter().any(|(ok, _)| !ok) {
+            return Ok((None, objs));
+        }
+        let stacks: Vec<i64> = objs.iter().map(|o| max_stack(o)).collect();
+        if stacks.iter().any(|&s| s < 0) {
+            return Ok((None, objs));
+        }
+        Ok((Some(stacks.into_iter().max().unwrap_or(0)), objs))
+    };
+    let Some(mut hi) = hi else {
+        return Ok((lo, lo_objs)); // first probe was clean: nothing above it to try
+    };
+    let mut lo = lo;
+    // stop when the bracket is within ~1/8 of lo: the slot/grid payoff below that is noise
+    while hi - lo > (lo / 8).max(8) {
+        let mid = (lo + hi) / 2;
+        let (st, _) = compile_at(mid)?;
+        match st {
+            Some(0) => {
+                eprintln!("  [tune] {sym} chunk={mid} (refine) -> STACK=0");
+                lo = mid;
+            }
+            Some(st) => {
+                eprintln!("  [tune] {sym} chunk={mid} (refine) -> STACK={st}");
+                hi = mid;
+            }
+            None => {
+                hi = mid;
+            }
+        }
+    }
+    // re-emit the winner so the returned objects match `lo` (probes overwrote them)
+    let (_, objs) = compile_at(lo)?;
+    let _ = lo_objs;
+    Ok((lo, objs))
 }

--- a/setup/exps-codegen/src/autotune.rs
+++ b/setup/exps-codegen/src/autotune.rs
@@ -2,6 +2,7 @@
 //! with zero register spill (STACK=0 per `cuobjdump -res-usage`), bisecting down
 //! from the start size.
 
+use anyhow::Context;
 use crate::emit::emit_air;
 use crate::ir::{plan_chunks, Ir};
 use crate::toolchain::Toolchain;
@@ -121,7 +122,9 @@ fn tune_inner(
             // this clean size and the last spilling one; keep the largest clean.
             let (best_chunk, best_objs) = refine_up(tc, ir, sym, probe, chunk, last_spill, objs)?;
             for obj in &best_objs {
-                let _ = std::fs::copy(obj, out_dir.join(obj.file_name().unwrap()));
+                let dest = out_dir.join(obj.file_name().unwrap());
+                std::fs::copy(obj, &dest)
+                    .with_context(|| format!("staging tuned object {} -> {}", obj.display(), dest.display()))?;
             }
             return Ok(Some(best_chunk));
         }
@@ -184,12 +187,12 @@ fn refine_up(
                 hi = mid;
             }
             None => {
+                eprintln!("  [tune] {sym} chunk={mid} (refine) -> compile failed, treated as spilling");
                 hi = mid;
             }
         }
     }
     // re-emit the winner so the returned objects match `lo` (probes overwrote them)
     let (_, objs) = compile_at(lo)?;
-    let _ = lo_objs;
     Ok((lo, objs))
 }

--- a/setup/exps-codegen/src/check.rs
+++ b/setup/exps-codegen/src/check.rs
@@ -3,6 +3,12 @@
 //! non-tmp operand (column, constant, challenge, ...) gets one random value
 //! per assignment; `Pow{base,j}` is derived from the value of `Ch{base}` so
 //! the powers table is modelled exactly as the launcher computes it.
+//!
+//! Every distinct leaf gets an independent random value, so the check catches
+//! any rewrite that is not an identity of the free field algebra; that is the
+//! only kind of rewrite the optimizer performs. A malformed IR (undefined tmp,
+//! unset table word, empty program) is reported as `Err`, never a panic: one
+//! bad AIR must not take down the whole generation run.
 
 use crate::field::{self, F3, Rng};
 use crate::ir::{Ir, Operand};
@@ -16,57 +22,55 @@ struct Env {
 }
 
 impl Env {
-    fn value(&mut self, opnd: &Operand, tmps: &HashMap<u64, F3>) -> F3 {
-        match opnd {
-            Operand::Tmp { id, .. } => *tmps.get(id).unwrap_or_else(|| panic!("use of undefined tmp t{id}")),
+    fn value(&mut self, opnd: &Operand, tmps: &HashMap<u64, F3>) -> Result<F3, String> {
+        Ok(match opnd {
+            Operand::Tmp { id, .. } => *tmps.get(id).ok_or_else(|| format!("use of undefined tmp t{id}"))?,
             Operand::Num(v) => F3::base(*v),
             Operand::Pow { base, j } => {
-                let ch = self.value(&Operand::Ch { base: *base }, tmps);
+                let ch = self.value(&Operand::Ch { base: *base }, tmps)?;
                 field::pow3(ch, *j)
             }
-            Operand::Tab { idx, .. } => *self.tab.get(idx).unwrap_or_else(|| panic!("use of unset table word {idx}")),
+            Operand::Tab { idx, .. } => *self.tab.get(idx).ok_or_else(|| format!("use of unset table word {idx}"))?,
             leaf => {
                 let dim = leaf.dim();
                 if let Some(v) = self.leaves.get(leaf) {
-                    return *v;
+                    return Ok(*v);
                 }
                 let v = self.rng.f3(dim);
                 self.leaves.insert(leaf.clone(), v);
                 v
             }
-        }
+        })
     }
 }
 
 /// Evaluate `ir` under `env`; returns the value of the explicit output store
 /// (or of the last tmp when the expression ends in one) and its dim.
-fn eval(ir: &Ir, env: &mut Env) -> (F3, u64) {
+fn eval(ir: &Ir, env: &mut Env) -> Result<(F3, u64), String> {
     // The per-launch table program first, exactly as the table kernel runs it.
     env.tab.clear();
     let mut ttmps: HashMap<u64, F3> = HashMap::new();
     for instr in &ir.tab {
-        let a = env.value(&instr.a, &ttmps);
-        let b = env.value(&instr.b, &ttmps);
+        let a = env.value(&instr.a, &ttmps)?;
+        let b = env.value(&instr.b, &ttmps)?;
         let v = field::apply(&instr.op, a, instr.a.dim(), b, instr.b.dim());
-        ttmps.insert(instr.dst_id.expect("table op without dst"), v);
+        ttmps.insert(instr.dst_id.ok_or("table op without dst")?, v);
     }
     for &(tmp, idx, _dim) in &ir.tab_out {
-        env.tab.insert(idx, ttmps[&tmp]);
+        env.tab.insert(idx, *ttmps.get(&tmp).ok_or_else(|| format!("table export of undefined tmp t{tmp}"))?);
     }
     let mut tmps: HashMap<u64, F3> = HashMap::new();
     let mut out: Option<(F3, u64)> = None;
     for instr in &ir.instrs {
-        let a = env.value(&instr.a, &tmps);
-        let b = env.value(&instr.b, &tmps);
+        let a = env.value(&instr.a, &tmps)?;
+        let b = env.value(&instr.b, &tmps)?;
         let v = field::apply(&instr.op, a, instr.a.dim(), b, instr.b.dim());
         if instr.dst_is_tmp {
-            tmps.insert(instr.dst_id.unwrap(), v);
-            out = Some((v, instr.ddim));
-        } else {
-            out = Some((v, instr.ddim));
+            tmps.insert(instr.dst_id.ok_or("tmp op without dst id")?, v);
         }
+        out = Some((v, instr.ddim));
     }
-    out.expect("empty IR")
+    out.ok_or_else(|| "empty IR".to_string())
 }
 
 /// `Ok(())` if both IRs produce identical outputs on `rounds` random
@@ -74,8 +78,8 @@ fn eval(ir: &Ir, env: &mut Env) -> (F3, u64) {
 pub fn equivalent(original: &Ir, optimized: &Ir, rounds: u64) -> Result<(), String> {
     for round in 0..rounds {
         let mut env = Env { rng: Rng(0x5eed_0000 + round), leaves: HashMap::new(), tab: HashMap::new() };
-        let (vo, do_) = eval(original, &mut env);
-        let (vn, dn) = eval(optimized, &mut env);
+        let (vo, do_) = eval(original, &mut env).map_err(|e| format!("original IR: {e}"))?;
+        let (vn, dn) = eval(optimized, &mut env).map_err(|e| format!("optimized IR: {e}"))?;
         // A base-field value stored into a dim-3 output is zero-padded, so
         // compare as F3 after normalizing dims.
         let norm = |v: F3, d: u64| if d == 1 { F3::base(v.a) } else { v };

--- a/setup/exps-codegen/src/check.rs
+++ b/setup/exps-codegen/src/check.rs
@@ -1,0 +1,87 @@
+//! Host-side equivalence check: evaluate two IRs of the same expression on
+//! identical random operand values and compare the outputs exactly. Every
+//! non-tmp operand (column, constant, challenge, ...) gets one random value
+//! per assignment; `Pow{base,j}` is derived from the value of `Ch{base}` so
+//! the powers table is modelled exactly as the launcher computes it.
+
+use crate::field::{self, F3, Rng};
+use crate::ir::{Ir, Operand};
+use std::collections::HashMap;
+
+struct Env {
+    rng: Rng,
+    leaves: HashMap<Operand, F3>,
+    /// hoisted-invariants table of the IR being evaluated (word index -> value)
+    tab: HashMap<u64, F3>,
+}
+
+impl Env {
+    fn value(&mut self, opnd: &Operand, tmps: &HashMap<u64, F3>) -> F3 {
+        match opnd {
+            Operand::Tmp { id, .. } => *tmps.get(id).unwrap_or_else(|| panic!("use of undefined tmp t{id}")),
+            Operand::Num(v) => F3::base(*v),
+            Operand::Pow { base, j } => {
+                let ch = self.value(&Operand::Ch { base: *base }, tmps);
+                field::pow3(ch, *j)
+            }
+            Operand::Tab { idx, .. } => *self.tab.get(idx).unwrap_or_else(|| panic!("use of unset table word {idx}")),
+            leaf => {
+                let dim = leaf.dim();
+                if let Some(v) = self.leaves.get(leaf) {
+                    return *v;
+                }
+                let v = self.rng.f3(dim);
+                self.leaves.insert(leaf.clone(), v);
+                v
+            }
+        }
+    }
+}
+
+/// Evaluate `ir` under `env`; returns the value of the explicit output store
+/// (or of the last tmp when the expression ends in one) and its dim.
+fn eval(ir: &Ir, env: &mut Env) -> (F3, u64) {
+    // The per-launch table program first, exactly as the table kernel runs it.
+    env.tab.clear();
+    let mut ttmps: HashMap<u64, F3> = HashMap::new();
+    for instr in &ir.tab {
+        let a = env.value(&instr.a, &ttmps);
+        let b = env.value(&instr.b, &ttmps);
+        let v = field::apply(&instr.op, a, instr.a.dim(), b, instr.b.dim());
+        ttmps.insert(instr.dst_id.expect("table op without dst"), v);
+    }
+    for &(tmp, idx, _dim) in &ir.tab_out {
+        env.tab.insert(idx, ttmps[&tmp]);
+    }
+    let mut tmps: HashMap<u64, F3> = HashMap::new();
+    let mut out: Option<(F3, u64)> = None;
+    for instr in &ir.instrs {
+        let a = env.value(&instr.a, &tmps);
+        let b = env.value(&instr.b, &tmps);
+        let v = field::apply(&instr.op, a, instr.a.dim(), b, instr.b.dim());
+        if instr.dst_is_tmp {
+            tmps.insert(instr.dst_id.unwrap(), v);
+            out = Some((v, instr.ddim));
+        } else {
+            out = Some((v, instr.ddim));
+        }
+    }
+    out.expect("empty IR")
+}
+
+/// `Ok(())` if both IRs produce identical outputs on `rounds` random
+/// assignments; `Err` with the first mismatch otherwise.
+pub fn equivalent(original: &Ir, optimized: &Ir, rounds: u64) -> Result<(), String> {
+    for round in 0..rounds {
+        let mut env = Env { rng: Rng(0x5eed_0000 + round), leaves: HashMap::new(), tab: HashMap::new() };
+        let (vo, do_) = eval(original, &mut env);
+        let (vn, dn) = eval(optimized, &mut env);
+        // A base-field value stored into a dim-3 output is zero-padded, so
+        // compare as F3 after normalizing dims.
+        let norm = |v: F3, d: u64| if d == 1 { F3::base(v.a) } else { v };
+        if norm(vo, do_) != norm(vn, dn) {
+            return Err(format!("round {round}: original={vo:?} (dim {do_}) optimized={vn:?} (dim {dn})"));
+        }
+    }
+    Ok(())
+}

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -135,8 +135,8 @@ fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
             let i = *base;
             vec![format!("  g3 {name}; {name}.a=ch[{i}]; {name}.b=ch[{}]; {name}.c=ch[{}];", i + 1, i + 2)]
         }
-        Operand::Pow { j, .. } => {
-            let i = 3 * *j;
+        Operand::Pow { base, j } => {
+            let i = ir.pow_offset(*base) + 3 * *j;
             let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
             vec![format!("  g3 {name}; {name}.a={l0}; {name}.b={l1}; {name}.c={l2};")]
         }
@@ -298,39 +298,51 @@ fn tab_body(ir: &Ir) -> String {
 /// head of scratch and runs it. Empty strings when the IR uses no powers.
 /// One block: thread t starts at `v^t` and strides by `v^blockDim`.
 fn pow_kernel(sym: &str, ir: &Ir) -> (String, String) {
-    if ir.pow.is_none() && ir.tab.is_empty() {
+    if ir.pow.is_empty() && ir.tab.is_empty() {
         return (String::new(), "  const gl64_t* pw = scratch;".to_string());
     }
-    // with no powers the loop body is skipped (n = 0); `base` then only names
-    // a valid challenge slot for the unused `v`
-    let (base, n) = ir.pow.unwrap_or((0, 0));
+    // One fill loop per challenge region, laid out end to end in `pow_offset` order.
+    let regions: String = ir
+        .pow
+        .iter()
+        .map(|&(base, n)| {
+            let off = ir.pow_offset(base);
+            format!(
+                r#"  {{
+    g3 v; v.a=ch[{base}]; v.b=ch[{}]; v.c=ch[{}];
+    g3 cur=one, b=v; uint64_t e=threadIdx.x;
+    while (e) {{ if (e&1) cur=cg_mul33(cur,b); b=cg_mul33(b,b); e>>=1; }}
+    g3 step=one; b=v; e=blockDim.x;
+    while (e) {{ if (e&1) step=cg_mul33(step,b); b=cg_mul33(b,b); e>>=1; }}
+    for (uint64_t k=threadIdx.x; k<{n}ull; k+=blockDim.x) {{
+      pw[{off}+3*k]=cur.a; pw[{off}+3*k+1]=cur.b; pw[{off}+3*k+2]=cur.c; cur=cg_mul33(cur,step);
+    }}
+  }}"#,
+                base + 1,
+                base + 2
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("
+");
     let tab = tab_body(ir);
     let kernel = format!(
-        r#"__global__ void gen_{sym}_pow(const StepsParams* __restrict__ P, gl64_t* __restrict__ pw, uint64_t n) {{
+        r#"__global__ void gen_{sym}_pow(const StepsParams* __restrict__ P, gl64_t* __restrict__ pw) {{
   const gl64_t* __restrict__ ch=(const gl64_t*)P->challenges; const gl64_t* __restrict__ av=(const gl64_t*)P->airValues;
   const gl64_t* __restrict__ agv=(const gl64_t*)P->airgroupValues; const gl64_t* __restrict__ pub=(const gl64_t*)P->publicInputs;
   [[maybe_unused]] const gl64_t* __restrict__ aux=(const gl64_t*)P->aux_trace; [[maybe_unused]] const gl64_t* __restrict__ cst=(const gl64_t*)P->pConstPolsExtendedTreeAddress;
-  g3 v; v.a=ch[{base}]; v.b=ch[{}]; v.c=ch[{}];
   g3 one; one.a=gl64_t(uint64_t(1)); one.b=gl64_t(uint64_t(0)); one.c=gl64_t(uint64_t(0));
-  g3 cur=one, b=v; uint64_t e=threadIdx.x;
-  while (e) {{ if (e&1) cur=cg_mul33(cur,b); b=cg_mul33(b,b); e>>=1; }}
-  g3 step=one; b=v; e=blockDim.x;
-  while (e) {{ if (e&1) step=cg_mul33(step,b); b=cg_mul33(b,b); e>>=1; }}
-  for (uint64_t k=threadIdx.x; k<n; k+=blockDim.x) {{
-    pw[3*k]=cur.a; pw[3*k+1]=cur.b; pw[3*k+2]=cur.c; cur=cg_mul33(cur,step);
-  }}
+{regions}
   __syncthreads();
   // row-invariant program: once per launch, after the powers it may read
   if (threadIdx.x == 0) {{
 {tab}
   }}
-}}"#,
-        base + 1,
-        base + 2
+}}"#
     );
     let prologue = format!(
         r#"  const gl64_t* pw = scratch; scratch += {pe}ull; scratchElems -= {pe}ull;
-  gen_{sym}_pow<<<1,256,0,stream>>>(d_params, (gl64_t*)pw, {n}ull);"#,
+  gen_{sym}_pow<<<1,256,0,stream>>>(d_params, (gl64_t*)pw);"#,
         pe = ir.table_words()
     );
     (kernel, prologue)

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -135,6 +135,9 @@ fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
             let i = *base;
             vec![format!("  g3 {name}; {name}.a=ch[{i}]; {name}.b=ch[{}]; {name}.c=ch[{}];", i + 1, i + 2)]
         }
+        Operand::Pow { base, j } if ir.pow_in_regs => {
+            vec![format!("  g3 {name} = pwreg_{base}_{j};")]
+        }
         Operand::Pow { base, j } => {
             let i = ir.pow_offset(*base) + 3 * *j;
             let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
@@ -594,31 +597,61 @@ pub fn emit_exprs_tu(sym: &str, items: &[(i64, crate::ir::Ir, u64)]) -> String {
         // explicit output store, `t<id>` when the expression ends in a tmp.
         let last = ir.instrs.last().unwrap();
         let result = if last.dst_is_tmp { format!("t{}", last.dst_id.unwrap()) } else { "qq".to_string() };
-        let store = if *out_dim == 3 {
-            format!("    {{ g3 v_={result}; exps_expr_store(dest,row,destDomain,stagePos,stageCols,destDim,destExpr,mode,scalar,v_,3); }}")
+        // Value type of this expression and how the plain store receives it.
+        let (vt, vdim) = if *out_dim == 3 { ("g3", 3) } else { ("gl64_t", 1) };
+        let to_g3 = if *out_dim == 3 {
+            "g3 v_=ev_;".to_string()
         } else {
-            format!("    {{ g3 v_; v_.a={result}; v_.b=gl64_t(uint64_t(0)); v_.c=gl64_t(uint64_t(0)); exps_expr_store(dest,row,destDomain,stagePos,stageCols,destDim,destExpr,mode,scalar,v_,1); }}")
+            "g3 v_; v_.a=ev_; v_.b=gl64_t(uint64_t(0)); v_.c=gl64_t(uint64_t(0));".to_string()
         };
-        kernels.push(format!(
-            r#"__global__ void gen_{sym}_x{exp_id}(const StepsParams* __restrict__ P, gl64_t* __restrict__ dest,
-    uint64_t N, uint64_t destDomain, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3,
-    uint64_t mode, uint64_t scalar, uint64_t stagePos, uint64_t stageCols, uint64_t destDim, uint32_t destExpr) {{
-  const uint64_t NExt = N; const uint64_t MASK = N-1;
+        let store = format!("    {{ {to_g3} exps_expr_store(dest,row,destDomain,stagePos,stageCols,destDim,destExpr,mode,scalar,v_,{vdim}); }}");
+        // Challenge powers for this kernel, computed once per thread into registers
+        // (the kernel has no scratch table; a thread serves many rows, so the few
+        // cubic multiplies amortize). Same arithmetic as the Q table: repeated
+        // cg_mul33 from the challenge, so the folded chains stay exact.
+        let pwregs: String = if ir.pow_in_regs {
+            let mut lines: Vec<String> = Vec::new();
+            for &(base, n) in &ir.pow {
+                if n < 2 {
+                    continue;
+                }
+                lines.push(format!(
+                    "  [[maybe_unused]] g3 pwreg_{base}_1; pwreg_{base}_1.a=ch[{base}]; pwreg_{base}_1.b=ch[{}]; pwreg_{base}_1.c=ch[{}];",
+                    base + 1,
+                    base + 2
+                ));
+                for j in 2..n {
+                    lines.push(format!("  [[maybe_unused]] g3 pwreg_{base}_{j} = cg_mul33(pwreg_{base}_{}, pwreg_{base}_1);", j - 1));
+                }
+            }
+            lines.join("\n") + "\n"
+        } else {
+            String::new()
+        };
+        // Per-row evaluation shared by the kernel body.
+        let prologue = format!(
+            r#"  const uint64_t NExt = N; const uint64_t MASK = N-1;
   const gl64_t* __restrict__ aux=(const gl64_t*)P->aux_trace; const gl64_t* __restrict__ cst=(const gl64_t*)P->pConstPolsAddress;
   const gl64_t* __restrict__ ch=(const gl64_t*)P->challenges; const gl64_t* __restrict__ av=(const gl64_t*)P->airValues;
   const gl64_t* __restrict__ agv=(const gl64_t*)P->airgroupValues; const gl64_t* __restrict__ pub=(const gl64_t*)P->publicInputs;
   [[maybe_unused]] const gl64_t* __restrict__ ccf=(const gl64_t*)P->pCustomCommitsFixed;
+{pwregs}  auto eval_ = [&](uint64_t row) -> {vt} {{
+{}
+    return {result};
+  }};"#,
+            body.join("\n")
+        );
+        let sig = "(const StepsParams* __restrict__ P, gl64_t* __restrict__ dest,\n    uint64_t N, uint64_t destDomain, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3,\n    uint64_t mode, uint64_t scalar, uint64_t stagePos, uint64_t stageCols, uint64_t destDim, uint32_t destExpr)";
+        kernels.push(format!(
+            r#"__global__ void gen_{sym}_x{exp_id}{sig} {{
+{prologue}
   for (uint64_t row=blockIdx.x*blockDim.x+threadIdx.x; row<N; row+=(uint64_t)gridDim.x*blockDim.x) {{
-{}
-{}
+    {vt} ev_ = eval_(row);
+{store}
   }}
-}}"#,
-            body.join("\n"),
-            store
+}}"#
         ));
-        cases_launch.push(format!(
-            "    case {exp_id}ull: gen_{sym}_x{exp_id}<<<grid,{GEN_BLK},0,stream>>>(P,dest,N,destDomain,off_cm1,off_cm2,off_cm3,mode,scalar,stagePos,stageCols,destDim,destExpr); return 1;"
-        ));
+        cases_launch.push(format!("    case {exp_id}ull: gen_{sym}_x{exp_id}<<<grid,{GEN_BLK},0,stream>>>(P,dest,N,destDomain,off_cm1,off_cm2,off_cm3,mode,scalar,stagePos,stageCols,destDim,destExpr); return 1;"));
         cases_covered.push(format!("    case {exp_id}ull: return 1;"));
     }
     format!(

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -99,6 +99,32 @@ fn rowexpr(stride: i64) -> String {
     }
 }
 
+/// A read of table word `i` (powers / hoisted invariants): every thread reads
+/// the same address, so it is a broadcast. EXPS_PW_LDG=1 (codegen-time knob,
+/// OFF by default) routes it through `__ldg`; measured no effect on the small
+/// kernels it was meant for (Binary -0.6%, VirtualTableZisk1 0%).
+fn pw_load(i: u64) -> String {
+    if std::env::var("EXPS_PW_LDG").is_ok_and(|v| v == "1") {
+        format!("gl64_t(__ldg((const unsigned long long*)&pw[{i}]))")
+    } else {
+        format!("pw[{i}]")
+    }
+}
+
+/// `__launch_bounds__(GEN_BLK, MINB)` prefix for the per-row kernels when
+/// EXPS_MINB=<minBlocksPerSM> is set at codegen time: caps registers per thread
+/// (2 -> 128, 3 -> 85, 4 -> 64). Experiment knob, OFF by default: Main's
+/// hoisted kernel sits at 255 registers (16.7% occupancy) but every cap
+/// measured +11% slower (129.6 -> 144 ms on the 66-tx block) -- the compiler
+/// pays for the registers with recompute/spills, and occupancy does not buy
+/// it back.
+fn launch_bounds() -> String {
+    match std::env::var("EXPS_MINB").ok().and_then(|v| v.parse::<u32>().ok()) {
+        Some(m) if m >= 1 => format!("__launch_bounds__({GEN_BLK}, {m}) "),
+        _ => String::new(),
+    }
+}
+
 /// Lines that materialize a non-tmp operand into the local `name`.
 fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
     match opnd {
@@ -108,6 +134,20 @@ fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
         Operand::Ch { base } => {
             let i = *base;
             vec![format!("  g3 {name}; {name}.a=ch[{i}]; {name}.b=ch[{}]; {name}.c=ch[{}];", i + 1, i + 2)]
+        }
+        Operand::Pow { j, .. } => {
+            let i = 3 * *j;
+            let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
+            vec![format!("  g3 {name}; {name}.a={l0}; {name}.b={l1}; {name}.c={l2};")]
+        }
+        Operand::Tab { idx, dim } => {
+            let i = ir.pow_words() + *idx;
+            if *dim == 1 {
+                vec![format!("  gl64_t {name} = {};", pw_load(i))]
+            } else {
+                let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
+                vec![format!("  g3 {name}; {name}.a={l0}; {name}.b={l1}; {name}.c={l2};")]
+            }
         }
         Operand::Av { pos, dim } | Operand::Agv { pos, dim } => {
             let arr = if matches!(opnd, Operand::Av { .. }) { "av" } else { "agv" };
@@ -215,32 +255,105 @@ fn store_qq(out_dim: u64) -> &'static str {
     }
 }
 
-/// The fixed C-ABI the loader dlsym's from each `.exps.so`.
-fn c_abi_exports(sym: &str, n_slots: u64) -> String {
+/// Elements of scratch reserved at its head for the challenge-powers table.
+/// The fixed C-ABI the loader dlsym's from each `.exps.so`. `exps_min_scratch`
+/// covers one wave of cross-chunk temps plus the per-launch table (powers +
+/// hoisted invariants).
+fn c_abi_exports(sym: &str, n_slots: u64, ir: &Ir) -> String {
     format!(
         r#"extern "C" void exps_launch(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
     launch_gen_{sym}(d_params, q, scratch, scratchElems, NExt, off_cm1, off_cm2, off_cm3, off_zi, stream);
 }}
-extern "C" unsigned long long exps_min_scratch() {{ return {n_slots} * {GEN_BLK}ull; }}"#
+extern "C" unsigned long long exps_min_scratch() {{ return {n_slots} * {GEN_BLK}ull + {}ull; }}"#,
+        ir.table_words()
     )
 }
 
+/// Straight-line body of the hoisted-invariants program for thread 0 of the
+/// table kernel: the ops of `ir.tab` followed by the exports into `pw[]` after
+/// the powers. Reuses the chunk emitter, so operand loads and field ops are
+/// the exact same code the per-row kernels would have run.
+fn tab_body(ir: &Ir) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let declared: HashSet<u64> = HashSet::new();
+    for instr in &ir.tab {
+        let (l, _) = emit_op(instr, ir, &declared);
+        lines.extend(l.into_iter().map(|x| format!("  {x}")));
+    }
+    let base = ir.pow_words();
+    for &(tmp, idx, dim) in &ir.tab_out {
+        let w = base + idx;
+        if dim == 1 {
+            lines.push(format!("    pw[{w}] = t{tmp};"));
+        } else {
+            lines.push(format!("    pw[{w}] = t{tmp}.a; pw[{}] = t{tmp}.b; pw[{}] = t{tmp}.c;", w + 1, w + 2));
+        }
+    }
+    lines.join("\n")
+}
+
+/// Kernel filling the challenge-powers table `pw[3*j..3*j+3] = ch[base..]^j`
+/// for j in 0..n, plus the launcher prologue that carves the table off the
+/// head of scratch and runs it. Empty strings when the IR uses no powers.
+/// One block: thread t starts at `v^t` and strides by `v^blockDim`.
+fn pow_kernel(sym: &str, ir: &Ir) -> (String, String) {
+    if ir.pow.is_none() && ir.tab.is_empty() {
+        return (String::new(), "  const gl64_t* pw = scratch;".to_string());
+    }
+    // with no powers the loop body is skipped (n = 0); `base` then only names
+    // a valid challenge slot for the unused `v`
+    let (base, n) = ir.pow.unwrap_or((0, 0));
+    let tab = tab_body(ir);
+    let kernel = format!(
+        r#"__global__ void gen_{sym}_pow(const StepsParams* __restrict__ P, gl64_t* __restrict__ pw, uint64_t n) {{
+  const gl64_t* __restrict__ ch=(const gl64_t*)P->challenges; const gl64_t* __restrict__ av=(const gl64_t*)P->airValues;
+  const gl64_t* __restrict__ agv=(const gl64_t*)P->airgroupValues; const gl64_t* __restrict__ pub=(const gl64_t*)P->publicInputs;
+  [[maybe_unused]] const gl64_t* __restrict__ aux=(const gl64_t*)P->aux_trace; [[maybe_unused]] const gl64_t* __restrict__ cst=(const gl64_t*)P->pConstPolsExtendedTreeAddress;
+  g3 v; v.a=ch[{base}]; v.b=ch[{}]; v.c=ch[{}];
+  g3 one; one.a=gl64_t(uint64_t(1)); one.b=gl64_t(uint64_t(0)); one.c=gl64_t(uint64_t(0));
+  g3 cur=one, b=v; uint64_t e=threadIdx.x;
+  while (e) {{ if (e&1) cur=cg_mul33(cur,b); b=cg_mul33(b,b); e>>=1; }}
+  g3 step=one; b=v; e=blockDim.x;
+  while (e) {{ if (e&1) step=cg_mul33(step,b); b=cg_mul33(b,b); e>>=1; }}
+  for (uint64_t k=threadIdx.x; k<n; k+=blockDim.x) {{
+    pw[3*k]=cur.a; pw[3*k+1]=cur.b; pw[3*k+2]=cur.c; cur=cg_mul33(cur,step);
+  }}
+  __syncthreads();
+  // row-invariant program: once per launch, after the powers it may read
+  if (threadIdx.x == 0) {{
+{tab}
+  }}
+}}"#,
+        base + 1,
+        base + 2
+    );
+    let prologue = format!(
+        r#"  const gl64_t* pw = scratch; scratch += {pe}ull; scratchElems -= {pe}ull;
+  gen_{sym}_pow<<<1,256,0,stream>>>(d_params, (gl64_t*)pw, {n}ull);"#,
+        pe = ir.table_words()
+    );
+    (kernel, prologue)
+}
+
 /// Small-expression path: kernel + launcher + C-ABI exports in ONE self-contained TU.
-fn single_kernel_tu(sym: &str, kernel: &str, launcher_body: &str, n_slots: u64) -> String {
+fn single_kernel_tu(sym: &str, kernel: &str, launcher_body: &str, ir: &Ir) -> String {
+    let (pk, prologue) = pow_kernel(sym, ir);
     format!(
         r#"// AUTO-GENERATED Q kernel for {sym} (single kernel, no scratch)
 #include "gen_common.cuh"
 #define OFF(r,c,nr,nc,lyt) getBufferOffset((uint64_t)(r),(uint64_t)(c),(uint64_t)(nr),(uint64_t)(nc),(lyt))
+{pk}
 {kernel}
 void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
+{prologue}
 {launcher_body}
 }}
 #undef OFF
 {}
 "#,
-        c_abi_exports(sym, n_slots)
+        c_abi_exports(sym, 0, ir)
     )
 }
 
@@ -252,9 +365,9 @@ fn chunk_tu(sym: &str, lo: usize, hi: usize, kernels: &[String]) -> String {
         parts.push(kernel.clone());
         parts.push(format!(
             r#"extern "C" void run_{sym}_c{i}(uint64_t grid, uint64_t blk, cudaStream_t stream, StepsParams* d_params,
-    gl64_t* q, gl64_t* scratch, uint64_t NExt, uint64_t base,
+    gl64_t* q, gl64_t* scratch, const gl64_t* pw, uint64_t NExt, uint64_t base,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi) {{
-  gen_{sym}_c{i}<<<grid,blk,0,stream>>>(d_params,q,scratch,NExt,base,off_cm1,off_cm2,off_cm3,off_zi);
+  gen_{sym}_c{i}<<<grid,blk,0,stream>>>(d_params,q,scratch,pw,NExt,base,off_cm1,off_cm2,off_cm3,off_zi);
 }}"#
         ));
     }
@@ -271,27 +384,30 @@ fn chunk_tu(sym: &str, lo: usize, hi: usize, kernels: &[String]) -> String {
 }
 
 /// The Q launcher TU (`exps_launch`): cross-TU `run_*` decls + the adaptive-grid wave loop + C-ABI.
-fn launcher_tu(sym: &str, n_chunks: usize, total_slots: u64) -> String {
+fn launcher_tu(sym: &str, n_chunks: usize, total_slots: u64, ir: &Ir) -> String {
     let decls: Vec<String> = (0..n_chunks)
         .map(|i| {
             format!(
-                "extern \"C\" void run_{sym}_c{i}(uint64_t, uint64_t, cudaStream_t, StepsParams*, gl64_t*, gl64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);"
+                "extern \"C\" void run_{sym}_c{i}(uint64_t, uint64_t, cudaStream_t, StepsParams*, gl64_t*, gl64_t*, const gl64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);"
             )
         })
         .collect();
     let calls: Vec<String> = (0..n_chunks)
         .map(|i| {
-            format!("    run_{sym}_c{i}(grid, BLK, stream, d_params, q, scratch, NExt, base, off_cm1, off_cm2, off_cm3, off_zi);")
+            format!("    run_{sym}_c{i}(grid, BLK, stream, d_params, q, scratch, pw, NExt, base, off_cm1, off_cm2, off_cm3, off_zi);")
         })
         .collect();
+    let (pk, prologue) = pow_kernel(sym, ir);
     format!(
         r#"// AUTO-GENERATED Q launcher for {sym} (cross-boundary temps={total_slots}, {n_chunks} chunks)
 #include "gen_common.cuh"
 {}
+{pk}
 // adaptive grid: shrink so total_slots*grid*BLK <= scratchElems (per-wave scratch fits the tmp region);
 // each chunk kernel computes WAVE=gridDim*blockDim at runtime, so any grid is correct.
 void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
+{prologue}
   const uint64_t BLK = {GEN_BLK}ull;
   uint64_t grid = {total_slots}ull ? (scratchElems / ({total_slots}ull*BLK)) : 512ull;
   if (grid > 512ull) grid = 512ull;
@@ -305,7 +421,7 @@ void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_
 "#,
         decls.join("\n"),
         calls.join("\n"),
-        c_abi_exports(sym, total_slots)
+        c_abi_exports(sym, total_slots, ir)
     )
 }
 
@@ -325,7 +441,7 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
             }
         }
         let kernel = format!(
-            r#"__global__ void gen_{sym}_kernel(const StepsParams* __restrict__ P, gl64_t* __restrict__ q,
+            r#"__global__ void gen_{sym}_kernel(const StepsParams* __restrict__ P, gl64_t* __restrict__ q, [[maybe_unused]] const gl64_t* __restrict__ pw,
     uint64_t NExt, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi) {{
   const uint64_t MASK = NExt-1;
   const gl64_t* __restrict__ aux=(const gl64_t*)P->aux_trace; const gl64_t* __restrict__ cst=(const gl64_t*)P->pConstPolsExtendedTreeAddress;
@@ -341,16 +457,15 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
             store_qq(plan.out_dim)
         );
         let launcher_body = format!(
-            "  (void)scratch; (void)scratchElems; gen_{sym}_kernel<<<512,256,0,stream>>>(d_params,q,NExt,off_cm1,off_cm2,off_cm3,off_zi);"
+            "  (void)scratchElems; gen_{sym}_kernel<<<512,256,0,stream>>>(d_params,q,pw,NExt,off_cm1,off_cm2,off_cm3,off_zi);"
         );
-        return vec![(format!("gen_{sym}.cu"), single_kernel_tu(sym, &kernel, &launcher_body, 0))];
+        return vec![(format!("gen_{sym}.cu"), single_kernel_tu(sym, &kernel, &launcher_body, ir))];
     }
 
     // chunked (tiled): one register-bounded kernel per chunk.
     let mut kernels: Vec<String> = Vec::with_capacity(plan.n_chunks);
     for chunk_idx in 0..plan.n_chunks {
-        let lo_op = chunk_idx * plan.chunk;
-        let hi_op = ((chunk_idx + 1) * plan.chunk).min(ir.instrs.len());
+        let (lo_op, hi_op) = plan.range(chunk_idx);
         let chunk_ops = &ir.instrs[lo_op..hi_op];
 
         let mut used_temps: HashSet<u64> = HashSet::new();
@@ -409,7 +524,8 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
             lines.push(store_qq(plan.out_dim).to_string());
         }
         kernels.push(format!(
-            r#"__global__ void gen_{sym}_c{chunk_idx}(const StepsParams* __restrict__ P, gl64_t* __restrict__ q, gl64_t* __restrict__ scratch,
+            r#"__global__ void {lb}gen_{sym}_c{chunk_idx}(const StepsParams* __restrict__ P, gl64_t* __restrict__ q, gl64_t* __restrict__ scratch,
+    [[maybe_unused]] const gl64_t* __restrict__ pw,
     uint64_t NExt, uint64_t tileBase, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi) {{
   const uint64_t MASK = NExt-1; const uint64_t WAVE = (uint64_t)gridDim.x*blockDim.x;
   const uint64_t lo_ = blockIdx.x*blockDim.x + threadIdx.x; const uint64_t row = tileBase + lo_;
@@ -420,12 +536,13 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
   [[maybe_unused]] const gl64_t* __restrict__ ccf=(const gl64_t*)P->pCustomCommitsFixed;
 {}
 }}"#,
-            lines.join("\n")
+            lines.join("\n"),
+            lb = launch_bounds(),
         ));
     }
 
     let mut files: Vec<(String, String)> =
-        vec![(format!("gen_{sym}.cu"), launcher_tu(sym, plan.n_chunks, plan.total_slots))];
+        vec![(format!("gen_{sym}.cu"), launcher_tu(sym, plan.n_chunks, plan.total_slots, ir))];
     let mut tu = 0usize;
     let mut lo = 0usize;
     while lo < plan.n_chunks {

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -99,32 +99,6 @@ fn rowexpr(stride: i64) -> String {
     }
 }
 
-/// A read of table word `i` (powers / hoisted invariants): every thread reads
-/// the same address, so it is a broadcast. EXPS_PW_LDG=1 (codegen-time knob,
-/// OFF by default) routes it through `__ldg`; measured no effect on the small
-/// kernels it was meant for (Binary -0.6%, VirtualTableZisk1 0%).
-fn pw_load(i: u64) -> String {
-    if std::env::var("EXPS_PW_LDG").is_ok_and(|v| v == "1") {
-        format!("gl64_t(__ldg((const unsigned long long*)&pw[{i}]))")
-    } else {
-        format!("pw[{i}]")
-    }
-}
-
-/// `__launch_bounds__(GEN_BLK, MINB)` prefix for the per-row kernels when
-/// EXPS_MINB=<minBlocksPerSM> is set at codegen time: caps registers per thread
-/// (2 -> 128, 3 -> 85, 4 -> 64). Experiment knob, OFF by default: Main's
-/// hoisted kernel sits at 255 registers (16.7% occupancy) but every cap
-/// measured +11% slower (129.6 -> 144 ms on the 66-tx block) -- the compiler
-/// pays for the registers with recompute/spills, and occupancy does not buy
-/// it back.
-fn launch_bounds() -> String {
-    match std::env::var("EXPS_MINB").ok().and_then(|v| v.parse::<u32>().ok()) {
-        Some(m) if m >= 1 => format!("__launch_bounds__({GEN_BLK}, {m}) "),
-        _ => String::new(),
-    }
-}
-
 /// Lines that materialize a non-tmp operand into the local `name`.
 fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
     match opnd {
@@ -140,16 +114,14 @@ fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
         }
         Operand::Pow { base, j } => {
             let i = ir.pow_offset(*base) + 3 * *j;
-            let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
-            vec![format!("  g3 {name}; {name}.a={l0}; {name}.b={l1}; {name}.c={l2};")]
+            vec![format!("  g3 {name}; {name}.a=pw[{i}]; {name}.b=pw[{}]; {name}.c=pw[{}];", i + 1, i + 2)]
         }
         Operand::Tab { idx, dim } => {
             let i = ir.pow_words() + *idx;
             if *dim == 1 {
-                vec![format!("  gl64_t {name} = {};", pw_load(i))]
+                vec![format!("  gl64_t {name} = pw[{i}];")]
             } else {
-                let (l0, l1, l2) = (pw_load(i), pw_load(i + 1), pw_load(i + 2));
-                vec![format!("  g3 {name}; {name}.a={l0}; {name}.b={l1}; {name}.c={l2};")]
+                vec![format!("  g3 {name}; {name}.a=pw[{i}]; {name}.b=pw[{}]; {name}.c=pw[{}];", i + 1, i + 2)]
             }
         }
         Operand::Av { pos, dim } | Operand::Agv { pos, dim } => {
@@ -539,7 +511,7 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
             lines.push(store_qq(plan.out_dim).to_string());
         }
         kernels.push(format!(
-            r#"__global__ void {lb}gen_{sym}_c{chunk_idx}(const StepsParams* __restrict__ P, gl64_t* __restrict__ q, gl64_t* __restrict__ scratch,
+            r#"__global__ void gen_{sym}_c{chunk_idx}(const StepsParams* __restrict__ P, gl64_t* __restrict__ q, gl64_t* __restrict__ scratch,
     [[maybe_unused]] const gl64_t* __restrict__ pw,
     uint64_t NExt, uint64_t tileBase, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi) {{
   const uint64_t MASK = NExt-1; const uint64_t WAVE = (uint64_t)gridDim.x*blockDim.x;
@@ -552,7 +524,6 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
 {}
 }}"#,
             lines.join("\n"),
-            lb = launch_bounds(),
         ));
     }
 

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -232,6 +232,26 @@ fn store_qq(out_dim: u64) -> &'static str {
     }
 }
 
+/// Host-side check at the top of every launcher. `exps_min_scratch()` is the
+/// contract with the loader: the per-launch table plus (chunked kernels) one
+/// wave of cross-chunk temps. Below it the table carve-out in the prologue
+/// underflows and the kernels would read/write past the scratch buffer, so
+/// fail loudly instead.
+fn scratch_guard(sym: &str, table_words: u64, total_slots: u64) -> String {
+    let need = if total_slots > 0 {
+        format!("{table_words}ull + {total_slots}ull*{GEN_BLK}ull")
+    } else {
+        format!("{table_words}ull")
+    };
+    format!(
+        r#"  if (scratchElems < {need}) {{
+    fprintf(stderr, "[exps] {sym}: scratch too small (%llu < %llu elements)\n",
+        (unsigned long long)scratchElems, (unsigned long long)({need}));
+    abort();
+  }}"#
+    )
+}
+
 /// The fixed C-ABI the loader dlsym's from each `.exps.so`. `exps_min_scratch`
 /// covers one wave of cross-chunk temps plus the per-launch table (powers +
 /// hoisted invariants).
@@ -338,13 +358,15 @@ fn single_kernel_tu(sym: &str, kernel: &str, launcher_body: &str, ir: &Ir) -> St
 {kernel}
 void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
+{guard}
 {prologue}
 {launcher_body}
 }}
 #undef OFF
 {}
 "#,
-        c_abi_exports(sym, 0, ir)
+        c_abi_exports(sym, 0, ir),
+        guard = scratch_guard(sym, ir.table_words(), 0),
     )
 }
 
@@ -399,14 +421,7 @@ fn launcher_tu(sym: &str, n_chunks: usize, total_slots: u64, ir: &Ir) -> String 
 void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
   const uint64_t BLK = {GEN_BLK}ull;
-  // exps_min_scratch() is the contract with the loader: one wave of cross-chunk
-  // temps plus the per-launch table. Below it the table carve-out underflows and
-  // the chunk kernels would write past the scratch buffer, so fail loudly.
-  if (scratchElems < {table_words}ull + {total_slots}ull*BLK) {{
-    fprintf(stderr, "[exps] {sym}: scratch too small (%llu < %llu elements)\n",
-        (unsigned long long)scratchElems, (unsigned long long)({table_words}ull + {total_slots}ull*BLK));
-    abort();
-  }}
+{guard}
 {prologue}
   uint64_t grid = {total_slots}ull ? (scratchElems / ({total_slots}ull*BLK)) : 512ull;
   if (grid > 512ull) grid = 512ull;
@@ -420,7 +435,7 @@ void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_
         decls.join("\n"),
         calls.join("\n"),
         c_abi_exports(sym, total_slots, ir),
-        table_words = ir.table_words(),
+        guard = scratch_guard(sym, ir.table_words(), total_slots),
     )
 }
 

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -20,6 +20,8 @@ pub const COMMON_CUH: &str = r#"#pragma once
 #include "steps.hpp"
 #include "goldilocks_trace_layout.cuh"
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 // cg_* = the codegen's Goldilocks cubic-extension helpers (g3 = one Fp3 element).
 // Prefixed to avoid collisions with the prover headers this TU also includes;
 // digit suffixes are operand dims (mul33 = 3x3, mul31 = 3x1, inv3 = cubic inverse).
@@ -230,7 +232,6 @@ fn store_qq(out_dim: u64) -> &'static str {
     }
 }
 
-/// Elements of scratch reserved at its head for the challenge-powers table.
 /// The fixed C-ABI the loader dlsym's from each `.exps.so`. `exps_min_scratch`
 /// covers one wave of cross-chunk temps plus the per-launch table (powers +
 /// hoisted invariants).
@@ -270,7 +271,8 @@ fn tab_body(ir: &Ir) -> String {
 
 /// Kernel filling the challenge-powers table `pw[3*j..3*j+3] = ch[base..]^j`
 /// for j in 0..n, plus the launcher prologue that carves the table off the
-/// head of scratch and runs it. Empty strings when the IR uses no powers.
+/// head of scratch and runs it. No kernel (and a prologue that just aliases
+/// `pw` to scratch) when the IR has neither powers nor a table.
 /// One block: thread t starts at `v^t` and strides by `v^blockDim`.
 fn pow_kernel(sym: &str, ir: &Ir) -> (String, String) {
     if ir.pow.is_empty() && ir.tab.is_empty() {
@@ -298,8 +300,10 @@ fn pow_kernel(sym: &str, ir: &Ir) -> (String, String) {
             )
         })
         .collect::<Vec<_>>()
-        .join("
-");
+        .join(
+            "
+",
+        );
     let tab = tab_body(ir);
     let kernel = format!(
         r#"__global__ void gen_{sym}_pow(const StepsParams* __restrict__ P, gl64_t* __restrict__ pw) {{
@@ -394,11 +398,18 @@ fn launcher_tu(sym: &str, n_chunks: usize, total_slots: u64, ir: &Ir) -> String 
 // each chunk kernel computes WAVE=gridDim*blockDim at runtime, so any grid is correct.
 void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_t scratchElems, uint64_t NExt,
     uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t off_zi, cudaStream_t stream) {{
-{prologue}
   const uint64_t BLK = {GEN_BLK}ull;
+  // exps_min_scratch() is the contract with the loader: one wave of cross-chunk
+  // temps plus the per-launch table. Below it the table carve-out underflows and
+  // the chunk kernels would write past the scratch buffer, so fail loudly.
+  if (scratchElems < {table_words}ull + {total_slots}ull*BLK) {{
+    fprintf(stderr, "[exps] {sym}: scratch too small (%llu < %llu elements)\n",
+        (unsigned long long)scratchElems, (unsigned long long)({table_words}ull + {total_slots}ull*BLK));
+    abort();
+  }}
+{prologue}
   uint64_t grid = {total_slots}ull ? (scratchElems / ({total_slots}ull*BLK)) : 512ull;
   if (grid > 512ull) grid = 512ull;
-  if (grid < 1ull) grid = 1ull;
   const uint64_t WAVE = grid * BLK;
   for (uint64_t base=0; base<NExt; base+=WAVE) {{
 {}
@@ -408,7 +419,8 @@ void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_
 "#,
         decls.join("\n"),
         calls.join("\n"),
-        c_abi_exports(sym, total_slots, ir)
+        c_abi_exports(sym, total_slots, ir),
+        table_words = ir.table_words(),
     )
 }
 
@@ -592,7 +604,10 @@ pub fn emit_exprs_tu(sym: &str, items: &[(i64, crate::ir::Ir, u64)]) -> String {
                     base + 2
                 ));
                 for j in 2..n {
-                    lines.push(format!("  [[maybe_unused]] g3 pwreg_{base}_{j} = cg_mul33(pwreg_{base}_{}, pwreg_{base}_1);", j - 1));
+                    lines.push(format!(
+                        "  [[maybe_unused]] g3 pwreg_{base}_{j} = cg_mul33(pwreg_{base}_{}, pwreg_{base}_1);",
+                        j - 1
+                    ));
                 }
             }
             lines.join("\n") + "\n"

--- a/setup/exps-codegen/src/field.rs
+++ b/setup/exps-codegen/src/field.rs
@@ -1,0 +1,155 @@
+//! Exact Goldilocks (p = 2^64 - 2^32 + 1) and cubic-extension arithmetic
+//! (Fp[x]/(x^3 - x - 1)), bit-identical to the device helpers in
+//! `gen_common.cuh`. Used for constant folding and for the host-side
+//! equivalence check of the optimized IR.
+
+pub const P: u64 = 0xFFFF_FFFF_0000_0001;
+
+#[inline]
+pub fn add(a: u64, b: u64) -> u64 {
+    let (s, c) = a.overflowing_add(b);
+    let s = if c { s.wrapping_sub(P) } else { s };
+    if s >= P {
+        s - P
+    } else {
+        s
+    }
+}
+
+#[inline]
+pub fn sub(a: u64, b: u64) -> u64 {
+    if a >= b {
+        a - b
+    } else {
+        a.wrapping_sub(b).wrapping_add(P)
+    }
+}
+
+#[inline]
+pub fn mul(a: u64, b: u64) -> u64 {
+    ((a as u128 * b as u128) % P as u128) as u64
+}
+
+/// One Fp3 element `a + b x + c x^2`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct F3 {
+    pub a: u64,
+    pub b: u64,
+    pub c: u64,
+}
+
+impl F3 {
+    pub const fn base(a: u64) -> F3 {
+        F3 { a, b: 0, c: 0 }
+    }
+}
+
+/// Same Karatsuba arrangement as `cg_mul33` (the result is the exact field
+/// product, so the arrangement only matters for reading the two side by side).
+pub fn mul33(x: F3, y: F3) -> F3 {
+    let aa = mul(add(x.a, x.b), add(y.a, y.b));
+    let bb = mul(add(x.a, x.c), add(y.a, y.c));
+    let cc = mul(add(x.b, x.c), add(y.b, y.c));
+    let d = mul(x.a, y.a);
+    let e = mul(x.b, y.b);
+    let f = mul(x.c, y.c);
+    let g = sub(d, e);
+    F3 { a: sub(add(cc, g), f), b: sub(sub(sub(add(aa, cc), e), e), d), c: sub(bb, g) }
+}
+
+pub fn mul31(x: F3, s: u64) -> F3 {
+    F3 { a: mul(x.a, s), b: mul(x.b, s), c: mul(x.c, s) }
+}
+
+pub fn add33(x: F3, y: F3) -> F3 {
+    F3 { a: add(x.a, y.a), b: add(x.b, y.b), c: add(x.c, y.c) }
+}
+
+pub fn sub33(x: F3, y: F3) -> F3 {
+    F3 { a: sub(x.a, y.a), b: sub(x.b, y.b), c: sub(x.c, y.c) }
+}
+
+/// Generic op on values of any dim pair (1 or 3), mirroring the `cg_*` helpers.
+pub fn apply(op: &str, x: F3, xd: u64, y: F3, yd: u64) -> F3 {
+    match (op, xd, yd) {
+        ("add", _, _) => add33(x, y),
+        ("sub", _, _) => sub33(x, y),
+        ("mul", 1, 1) => F3::base(mul(x.a, y.a)),
+        ("mul", 3, 1) => mul31(x, y.a),
+        ("mul", 1, 3) => mul31(y, x.a),
+        ("mul", _, _) => mul33(x, y),
+        _ => panic!("unexpected op {op}"),
+    }
+}
+
+/// x^n by square-and-multiply.
+pub fn pow3(x: F3, n: u64) -> F3 {
+    let mut r = F3::base(1);
+    let mut b = x;
+    let mut n = n;
+    while n > 0 {
+        if n & 1 == 1 {
+            r = mul33(r, b);
+        }
+        b = mul33(b, b);
+        n >>= 1;
+    }
+    r
+}
+
+/// Tiny deterministic PRNG (splitmix64) for the equivalence check.
+pub struct Rng(pub u64);
+impl Rng {
+    pub fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    pub fn field(&mut self) -> u64 {
+        self.next() % P
+    }
+    pub fn f3(&mut self, dim: u64) -> F3 {
+        if dim == 1 {
+            F3::base(self.field())
+        } else {
+            F3 { a: self.field(), b: self.field(), c: self.field() }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mul33_matches_schoolbook_reduction() {
+        let mut r = Rng(7);
+        for _ in 0..1000 {
+            let x = r.f3(3);
+            let y = r.f3(3);
+            // schoolbook with x^3 = x + 1, x^4 = x^2 + x
+            let c0 = mul(x.a, y.a);
+            let c1 = add(mul(x.a, y.b), mul(x.b, y.a));
+            let c2 = add(add(mul(x.a, y.c), mul(x.b, y.b)), mul(x.c, y.a));
+            let c3 = add(mul(x.b, y.c), mul(x.c, y.b));
+            let c4 = mul(x.c, y.c);
+            let want = F3 { a: add(c0, c3), b: add(add(c1, c3), c4), c: add(c2, c4) };
+            assert_eq!(mul33(x, y), want);
+        }
+    }
+
+    #[test]
+    fn add_sub_roundtrip() {
+        let mut r = Rng(3);
+        for _ in 0..1000 {
+            let a = r.field();
+            let b = r.field();
+            assert_eq!(sub(add(a, b), b), a);
+            assert_eq!(add(sub(a, b), b), a);
+        }
+        assert_eq!(add(P - 1, 1), 0);
+        assert_eq!(sub(0, 1), P - 1);
+    }
+}

--- a/setup/exps-codegen/src/ir.rs
+++ b/setup/exps-codegen/src/ir.rs
@@ -9,18 +9,59 @@ use std::collections::{HashMap, HashSet};
 
 /// A resolved source operand. `dim()` is the field-extension degree (1 = base
 /// Goldilocks, 3 = cubic).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Operand {
-    Tmp { id: u64, dim: u64 },
+    Tmp {
+        id: u64,
+        dim: u64,
+    },
     Num(u64),
-    Cm { stage: u64, pos: u64, dim: u64, stride: i64 },
-    Const { id: u64, stride: i64 },
-    Custom { off: u64, pos: u64, dim: u64, ncols: u64, stride: i64 },
+    Cm {
+        stage: u64,
+        pos: u64,
+        dim: u64,
+        stride: i64,
+    },
+    Const {
+        id: u64,
+        stride: i64,
+    },
+    Custom {
+        off: u64,
+        pos: u64,
+        dim: u64,
+        ncols: u64,
+        stride: i64,
+    },
     Zi,
-    Ch { base: u64 },
-    Av { pos: u64, dim: u64 },
-    Agv { pos: u64, dim: u64 },
-    Pub { id: u64 },
+    Ch {
+        base: u64,
+    },
+    Av {
+        pos: u64,
+        dim: u64,
+    },
+    Agv {
+        pos: u64,
+        dim: u64,
+    },
+    Pub {
+        id: u64,
+    },
+    /// `ch[base..base+3]^j` (j >= 2), read from the challenge-powers table the
+    /// launcher computes once per call at the head of scratch (see `opt.rs`).
+    Pow {
+        base: u64,
+        j: u64,
+    },
+    /// Word `idx` of the hoisted-invariants table that follows the powers in
+    /// the same per-launch region: a subexpression built only from challenges,
+    /// powers, publics and air values, computed once per launch instead of
+    /// once per row (see `Ir::tab`).
+    Tab {
+        idx: u64,
+        dim: u64,
+    },
 }
 
 impl Operand {
@@ -30,8 +71,9 @@ impl Operand {
             | Operand::Cm { dim, .. }
             | Operand::Custom { dim, .. }
             | Operand::Av { dim, .. }
-            | Operand::Agv { dim, .. } => *dim,
-            Operand::Ch { .. } => 3,
+            | Operand::Agv { dim, .. }
+            | Operand::Tab { dim, .. } => *dim,
+            Operand::Ch { .. } | Operand::Pow { .. } => 3,
             Operand::Num(_) | Operand::Const { .. } | Operand::Zi | Operand::Pub { .. } => 1,
         }
     }
@@ -65,9 +107,28 @@ pub struct Ir {
     pub ncols: HashMap<u64, u64>,
     pub n_constants: u64,
     pub n_bits: u64,
+    /// Challenge-powers table the kernels read: `Some((ch_base, n))` means
+    /// `ch[ch_base..]^j` for j in 0..n (3 elems each) at the head of scratch.
+    pub pow: Option<(u64, u64)>,
+    /// Row-invariant program run once per launch (thread 0 of the table
+    /// kernel, after the powers): straight-line ops over invariant leaves and
+    /// its own tmps. `tab_out` exports tmps to table words (`Operand::Tab`):
+    /// (tmp id, word index, dim); `tab_words` is the exported size.
+    pub tab: Vec<Instr>,
+    pub tab_out: Vec<(u64, u64, u64)>,
+    pub tab_words: u64,
 }
 
 impl Ir {
+    /// Words of the powers table (3 per power).
+    pub fn pow_words(&self) -> u64 {
+        self.pow.map_or(0, |(_, n)| 3 * n)
+    }
+    /// Total per-launch table words carved off the head of scratch.
+    pub fn table_words(&self) -> u64 {
+        self.pow_words() + self.tab_words
+    }
+
     pub fn uses_zi(&self) -> bool {
         self.instrs.iter().any(|i| matches!(i.a, Operand::Zi) || matches!(i.b, Operand::Zi))
     }
@@ -236,13 +297,23 @@ pub fn build_ir_expr(
             idx,
         });
     }
-    Ok(Ir { instrs, ncols, n_constants, n_bits: stark_info.stark_struct.n_bits })
+    Ok(Ir {
+        instrs,
+        ncols,
+        n_constants,
+        n_bits: stark_info.stark_struct.n_bits,
+        pow: None,
+        tab: Vec::new(),
+        tab_out: Vec::new(),
+        tab_words: 0,
+    })
 }
 
 /// Liveness + chunking + scratch-slot coloring for one chunk size.
 pub struct ChunkPlan {
-    pub chunk: usize,
     pub n_chunks: usize,
+    /// Chunk i covers ops `bounds[i]..bounds[i+1]`; len = n_chunks + 1.
+    pub bounds: Vec<usize>,
     pub out_dim: u64,
     pub def_idx: HashMap<u64, usize>,
     pub dim_of: HashMap<u64, u64>,
@@ -253,7 +324,10 @@ pub struct ChunkPlan {
 
 impl ChunkPlan {
     pub fn chunk_of(&self, op_idx: usize) -> usize {
-        op_idx / self.chunk
+        chunk_of_bounds(&self.bounds, op_idx)
+    }
+    pub fn range(&self, chunk_idx: usize) -> (usize, usize) {
+        (self.bounds[chunk_idx], self.bounds[chunk_idx + 1])
     }
     pub fn slot_index(&self, t: u64) -> u64 {
         self.slot_index[&t]
@@ -262,6 +336,71 @@ impl ChunkPlan {
 
 /// Build the liveness/chunk/coloring plan for `ir` at the given chunk size.
 /// `sym` is only used in the SSA-violation error message.
+/// Index of the chunk containing `op_idx` for sorted `bounds` (bounds[0] = 0).
+pub fn chunk_of_bounds(bounds: &[usize], op_idx: usize) -> usize {
+    // number of starts <= op_idx, minus one
+    bounds.partition_point(|&b| b <= op_idx) - 1
+}
+
+/// Choose chunk boundaries minimizing the scratch words crossing them.
+/// `cross[p]` = words of temps defined before op p and last used at or after
+/// it; a cut at p costs cross[p] + CUT_PENALTY (a kernel launch per wave and
+/// the load/store pair around it), chunks are at most `max_chunk` ops.
+/// DP over positions, O(n_ops * max_chunk).
+fn adaptive_bounds(
+    n_ops: usize,
+    max_chunk: usize,
+    def_idx: &HashMap<u64, usize>,
+    last_use: &HashMap<u64, usize>,
+    dim_of: &HashMap<u64, u64>,
+) -> Vec<usize> {
+    const CUT_PENALTY: u64 = 2;
+    // difference array: temp t crosses every boundary p with def < p <= last_use
+    let mut diff = vec![0i64; n_ops + 2];
+    for (&t, &d) in def_idx {
+        if let Some(&lu) = last_use.get(&t) {
+            if lu > d {
+                let w = dim_of.get(&t).copied().unwrap_or(1) as i64;
+                diff[d + 1] += w;
+                diff[lu + 1] -= w;
+            }
+        }
+    }
+    let mut cross = vec![0u64; n_ops + 1];
+    let mut acc = 0i64;
+    for p in 0..=n_ops {
+        acc += diff[p];
+        cross[p] = acc.max(0) as u64;
+    }
+    // best[p] = min cost of cutting ops [0, p) into chunks (cut at p included, except p = n_ops)
+    let inf = u64::MAX / 4;
+    let mut best = vec![inf; n_ops + 1];
+    let mut prev = vec![usize::MAX; n_ops + 1];
+    best[0] = 0;
+    for p in 1..=n_ops {
+        let cut_cost = if p == n_ops { 0 } else { cross[p] + CUT_PENALTY };
+        let lo = p.saturating_sub(max_chunk);
+        let mut bq = inf;
+        let mut bi = usize::MAX;
+        for (off, &b) in best[lo..p].iter().enumerate() {
+            if b < bq {
+                bq = b;
+                bi = lo + off;
+            }
+        }
+        best[p] = bq + cut_cost;
+        prev[p] = bi;
+    }
+    let mut bounds = vec![n_ops];
+    let mut p = n_ops;
+    while p > 0 {
+        p = prev[p];
+        bounds.push(p);
+    }
+    bounds.reverse();
+    bounds
+}
+
 pub fn plan_chunks(ir: &Ir, chunk_req: usize, sym: &str) -> anyhow::Result<ChunkPlan> {
     let n_ops = ir.instrs.len();
 
@@ -288,8 +427,20 @@ pub fn plan_chunks(ir: &Ir, chunk_req: usize, sym: &str) -> anyhow::Result<Chunk
     }
 
     let chunk = chunk_req.clamp(1, n_ops.max(1));
-    let n_chunks = n_ops.div_ceil(chunk);
-    let chunk_of = |op_idx: usize| op_idx / chunk;
+    // Cut points. Fixed every `chunk` ops, or (default) placed where few values
+    // are live: every temp alive across a boundary costs a scratch slot word per
+    // row and shrinks the launcher grid, so boundaries belong at the live-range
+    // minima, subject to each chunk staying within the spill-free size.
+    let adaptive = std::env::var("EXPS_ADAPTIVE_CHUNKS").map_or(true, |v| v != "0");
+    let bounds: Vec<usize> = if adaptive && n_ops > chunk {
+        adaptive_bounds(n_ops, chunk, &def_idx, &last_use, &dim_of)
+    } else {
+        let mut b: Vec<usize> = (0..n_ops).step_by(chunk).collect();
+        b.push(n_ops);
+        b
+    };
+    let n_chunks = bounds.len() - 1;
+    let chunk_of = |op_idx: usize| chunk_of_bounds(&bounds, op_idx);
 
     let mut out_dim = 3u64;
     for instr in &ir.instrs {
@@ -350,5 +501,5 @@ pub fn plan_chunks(ir: &Ir, chunk_req: usize, sym: &str) -> anyhow::Result<Chunk
         slot_index.insert(t, s);
     }
 
-    Ok(ChunkPlan { chunk, n_chunks, out_dim, def_idx, dim_of, cut_temps, total_slots, slot_index })
+    Ok(ChunkPlan { n_chunks, bounds, out_dim, def_idx, dim_of, cut_temps, total_slots, slot_index })
 }

--- a/setup/exps-codegen/src/ir.rs
+++ b/setup/exps-codegen/src/ir.rs
@@ -119,6 +119,10 @@ pub struct Ir {
     pub tab: Vec<Instr>,
     pub tab_out: Vec<(u64, u64, u64)>,
     pub tab_words: u64,
+    /// Standalone (non-Q) expression kernels have no scratch table: their
+    /// challenge powers are computed once per thread into registers in the
+    /// kernel prologue instead, and `Operand::Pow` reads `pwreg_<base>_<j>`.
+    pub pow_in_regs: bool,
 }
 
 impl Ir {
@@ -312,6 +316,7 @@ pub fn build_ir_expr(
         tab: Vec::new(),
         tab_out: Vec::new(),
         tab_words: 0,
+        pow_in_regs: false,
     })
 }
 

--- a/setup/exps-codegen/src/ir.rs
+++ b/setup/exps-codegen/src/ir.rs
@@ -297,6 +297,16 @@ pub fn build_ir_expr(
 
     let mut instrs = Vec::with_capacity(code.len());
     for (idx, step) in code.iter().enumerate() {
+        // Only the binary field ops are modelled (by the emitter, the optimizer
+        // and the host evaluator alike); anything else leaves the AIR on the
+        // interpreter instead of failing deep inside a pass.
+        if !matches!(step.op.as_str(), "add" | "sub" | "mul") || step.src.len() != 2 {
+            return Err(anyhow::Error::new(UnhandledOperand(format!(
+                "op {} with {} operands",
+                step.op,
+                step.src.len()
+            ))));
+        }
         instrs.push(Instr {
             op: step.op.clone(),
             a: operand(&step.src[0])?,
@@ -345,8 +355,6 @@ impl ChunkPlan {
     }
 }
 
-/// Build the liveness/chunk/coloring plan for `ir` at the given chunk size.
-/// `sym` is only used in the SSA-violation error message.
 /// Index of the chunk containing `op_idx` for sorted `bounds` (bounds[0] = 0).
 pub fn chunk_of_bounds(bounds: &[usize], op_idx: usize) -> usize {
     // number of starts <= op_idx, minus one
@@ -412,6 +420,8 @@ fn adaptive_bounds(
     bounds
 }
 
+/// Build the liveness/chunk/coloring plan for `ir` at the given chunk size.
+/// `sym` is only used in the SSA-violation error message.
 pub fn plan_chunks(ir: &Ir, chunk_req: usize, sym: &str) -> anyhow::Result<ChunkPlan> {
     let n_ops = ir.instrs.len();
 

--- a/setup/exps-codegen/src/ir.rs
+++ b/setup/exps-codegen/src/ir.rs
@@ -107,9 +107,11 @@ pub struct Ir {
     pub ncols: HashMap<u64, u64>,
     pub n_constants: u64,
     pub n_bits: u64,
-    /// Challenge-powers table the kernels read: `Some((ch_base, n))` means
-    /// `ch[ch_base..]^j` for j in 0..n (3 elems each) at the head of scratch.
-    pub pow: Option<(u64, u64)>,
+    /// Challenge-powers table the kernels read, one region per challenge and
+    /// sorted by base: `(ch_base, n)` means `ch[ch_base..]^j` for j in 0..n
+    /// (3 elems each). The regions sit end to end at the head of scratch, so a
+    /// challenge's region starts at `pow_offset(ch_base)`.
+    pub pow: Vec<(u64, u64)>,
     /// Row-invariant program run once per launch (thread 0 of the table
     /// kernel, after the powers): straight-line ops over invariant leaves and
     /// its own tmps. `tab_out` exports tmps to table words (`Operand::Tab`):
@@ -120,9 +122,13 @@ pub struct Ir {
 }
 
 impl Ir {
-    /// Words of the powers table (3 per power).
+    /// Words of the powers table (3 per power, summed over the challenges).
     pub fn pow_words(&self) -> u64 {
-        self.pow.map_or(0, |(_, n)| 3 * n)
+        self.pow.iter().map(|&(_, n)| 3 * n).sum()
+    }
+    /// Word offset of `base`'s region inside the powers table.
+    pub fn pow_offset(&self, base: u64) -> u64 {
+        self.pow.iter().take_while(|&&(b, _)| b != base).map(|&(_, n)| 3 * n).sum()
     }
     /// Total per-launch table words carved off the head of scratch.
     pub fn table_words(&self) -> u64 {
@@ -302,7 +308,7 @@ pub fn build_ir_expr(
         ncols,
         n_constants,
         n_bits: stark_info.stark_struct.n_bits,
-        pow: None,
+        pow: Vec::new(),
         tab: Vec::new(),
         tab_out: Vec::new(),
         tab_words: 0,

--- a/setup/exps-codegen/src/lib.rs
+++ b/setup/exps-codegen/src/lib.rs
@@ -314,7 +314,7 @@ fn optimize_checked(ir: ir::Ir, c: &Candidate, cfg: &GenConfig) -> std::result::
     let (nc0, s0) = slots(&ir);
     let (nc1, s1) = slots(&opt);
     eprintln!(
-        "[exps-codegen] {}: ops {} -> {} ({:.1}%), cost {} -> {} ({:.1}%), horner terms {}, max live {} -> {}, remat {}, hoisted {} ops -> {} words, ltd {} terms/{} atoms, chunks {} -> {}, slots {} -> {}",
+        "[exps-codegen] {}: ops {} -> {} ({:.1}%), cost {} -> {} ({:.1}%), horner terms {}, max live {} -> {}, remat {}, hoisted {} ops -> {} words, inner {}{}, ltd {} terms/{} atoms, chunks {} -> {}, slots {} -> {}",
         c.name,
         st.ops_before,
         st.ops_after,
@@ -328,6 +328,8 @@ fn optimize_checked(ir: ir::Ir, c: &Candidate, cfg: &GenConfig) -> std::result::
         st.remat,
         st.tab_ops,
         st.tab_words,
+        st.inner_chains,
+        if st.inner_selected { " (fold)" } else { " (no fold)" },
         st.ltd_terms,
         st.ltd_atoms,
         nc0,
@@ -433,14 +435,30 @@ fn run_pipeline(
                 // EXPS_X_STATS=1: what the Q optimizer would do to this non-Q
                 // expression (equivalence-checked), to size that opportunity.
                 if std::env::var("EXPS_X_STATS").is_ok() {
-                    let xh = std::env::var("EXPS_X_HOIST").is_ok(); // stats only: no table in _x kernels yet
-                    let (o, st) = opt::optimize_opts(&eir, xh, false);
+                    // stats mirror the generated kernel: powers in registers, no hoisting
+                    let xh = std::env::var("EXPS_X_HOIST").is_ok();
+                    let (o, st) = opt::optimize_opts(&eir, xh, true);
                     let ok = check::equivalent(&eir, &o, 3).is_ok();
                     eprintln!(
                         "[exps-x-stats] {} x{}: ops {} -> {}, cost {} -> {}, live {} -> {}, hoisted {} ops -> {} words, equiv {}",
                         c.name, ec.exp_id, st.ops_before, st.ops_after, st.cost_before, st.cost_after, st.max_live_before, st.max_live_after, st.tab_ops, st.tab_words, ok
                     );
                 }
+                // Optimize the standalone expression too (inner-chain fold with the
+                // powers kept in registers, CSE, scheduling; no hoisting: no table).
+                // Equivalence-gated exactly like Q; on mismatch the original is kept.
+                let eir = if cfg.optimize && std::env::var("EXPS_X_OPT").map_or(true, |v| v != "0") {
+                    let (mut o, _st) = opt::optimize_opts(&eir, false, true);
+                    if check::equivalent(&eir, &o, 3).is_ok() {
+                        o.pow_in_regs = true;
+                        o
+                    } else {
+                        eprintln!("[exps-codegen] {} x{}: OPTIMIZED IR MISMATCH; keeping the setup's expression", c.name, ec.exp_id);
+                        eir
+                    }
+                } else {
+                    eir
+                };
                 items.push((ec.exp_id, eir, od));
             }
             if !items.is_empty() {

--- a/setup/exps-codegen/src/lib.rs
+++ b/setup/exps-codegen/src/lib.rs
@@ -17,9 +17,12 @@
 //! * [`generate_all`]  — a provingKey dir -> every AIR's `.exps.so`.
 
 mod autotune;
+mod check;
 mod emit;
+mod field;
 mod ir;
 mod model;
+mod opt;
 mod toolchain;
 
 use anyhow::{Context, Result};
@@ -50,6 +53,9 @@ pub struct GenConfig {
     /// provingKey is untouched). Requires `keep_dir`. Used for inspecting the
     /// generated sources.
     pub dry_run: bool,
+    /// Run the Q IR optimizer (CSE, Horner→powers, scheduling; see `opt.rs`).
+    /// `false` emits the expression exactly as the setup wrote it (A/B baseline).
+    pub optimize: bool,
 }
 
 impl Default for GenConfig {
@@ -61,6 +67,7 @@ impl Default for GenConfig {
             stark_src: None,
             keep_dir: None,
             dry_run: false,
+            optimize: true,
         }
     }
 }
@@ -267,6 +274,70 @@ pub fn generate_air(air_dir: &Path, cfg: &GenConfig) -> Result<PathBuf> {
     }
 }
 
+/// Optimize the Q IR and prove the result equivalent to the original on random
+/// inputs. A mismatch is a generator bug: the AIR is skipped loudly rather than
+/// emitted (the prover falls back to the interpreter for it).
+fn optimize_checked(ir: ir::Ir, c: &Candidate, cfg: &GenConfig) -> std::result::Result<ir::Ir, String> {
+    if !cfg.optimize {
+        return Ok(ir);
+    }
+    let (opt, st) = opt::optimize(&ir);
+    if let Err(e) = check::equivalent(&ir, &opt, 3) {
+        eprintln!("[exps-codegen] {}: OPTIMIZED IR MISMATCH — {e}; skipping", c.name);
+        return Err("optimizer self-check failed".to_string());
+    }
+    // Decline the optimized IR when CSE inflates live pressure without a large
+    // arithmetic win. Measured (aggregation mode, 66-tx block): recursive2 with
+    // live 40->223 and cost 84% ran +48% slower, the compressors (58->185, 77%)
+    // +21%, vadcop_final (40->223, 75%) +34%; Keccakf (453->349, 76%) ran -35%
+    // and ArithEq (55->92, 39%) -22%. Slots, not ops, decide for those shapes.
+    // Absolute floor: a jump from 5 to 11 live values is free (Dma64AlignedMemCpy
+    // measured -14%); the regressions all sat at 185-223 live, i.e. far past what
+    // a chunk can hold in registers, where every extra value is a scratch slot.
+    let live_ratio = st.max_live_after as f64 / st.max_live_before.max(1) as f64;
+    let cost_ratio = st.cost_after as f64 / st.cost_before.max(1) as f64;
+    let decline =
+        std::env::var("EXPS_NO_DECLINE").is_err() && live_ratio > 2.0 && st.max_live_after > 64 && cost_ratio > 0.5;
+    if decline {
+        eprintln!(
+            "[exps-codegen] {}: optimizer DECLINED (max live {} -> {}, cost {:.1}%): keeping the setup's expression",
+            c.name,
+            st.max_live_before,
+            st.max_live_after,
+            100.0 * cost_ratio
+        );
+        return Ok(ir);
+    }
+    // cross-chunk slots at the dry-run chunk size (or the default), before/after
+    let chunk = cfg.chunk.unwrap_or(DEFAULT_CHUNK);
+    let slots = |x: &ir::Ir| ir::plan_chunks(x, chunk, &c.sym).map(|p| (p.n_chunks, p.total_slots)).unwrap_or((0, 0));
+    let (nc0, s0) = slots(&ir);
+    let (nc1, s1) = slots(&opt);
+    eprintln!(
+        "[exps-codegen] {}: ops {} -> {} ({:.1}%), cost {} -> {} ({:.1}%), horner terms {}, max live {} -> {}, remat {}, hoisted {} ops -> {} words, ltd {} terms/{} atoms, chunks {} -> {}, slots {} -> {}",
+        c.name,
+        st.ops_before,
+        st.ops_after,
+        100.0 * st.ops_after as f64 / st.ops_before.max(1) as f64,
+        st.cost_before,
+        st.cost_after,
+        100.0 * st.cost_after as f64 / st.cost_before.max(1) as f64,
+        st.horner_terms,
+        st.max_live_before,
+        st.max_live_after,
+        st.remat,
+        st.tab_ops,
+        st.tab_words,
+        st.ltd_terms,
+        st.ltd_atoms,
+        nc0,
+        nc1,
+        s0,
+        s1
+    );
+    Ok(opt)
+}
+
 fn run_pipeline(
     tc: &Toolchain,
     work: &Path,
@@ -279,10 +350,10 @@ fn run_pipeline(
     // Build IR for every candidate (catches unhandled operands here). Each entry
     // is (candidate, Ok(ir) | Err(skip-reason)).
     let built: Vec<(&Candidate, std::result::Result<ir::Ir, String>)> = candidates
-        .iter()
+        .par_iter()
         .map(|c| {
             let r = match ir::build_ir(&c.stark_info, &c.expr_info) {
-                Ok(ir) => Ok(ir),
+                Ok(ir) => optimize_checked(ir, c, cfg),
                 Err(e) if e.downcast_ref::<UnhandledOperand>().is_some() => Err("unhandled operand".to_string()),
                 Err(e) => Err(format!("build_ir error: {e}")),
             };
@@ -358,6 +429,17 @@ fn run_pipeline(
                 let Some(od) = eir.out_dim() else { continue };
                 if od != 1 && od != 3 {
                     continue;
+                }
+                // EXPS_X_STATS=1: what the Q optimizer would do to this non-Q
+                // expression (equivalence-checked), to size that opportunity.
+                if std::env::var("EXPS_X_STATS").is_ok() {
+                    let xh = std::env::var("EXPS_X_HOIST").is_ok(); // stats only: no table in _x kernels yet
+                    let (o, st) = opt::optimize_opts(&eir, xh, false);
+                    let ok = check::equivalent(&eir, &o, 3).is_ok();
+                    eprintln!(
+                        "[exps-x-stats] {} x{}: ops {} -> {}, cost {} -> {}, live {} -> {}, hoisted {} ops -> {} words, equiv {}",
+                        c.name, ec.exp_id, st.ops_before, st.ops_after, st.cost_before, st.cost_after, st.max_live_before, st.max_live_after, st.tab_ops, st.tab_words, ok
+                    );
                 }
                 items.push((ec.exp_id, eir, od));
             }

--- a/setup/exps-codegen/src/lib.rs
+++ b/setup/exps-codegen/src/lib.rs
@@ -36,7 +36,7 @@ const DEFAULT_CAP: usize = 40000; // skip an AIR whose Q has more ops than this
 const DEFAULT_CHUNK: usize = 512; // fixed ops/chunk when autotuning is off
 const SLOTS_CAP: u64 = 1000; // skip an AIR whose cross-chunk cut exceeds this
 
-/// Codegen configuration. Defaults: CAP=40000, autotune on, arch=auto.
+/// Codegen configuration (the CLI defaults: cap 60000, autotune on, arch auto, optimizer on).
 #[derive(Debug, Clone)]
 pub struct GenConfig {
     /// Skip an AIR whose Q has more than this many ops (-> interpreter).
@@ -296,8 +296,10 @@ fn optimize_checked(ir: ir::Ir, c: &Candidate, cfg: &GenConfig) -> std::result::
     // a chunk can hold in registers, where every extra value is a scratch slot.
     let live_ratio = st.max_live_after as f64 / st.max_live_before.max(1) as f64;
     let cost_ratio = st.cost_after as f64 / st.cost_before.max(1) as f64;
-    let decline =
-        std::env::var("EXPS_NO_DECLINE").is_err() && live_ratio > 2.0 && st.max_live_after > 64 && cost_ratio > 0.5;
+    let decline = !std::env::var("EXPS_NO_DECLINE").is_ok_and(|v| v != "0")
+        && live_ratio > 2.0
+        && st.max_live_after > 64
+        && cost_ratio > 0.5;
     if decline {
         eprintln!(
             "[exps-codegen] {}: optimizer DECLINED (max live {} -> {}, cost {:.1}%): keeping the setup's expression",
@@ -379,7 +381,6 @@ fn run_pipeline(
 
     // Phase 3: emit the .cu sources; record per-sym slot counts.
     let mut slots_by_sym: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
-    let mut exprs_by_sym: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let mut generated: Vec<GeneratedAir> = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     let mut max_scratch: u64 = 0;
@@ -402,7 +403,13 @@ fn run_pipeline(
         } else {
             cfg.chunk.unwrap_or(DEFAULT_CHUNK)
         };
-        let plan = plan_chunks(ir, chunk, &c.sym)?;
+        let plan = match plan_chunks(ir, chunk, &c.sym) {
+            Ok(p) => p,
+            Err(why) => {
+                skipped.push((c.name.clone(), format!("chunk plan failed: {why}")));
+                continue;
+            }
+        };
         if plan.total_slots > SLOTS_CAP {
             skipped.push((c.name.clone(), format!("slots {} > SLOTS_CAP (wide cut)", plan.total_slots)));
             continue;
@@ -432,28 +439,19 @@ fn run_pipeline(
                 if od != 1 && od != 3 {
                     continue;
                 }
-                // EXPS_X_STATS=1: what the Q optimizer would do to this non-Q
-                // expression (equivalence-checked), to size that opportunity.
-                if std::env::var("EXPS_X_STATS").is_ok() {
-                    // stats mirror the generated kernel: powers in registers, no hoisting
-                    let xh = std::env::var("EXPS_X_HOIST").is_ok();
-                    let (o, st) = opt::optimize_opts(&eir, xh, true);
-                    let ok = check::equivalent(&eir, &o, 3).is_ok();
-                    eprintln!(
-                        "[exps-x-stats] {} x{}: ops {} -> {}, cost {} -> {}, live {} -> {}, hoisted {} ops -> {} words, equiv {}",
-                        c.name, ec.exp_id, st.ops_before, st.ops_after, st.cost_before, st.cost_after, st.max_live_before, st.max_live_after, st.tab_ops, st.tab_words, ok
-                    );
-                }
                 // Optimize the standalone expression too (inner-chain fold with the
                 // powers kept in registers, CSE, scheduling; no hoisting: no table).
                 // Equivalence-gated exactly like Q; on mismatch the original is kept.
-                let eir = if cfg.optimize && std::env::var("EXPS_X_OPT").map_or(true, |v| v != "0") {
+                let eir = if cfg.optimize && std::env::var("EXPS_X_OPT").ok().is_none_or(|v| v != "0") {
                     let (mut o, _st) = opt::optimize_opts(&eir, false, true);
                     if check::equivalent(&eir, &o, 3).is_ok() {
                         o.pow_in_regs = true;
                         o
                     } else {
-                        eprintln!("[exps-codegen] {} x{}: OPTIMIZED IR MISMATCH; keeping the setup's expression", c.name, ec.exp_id);
+                        eprintln!(
+                            "[exps-codegen] {} x{}: OPTIMIZED IR MISMATCH; keeping the setup's expression",
+                            c.name, ec.exp_id
+                        );
                         eir
                     }
                 } else {
@@ -462,9 +460,7 @@ fn run_pipeline(
                 items.push((ec.exp_id, eir, od));
             }
             if !items.is_empty() {
-                let n_exprs = items.len();
                 std::fs::write(work.join(format!("gen_{}_cexprs.cu", c.sym)), emit::emit_exprs_tu(&c.sym, &items))?;
-                exprs_by_sym.insert(c.sym.clone(), n_exprs);
             }
         }
         let n_ext = 1u64 << c.stark_info.stark_struct.n_bits_ext;
@@ -621,9 +617,14 @@ impl WorkDir {
                 use std::sync::atomic::{AtomicU64, Ordering};
                 static SEQ: AtomicU64 = AtomicU64::new(0);
                 let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-                let p = std::env::temp_dir().join(format!("genexps_{}_{}", std::process::id(), seq));
-                let _ = std::fs::remove_dir_all(&p);
-                std::fs::create_dir_all(&p)?;
+                // Fresh directory, never a pre-existing path: `create_dir` fails if
+                // something (a leftover or a planted symlink) is already there.
+                let nanos = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.subsec_nanos())
+                    .unwrap_or(0);
+                let p = std::env::temp_dir().join(format!("genexps_{}_{}_{}", std::process::id(), seq, nanos));
+                std::fs::create_dir(&p).with_context(|| format!("creating work dir {}", p.display()))?;
                 Ok(WorkDir { path: p, temp: true })
             }
         }

--- a/setup/exps-codegen/src/lib.rs
+++ b/setup/exps-codegen/src/lib.rs
@@ -25,6 +25,8 @@ mod model;
 mod opt;
 mod toolchain;
 
+pub use toolchain::nvcc_present;
+
 use anyhow::{Context, Result};
 use ir::{plan_chunks, UnhandledOperand};
 use model::{ExpressionsInfo, StarkInfo};

--- a/setup/exps-codegen/src/opt.rs
+++ b/setup/exps-codegen/src/opt.rs
@@ -1616,69 +1616,18 @@ fn linearize(
 /// recomputed for that use instead of kept live.
 const REMAT_WINDOW: usize = 64;
 const REMAT_COST_MAX: u64 = 16;
-/// Max Op nodes one clone may duplicate. Overridable while tuning.
+/// Max Op nodes one clone may duplicate.
 const REMAT_OPS_MAX: usize = 3;
-/// Far tier (EXPS_REMAT_FAR_WINDOW / _COST_MAX / _OPS_MAX): users this far
-/// apart justify a costlier clone. 0 window disables the tier.
-const REMAT_FAR_COST_MAX: u64 = 64;
-const REMAT_FAR_OPS_MAX: usize = 12;
-
-fn env_usize(k: &str, d: usize) -> usize {
-    std::env::var(k).ok().and_then(|v| v.parse().ok()).unwrap_or(d)
-}
-fn env_u64(k: &str, d: u64) -> u64 {
-    std::env::var(k).ok().and_then(|v| v.parse().ok()).unwrap_or(d)
-}
-
 /// Tail of the pipeline for a fixed root: rematerialize far-apart cheap
 /// shared values (twice: clones can expose new far-apart users), then keep the
-/// candidate schedule with the lowest max-live. Returns (order, clones made,
+/// candidate schedule with the lowest max-live. (A costlier "far" remat tier
+/// was tried and measured worse: Keccakf 266 -> 447 ms/proof, issue-bound.) Returns (order, clones made,
 /// max-live, schedule name).
 fn finish(dag: &mut Dag, root: NodeId) -> (Vec<NodeId>, usize, usize, &'static str) {
-    // The far remat tier is tried as a second candidate on a DAG copy and kept
-    // only if it lowers the final max-live (Keccakf: 349 -> 39 for +5% cost,
-    // and ncu shows that kernel is memory-bound, so slots matter more than
-    // ops; the compressor gets worse with it and keeps the near tier only).
-    // EXPS_REMAT_FAR_WINDOW forces: 0 = never, N = always with window N.
-    let forced = std::env::var("EXPS_REMAT_FAR_WINDOW").ok().and_then(|v| v.parse::<usize>().ok());
-    // Default: near tier only. Measured on the GPU (221-tx block): the far tier
-    // took Keccakf from 266 to 447 ms/proof (+42% ops outweighed the slot
-    // saving -- the kernel is issue-bound), so the live-based pick was wrong.
-    let try_far = match forced {
-        Some(0) | None => vec![false],
-        Some(_) => vec![true],
-    };
-    let mut best: Option<(Vec<NodeId>, usize, usize, &'static str, Dag)> = None;
-    for far in try_far {
-        let mut d2 = dag.clone();
-        let (o, rm, live, sw) = finish_with(&mut d2, root, far);
-        let better = best.as_ref().is_none_or(|(bo, _, bl, _, _)| (live, o.len()) < (*bl, bo.len()));
-        if better {
-            best = Some((o, rm, live, if far { "far" } else { sw }, d2));
-        }
-    }
-    let (o, rm, live, sw, d2) = best.unwrap();
-    *dag = d2;
-    (o, rm, live, sw)
-}
-
-fn finish_with(dag: &mut Dag, root: NodeId, far: bool) -> (Vec<NodeId>, usize, usize, &'static str) {
     let mut order = schedule_seq(&sequence(dag, root));
     let mut remat = 0usize;
     for _ in 0..2 {
-        let mut tiers = vec![RematTier {
-            window: env_usize("EXPS_REMAT_WINDOW", REMAT_WINDOW),
-            cost_max: env_u64("EXPS_REMAT_COST_MAX", REMAT_COST_MAX),
-            ops_max: env_usize("EXPS_REMAT_OPS_MAX", REMAT_OPS_MAX),
-        }];
-        if far {
-            let far_window = env_usize("EXPS_REMAT_FAR_WINDOW", 1024);
-            tiers.push(RematTier {
-                window: far_window.max(1),
-                cost_max: env_u64("EXPS_REMAT_FAR_COST_MAX", REMAT_FAR_COST_MAX),
-                ops_max: env_usize("EXPS_REMAT_FAR_OPS_MAX", REMAT_FAR_OPS_MAX),
-            });
-        }
+        let tiers = [RematTier { window: REMAT_WINDOW, cost_max: REMAT_COST_MAX, ops_max: REMAT_OPS_MAX }];
         let n = rematerialize(dag, root, &order, &tiers);
         remat += n;
         order = schedule_seq(&sequence(dag, root));

--- a/setup/exps-codegen/src/opt.rs
+++ b/setup/exps-codegen/src/opt.rs
@@ -1,0 +1,1677 @@
+//! Semantics-preserving optimization of the Q expression IR.
+//!
+//! 1. **CSE** — hash-consed DAG (value numbering) with commutative
+//!    canonicalization of `add`/`mul` and folding of number-only ops.
+//! 2. **Horner → powers** — the constraint combination `acc = vc·acc + cᵢ`
+//!    is rewritten as `Σ vcʲ·cᵢ` with `vcʲ` read from a per-launch powers
+//!    table (`Operand::Pow`). A base-field constraint then costs a `mul13`
+//!    instead of a `mul33`, and the terms become order-independent.
+//! 3. **Term clustering** — terms are ordered greedily so consecutive terms
+//!    share as many subtrees/columns as possible.
+//! 4. **Rematerialization** — shared single-op-on-leaves values whose uses
+//!    are far apart in that order are duplicated instead of kept live.
+//! 5. **List scheduling** — topological order that prefers ops freeing
+//!    registers, tie-broken by the clustered order.
+//!
+//! Field arithmetic is exact, so any topological order of the DAG computes
+//! the same value; `check::equivalent` verifies every output anyway.
+
+use crate::field;
+use crate::ir::{Instr, Ir, Operand};
+use std::collections::{BinaryHeap, HashMap, HashSet};
+
+type NodeId = usize;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum Kind {
+    Leaf(Operand),
+    Op { op: u8, a: NodeId, b: NodeId },
+}
+
+const ADD: u8 = 0;
+const SUB: u8 = 1;
+const MUL: u8 = 2;
+
+fn op_code(op: &str) -> u8 {
+    match op {
+        "add" => ADD,
+        "sub" => SUB,
+        "mul" => MUL,
+        other => panic!("unexpected op {other}"),
+    }
+}
+fn op_name(code: u8) -> &'static str {
+    match code {
+        ADD => "add",
+        SUB => "sub",
+        _ => "mul",
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Node {
+    kind: Kind,
+    dim: u64,
+}
+
+#[derive(Clone)]
+struct Dag {
+    nodes: Vec<Node>,
+    memo: HashMap<Kind, NodeId>,
+}
+
+impl Dag {
+    fn new() -> Self {
+        Dag { nodes: Vec::new(), memo: HashMap::new() }
+    }
+    fn intern(&mut self, kind: Kind, dim: u64) -> NodeId {
+        if let Some(&id) = self.memo.get(&kind) {
+            return id;
+        }
+        let id = self.nodes.len();
+        self.nodes.push(Node { kind: kind.clone(), dim });
+        self.memo.insert(kind, id);
+        id
+    }
+    fn leaf(&mut self, opnd: &Operand) -> NodeId {
+        let dim = opnd.dim();
+        self.intern(Kind::Leaf(opnd.clone()), dim)
+    }
+    fn num(&self, id: NodeId) -> Option<u64> {
+        match &self.nodes[id].kind {
+            Kind::Leaf(Operand::Num(v)) => Some(*v),
+            _ => None,
+        }
+    }
+    fn op(&mut self, op: u8, a: NodeId, b: NodeId) -> NodeId {
+        if let (Some(x), Some(y)) = (self.num(a), self.num(b)) {
+            let v = match op {
+                ADD => field::add(x, y),
+                SUB => field::sub(x, y),
+                _ => field::mul(x, y),
+            };
+            return self.leaf(&Operand::Num(v));
+        }
+        let (a, b) = if op != SUB && b < a { (b, a) } else { (a, b) };
+        let dim = self.nodes[a].dim.max(self.nodes[b].dim);
+        self.intern(Kind::Op { op, a, b }, dim)
+    }
+    fn children(&self, id: NodeId) -> Option<(NodeId, NodeId)> {
+        match self.nodes[id].kind {
+            Kind::Op { a, b, .. } => Some((a, b)),
+            _ => None,
+        }
+    }
+    fn is_leaf(&self, id: NodeId) -> bool {
+        matches!(self.nodes[id].kind, Kind::Leaf(_))
+    }
+}
+
+/// Summary of what the optimizer did to one expression.
+#[derive(Debug, Clone, Default)]
+pub struct OptStats {
+    pub ops_before: usize,
+    pub ops_after: usize,
+    pub cost_before: u64,
+    pub cost_after: u64,
+    pub horner_terms: usize,
+    pub max_live_before: usize,
+    pub max_live_after: usize,
+    pub remat: usize,
+    /// ops moved to the once-per-launch table program, and table words exported
+    pub tab_ops: usize,
+    pub tab_words: u64,
+    /// linear-term distribution: affine Horner terms rewritten, distinct atoms
+    pub ltd_terms: usize,
+    pub ltd_atoms: usize,
+}
+
+/// Rough instruction cost of one op by operand dims, for reporting only.
+fn cost(op: u8, ad: u64, bd: u64) -> u64 {
+    match (op, ad, bd) {
+        (MUL, 1, 1) => 4,
+        (MUL, 3, 3) => 40,
+        (MUL, _, _) => 12,
+        (_, 3, 3) => 3,
+        _ => 1,
+    }
+}
+
+fn ir_cost(ir: &Ir) -> u64 {
+    ir.instrs.iter().map(|i| cost(op_code(&i.op), i.a.dim(), i.b.dim())).sum()
+}
+
+/// Max number of simultaneously live tmps in a straight-line IR.
+fn max_live(ir: &Ir) -> usize {
+    let mut last_use: HashMap<u64, usize> = HashMap::new();
+    for (i, ins) in ir.instrs.iter().enumerate() {
+        for o in [&ins.a, &ins.b] {
+            if let Some((t, _)) = o.as_tmp() {
+                last_use.insert(t, i);
+            }
+        }
+    }
+    let mut live = 0usize;
+    let mut best = 0usize;
+    let mut dies_at: HashMap<usize, usize> = HashMap::new();
+    for (i, ins) in ir.instrs.iter().enumerate() {
+        live = live.saturating_sub(dies_at.remove(&i).unwrap_or(0));
+        if ins.dst_is_tmp {
+            let t = ins.dst_id.unwrap();
+            match last_use.get(&t) {
+                Some(&lu) if lu > i => {
+                    live += 1;
+                    *dies_at.entry(lu).or_default() += 1;
+                }
+                _ => {}
+            }
+        }
+        best = best.max(live);
+    }
+    best
+}
+
+/// Build the hash-consed DAG from SSA straight-line IR. Returns the output
+/// node, or `None` if the IR is not a single-output expression.
+fn build_dag(ir: &Ir) -> Option<(Dag, NodeId)> {
+    let mut dag = Dag::new();
+    let mut tmp: HashMap<u64, NodeId> = HashMap::new();
+    let mut out: Option<NodeId> = None;
+    let n = ir.instrs.len();
+    for (i, ins) in ir.instrs.iter().enumerate() {
+        let resolve = |dag: &mut Dag, o: &Operand| -> Option<NodeId> {
+            match o {
+                Operand::Tmp { id, .. } => tmp.get(id).copied(),
+                leaf => Some(dag.leaf(leaf)),
+            }
+        };
+        let a = resolve(&mut dag, &ins.a)?;
+        let b = resolve(&mut dag, &ins.b)?;
+        let node = dag.op(op_code(&ins.op), a, b);
+        if ins.dst_is_tmp {
+            let id = ins.dst_id?;
+            if tmp.contains_key(&id) {
+                return None; // not SSA
+            }
+            tmp.insert(id, node);
+        } else {
+            if i + 1 != n {
+                return None; // output store before the end
+            }
+            out = Some(node);
+        }
+    }
+    // Non-Q expressions end in a tmp instead of an explicit store: root = that tmp.
+    let out = match out {
+        Some(o) => o,
+        None => {
+            let last = ir.instrs.last()?;
+            let (id, _) = (last.dst_id?, last.dst_is_tmp);
+            *tmp.get(&id)?
+        }
+    };
+    Some((dag, out))
+}
+
+/// Detect the Horner chain `acc = vc·acc + c` ending at `root`. Returns the
+/// challenge leaf and the terms as `(constraint_node, power)`.
+fn horner_terms(dag: &Dag, root: NodeId, vc: NodeId) -> Option<Vec<(NodeId, u64)>> {
+    let mut terms: Vec<(NodeId, u64)> = Vec::new();
+    let mut node = root;
+    let mut power = 0u64;
+    loop {
+        let mut next: Option<(NodeId, NodeId)> = None; // (constraint, prev_acc)
+        if let Kind::Op { op: ADD, a, b } = dag.nodes[node].kind {
+            for (m, c) in [(a, b), (b, a)] {
+                if let Kind::Op { op: MUL, a: x, b: y } = dag.nodes[m].kind {
+                    if x == vc && y != vc {
+                        next = Some((c, y));
+                        break;
+                    }
+                    if y == vc && x != vc {
+                        next = Some((c, x));
+                        break;
+                    }
+                }
+            }
+        }
+        match next {
+            Some((c, prev)) => {
+                terms.push((c, power));
+                power += 1;
+                node = prev;
+            }
+            None => {
+                terms.push((node, power));
+                break;
+            }
+        }
+    }
+    if terms.len() >= 4 {
+        Some(terms)
+    } else {
+        None
+    }
+}
+
+/// The challenge leaf used by the constraint combination: the highest
+/// challenge id referenced by the expression (`std_vc` is declared after every
+/// challenge a constraint can mention).
+fn combination_challenge(dag: &Dag) -> Option<NodeId> {
+    let mut best: Option<(u64, NodeId)> = None;
+    for (i, n) in dag.nodes.iter().enumerate() {
+        if let Kind::Leaf(Operand::Ch { base }) = n.kind {
+            if best.is_none_or(|(b, _)| base > b) {
+                best = Some((base, i));
+            }
+        }
+    }
+    best.map(|(_, id)| id)
+}
+
+/// Reference counts (number of parent edges) of every node reachable from `root`.
+fn refcounts(dag: &Dag, root: NodeId) -> Vec<u32> {
+    let mut rc = vec![0u32; dag.nodes.len()];
+    let mut seen = vec![false; dag.nodes.len()];
+    let mut stack = vec![root];
+    seen[root] = true;
+    while let Some(n) = stack.pop() {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                rc[c] += 1;
+                if !seen[c] {
+                    seen[c] = true;
+                    stack.push(c);
+                }
+            }
+        }
+    }
+    rc
+}
+
+/// Feature bitset of a term: the shared Op nodes and column leaves it reads.
+fn term_features(dag: &Dag, term: NodeId, feat_idx: &HashMap<NodeId, usize>, words: usize) -> Vec<u64> {
+    let mut bits = vec![0u64; words];
+    let mut stack = vec![term];
+    let mut seen: HashSet<NodeId> = HashSet::new();
+    while let Some(n) = stack.pop() {
+        if !seen.insert(n) {
+            continue;
+        }
+        if let Some(&fi) = feat_idx.get(&n) {
+            bits[fi / 64] |= 1u64 << (fi % 64);
+            if !dag.is_leaf(n) {
+                continue; // a shared subtree is one feature; don't descend
+            }
+        }
+        if let Some((a, b)) = dag.children(n) {
+            stack.push(a);
+            stack.push(b);
+        }
+    }
+    bits
+}
+
+fn popcount_and(a: &[u64], b: &[u64]) -> u32 {
+    a.iter().zip(b).map(|(x, y)| (x & y).count_ones()).sum()
+}
+
+/// Greedy nearest-neighbour ordering of the terms by shared features.
+fn cluster_terms(dag: &Dag, terms: &[(NodeId, u64)], rc: &[u32]) -> Vec<usize> {
+    // features: Op nodes with >1 parent, plus column/const leaves
+    let mut feat_idx: HashMap<NodeId, usize> = HashMap::new();
+    for (i, n) in dag.nodes.iter().enumerate() {
+        let is_feat = match &n.kind {
+            Kind::Op { .. } => rc[i] > 1,
+            Kind::Leaf(Operand::Cm { .. }) | Kind::Leaf(Operand::Custom { .. }) | Kind::Leaf(Operand::Const { .. }) => {
+                true
+            }
+            _ => false,
+        };
+        if is_feat {
+            let k = feat_idx.len();
+            feat_idx.insert(i, k);
+        }
+    }
+    let words = feat_idx.len().div_ceil(64).max(1);
+    let feats: Vec<Vec<u64>> = terms.iter().map(|&(t, _)| term_features(dag, t, &feat_idx, words)).collect();
+
+    let n = terms.len();
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    let mut used = vec![false; n];
+    // start from the first term (keeps the natural order when nothing is shared)
+    let mut cur = 0usize;
+    used[cur] = true;
+    order.push(cur);
+    for _ in 1..n {
+        let mut best = usize::MAX;
+        let mut best_score = -1i64;
+        for j in 0..n {
+            if used[j] {
+                continue;
+            }
+            let s = popcount_and(&feats[cur], &feats[j]) as i64;
+            // tie-break: natural order, so equal-similarity terms stay sequential
+            if s > best_score || (s == best_score && j < best) {
+                best_score = s;
+                best = j;
+            }
+        }
+        used[best] = true;
+        order.push(best);
+        cur = best;
+    }
+    order
+}
+
+/// Per-term sparse feature lists + feature weights. Features are shared Op
+/// nodes (weight = clamped recompute cost, dim-aware) and column/const leaves
+/// (a reload is one load). A shared subtree is one feature: don't descend.
+fn term_feature_lists(dag: &Dag, terms: &[(NodeId, u64)], rc: &[u32], ex: &[u64]) -> (Vec<Vec<usize>>, Vec<i64>) {
+    let mut feat_idx: HashMap<NodeId, usize> = HashMap::new();
+    let mut weight: Vec<i64> = Vec::new();
+    for (i, n) in dag.nodes.iter().enumerate() {
+        let w = match &n.kind {
+            Kind::Op { .. } if rc[i] > 1 => Some((ex[i].clamp(1, 200)) as i64),
+            Kind::Leaf(Operand::Cm { .. }) | Kind::Leaf(Operand::Custom { .. }) | Kind::Leaf(Operand::Const { .. }) => {
+                Some(2)
+            }
+            _ => None,
+        };
+        if let Some(w) = w {
+            feat_idx.insert(i, weight.len());
+            weight.push(w);
+        }
+    }
+    let mut feats: Vec<Vec<usize>> = Vec::with_capacity(terms.len());
+    for &(t, _) in terms {
+        let mut fs: Vec<usize> = Vec::new();
+        let mut seen: HashSet<NodeId> = HashSet::new();
+        let mut stack = vec![t];
+        while let Some(n) = stack.pop() {
+            if !seen.insert(n) {
+                continue;
+            }
+            if let Some(&fi) = feat_idx.get(&n) {
+                fs.push(fi);
+                if !dag.is_leaf(n) {
+                    continue;
+                }
+            }
+            if let Some((a, b)) = dag.children(n) {
+                stack.push(a);
+                stack.push(b);
+            }
+        }
+        fs.sort_unstable();
+        fs.dedup();
+        feats.push(fs);
+    }
+    (feats, weight)
+}
+
+/// Live-set-aware term ordering. Nearest-neighbour clustering scores a
+/// candidate only against the *previous* term, so it forgets every shared
+/// value still in flight. Here each step picks the term that best consumes the
+/// shared values already open (bonus for the use that closes one) and
+/// penalizes opening new ones, weighted by recompute cost.
+fn order_live(feats: &[Vec<usize>], weight: &[i64]) -> Vec<usize> {
+    let mut uses_total = vec![0u32; weight.len()];
+    for fs in feats {
+        for &f in fs {
+            uses_total[f] += 1;
+        }
+    }
+    let mut uses_left = uses_total.clone();
+    let mut opened = vec![false; weight.len()];
+    let n = feats.len();
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    let mut used = vec![false; n];
+    for _ in 0..n {
+        let mut best = usize::MAX;
+        let mut best_score = i64::MIN;
+        for j in 0..n {
+            if used[j] {
+                continue;
+            }
+            let mut sc = 0i64;
+            for &f in &feats[j] {
+                if uses_total[f] <= 1 {
+                    continue;
+                }
+                if opened[f] {
+                    sc += weight[f] * if uses_left[f] == 1 { 3 } else { 1 };
+                } else {
+                    sc -= weight[f];
+                }
+            }
+            if sc > best_score || (sc == best_score && j < best) {
+                best_score = sc;
+                best = j;
+            }
+        }
+        used[best] = true;
+        order.push(best);
+        for &f in &feats[best] {
+            opened[f] = true;
+            uses_left[f] -= 1;
+        }
+    }
+    order
+}
+
+/// Reverse Cuthill-McKee over the term graph (terms adjacent when they share
+/// a feature). The bandwidth of this order bounds how far apart any shared
+/// value's users land, i.e. its live range -- the global property the greedy
+/// scorers miss (Keccakf: theta values with 5 users spread ~3000 ops apart).
+/// Hub features (more than `HUB` users) are dropped from adjacency: they
+/// connect everything and flatten the BFS.
+fn order_rcm(feats: &[Vec<usize>], nfeat: usize) -> Vec<usize> {
+    const HUB: usize = 48;
+    let n = feats.len();
+    let mut by_feat: Vec<Vec<usize>> = vec![Vec::new(); nfeat];
+    for (t, fs) in feats.iter().enumerate() {
+        for &f in fs {
+            by_feat[f].push(t);
+        }
+    }
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for ts in &by_feat {
+        if ts.len() < 2 || ts.len() > HUB {
+            continue;
+        }
+        for &a in ts {
+            for &b in ts {
+                if a != b {
+                    adj[a].push(b);
+                }
+            }
+        }
+    }
+    for a in adj.iter_mut() {
+        a.sort_unstable();
+        a.dedup();
+    }
+    let deg: Vec<usize> = adj.iter().map(|a| a.len()).collect();
+    // BFS from `start` over unvisited nodes; returns (order, last level)
+    let bfs = |start: usize, visited: &mut [bool]| -> (Vec<usize>, Vec<usize>) {
+        let mut out = vec![start];
+        let mut level = vec![start];
+        visited[start] = true;
+        let mut head = 0usize;
+        let mut last_level: Vec<usize> = vec![start];
+        while head < out.len() {
+            let frontier_end = out.len();
+            let mut next: Vec<usize> = Vec::new();
+            while head < frontier_end {
+                let u = out[head];
+                head += 1;
+                let mut nb: Vec<usize> = adj[u].iter().copied().filter(|&v| !visited[v]).collect();
+                nb.sort_by_key(|&v| (deg[v], v));
+                for v in nb {
+                    if !visited[v] {
+                        visited[v] = true;
+                        out.push(v);
+                        next.push(v);
+                    }
+                }
+            }
+            if !next.is_empty() {
+                last_level = next.clone();
+                level = next;
+            }
+        }
+        let _ = level;
+        (out, last_level)
+    };
+    let mut visited = vec![false; n];
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    for s0 in 0..n {
+        if visited[s0] {
+            continue;
+        }
+        // pseudo-peripheral start: farthest min-degree node of a probe BFS, twice
+        let mut start = s0;
+        for _ in 0..2 {
+            let mut probe = visited.clone();
+            let (_, last) = bfs(start, &mut probe);
+            start = last.into_iter().min_by_key(|&v| (deg[v], v)).unwrap_or(start);
+        }
+        let (comp, _) = bfs(start, &mut visited);
+        order.extend(comp);
+    }
+    order.reverse();
+    order
+}
+
+/// Candidate term orders. EXPS_CLUSTER=nn|live|rcm forces one; by default both
+/// live and rcm are returned and the caller keeps whichever yields the lower
+/// max-live once the sum chain is actually built and scheduled (the cheap
+/// open-count proxy picked wrong on Main and ArithEq, so the selection is exact).
+fn cluster_candidates(dag: &Dag, terms: &[(NodeId, u64)], rc: &[u32], ex: &[u64]) -> Vec<(&'static str, Vec<usize>)> {
+    let (feats, weight) = term_feature_lists(dag, terms, rc, ex);
+    let nfeat = weight.len();
+    match std::env::var("EXPS_CLUSTER").as_deref() {
+        Ok("nn") => vec![("nn", cluster_terms(dag, terms, rc))],
+        Ok("live") => vec![("live", order_live(&feats, &weight))],
+        Ok("rcm") => vec![("rcm", order_rcm(&feats, nfeat))],
+        _ => vec![("live", order_live(&feats, &weight)), ("rcm", order_rcm(&feats, nfeat))],
+    }
+}
+
+/// Row-invariance census (EXPS_OPT_DEBUG=3). Classifies every node as
+/// Invariant (built only from challenges / powers / publics / air values /
+/// numbers: the same for every row, so computable once per launch), Linear
+/// (an affine form Σ inv_k·atom_k + inv_0 over row-dependent base-field atoms:
+/// columns, constants, Zi, and base×base products) or Opaque (anything else,
+/// e.g. products with cubic columns). A Linear Horner term c_j makes
+/// vc^j·c_j = Σ (vc^j·inv_k)·atom_k: its mul33 disappears, the coefficients go
+/// to the per-launch table and merge across terms sharing an atom. Reports how
+/// much of the Q cost that shape covers, to decide whether the rewrite is worth
+/// building.
+#[derive(Clone)]
+enum Lf {
+    Inv,
+    Lin(HashSet<NodeId>),
+    Opaque,
+}
+
+fn lf_classify(dag: &Dag, n: NodeId, memo: &mut HashMap<NodeId, Lf>) -> Lf {
+    if let Some(v) = memo.get(&n) {
+        return v.clone();
+    }
+    let v = match &dag.nodes[n].kind {
+        Kind::Leaf(op) => match op {
+            Operand::Num(_)
+            | Operand::Ch { .. }
+            | Operand::Pow { .. }
+            | Operand::Pub { .. }
+            | Operand::Av { .. }
+            | Operand::Agv { .. }
+            | Operand::Tab { .. } => Lf::Inv,
+            Operand::Cm { dim: 3, .. } | Operand::Custom { dim: 3, .. } => Lf::Opaque,
+            Operand::Cm { .. } | Operand::Custom { .. } | Operand::Const { .. } | Operand::Zi => {
+                Lf::Lin(HashSet::from([n]))
+            }
+            Operand::Tmp { .. } => Lf::Opaque,
+        },
+        Kind::Op { op, a, b } => {
+            let la = lf_classify(dag, *a, memo);
+            let lb = lf_classify(dag, *b, memo);
+            match (*op, la, lb) {
+                (_, Lf::Inv, Lf::Inv) => Lf::Inv,
+                (ADD | SUB, Lf::Inv, Lf::Lin(s)) | (ADD | SUB, Lf::Lin(s), Lf::Inv) => Lf::Lin(s),
+                (ADD | SUB, Lf::Lin(mut x), Lf::Lin(y)) => {
+                    x.extend(y);
+                    Lf::Lin(x)
+                }
+                (MUL, Lf::Inv, Lf::Lin(s)) | (MUL, Lf::Lin(s), Lf::Inv) => Lf::Lin(s),
+                // base x base is a fresh row-dependent atom; cubic results are not affine
+                (MUL, Lf::Lin(_), Lf::Lin(_)) if dag.nodes[n].dim == 1 => Lf::Lin(HashSet::from([n])),
+                _ => Lf::Opaque,
+            }
+        }
+    };
+    memo.insert(n, v.clone());
+    v
+}
+
+fn linear_census(dag: &Dag, terms: &[(NodeId, u64)], label: &str) {
+    let mut memo: HashMap<NodeId, Lf> = HashMap::new();
+    let (mut n_inv, mut n_lin, mut n_opq) = (0usize, 0usize, 0usize);
+    let mut atoms: HashSet<NodeId> = HashSet::new();
+    // unique mul33 nodes reachable from terms of each class
+    let mut m33_lin: HashSet<NodeId> = HashSet::new();
+    let mut m33_all: HashSet<NodeId> = HashSet::new();
+    let mut cost_lin = 0u64;
+    let mut cost_all = 0u64;
+    let mut seen_all: HashSet<NodeId> = HashSet::new();
+    let mut seen_lin: HashSet<NodeId> = HashSet::new();
+    let mut lin_pow_terms = 0usize; // linear terms with p >= 1: their vc^j mul33 vanishes
+    for &(c, p) in terms {
+        let cls = lf_classify(dag, c, &mut memo);
+        let is_lin = matches!(cls, Lf::Lin(_));
+        match &cls {
+            Lf::Inv => n_inv += 1,
+            Lf::Lin(s) => {
+                n_lin += 1;
+                atoms.extend(s.iter().copied());
+                if p >= 1 {
+                    lin_pow_terms += 1;
+                }
+            }
+            Lf::Opaque => n_opq += 1,
+        }
+        // per-term visited set: shared DAG nodes must not be re-expanded
+        let mut seen_term: HashSet<NodeId> = HashSet::new();
+        let mut stack = vec![c];
+        while let Some(n) = stack.pop() {
+            if !seen_term.insert(n) {
+                continue;
+            }
+            let Kind::Op { op, a, b } = dag.nodes[n].kind else { continue };
+            let cst = cost(op, dag.nodes[a].dim, dag.nodes[b].dim);
+            if seen_all.insert(n) {
+                cost_all += cst;
+                if op == MUL && dag.nodes[a].dim == 3 && dag.nodes[b].dim == 3 {
+                    m33_all.insert(n);
+                }
+            }
+            if is_lin && seen_lin.insert(n) {
+                cost_lin += cst;
+                if op == MUL && dag.nodes[a].dim == 3 && dag.nodes[b].dim == 3 {
+                    m33_lin.insert(n);
+                }
+            }
+            stack.push(a);
+            stack.push(b);
+        }
+    }
+    eprintln!(
+        "[exps-opt-census] {label}: terms {} = inv {n_inv} + lin {n_lin} (with power {lin_pow_terms}) + opaque {n_opq}; distinct atoms in lin terms {}; mul33 inside terms: all {} lin {}; cost inside terms: all {cost_all} lin {cost_lin} ({:.1}%); removable vc^j mul33 ~{} (cost ~{})",
+        terms.len(),
+        atoms.len(),
+        m33_all.len(),
+        m33_lin.len(),
+        if cost_all > 0 { 100.0 * cost_lin as f64 / cost_all as f64 } else { 0.0 },
+        lin_pow_terms,
+        lin_pow_terms as u64 * 40
+    );
+}
+
+/// Symbolic affine form of a row-dependent value: Σ coef_k·atom_k + cst, with
+/// every `coef_k` and `cst` a row-invariant DAG node and every `atom_k` a
+/// row-dependent base-field node (column, constant, Zi, or a base×base
+/// product, kept opaque). `None` = not affine (e.g. a product with a cubic
+/// column).
+#[derive(Clone)]
+struct LinForm {
+    coef: Vec<(NodeId, NodeId)>, // (atom, coefficient), sorted by atom
+    cst: Option<NodeId>,
+}
+
+struct LinCtx {
+    memo: HashMap<NodeId, Option<LinForm>>,
+    one: NodeId,
+    zero: NodeId,
+}
+
+fn lin_scale(dag: &mut Dag, ctx: &LinCtx, f: &LinForm, m: NodeId) -> LinForm {
+    let coef = f.coef.iter().map(|&(a, c)| (a, if c == ctx.one { m } else { dag.op(MUL, m, c) })).collect();
+    let cst = f.cst.map(|c| if c == ctx.one { m } else { dag.op(MUL, m, c) });
+    LinForm { coef, cst }
+}
+
+fn lin_combine(dag: &mut Dag, ctx: &LinCtx, op: u8, x: &LinForm, y: &LinForm) -> LinForm {
+    // merge sorted coefficient lists
+    let mut coef: Vec<(NodeId, NodeId)> = Vec::with_capacity(x.coef.len() + y.coef.len());
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < x.coef.len() || j < y.coef.len() {
+        let take_x = j >= y.coef.len() || (i < x.coef.len() && x.coef[i].0 < y.coef[j].0);
+        let take_y = i >= x.coef.len() || (j < y.coef.len() && y.coef[j].0 < x.coef[i].0);
+        if take_x && !take_y {
+            coef.push(x.coef[i]);
+            i += 1;
+        } else if take_y && !take_x {
+            let (a, c) = y.coef[j];
+            coef.push((a, if op == ADD { c } else { dag.op(SUB, ctx.zero, c) }));
+            j += 1;
+        } else {
+            let (a, cx) = x.coef[i];
+            let (_, cy) = y.coef[j];
+            coef.push((a, dag.op(op, cx, cy)));
+            i += 1;
+            j += 1;
+        }
+    }
+    let cst = match (x.cst, y.cst) {
+        (None, None) => None,
+        (Some(c), None) => Some(c),
+        (None, Some(c)) => Some(if op == ADD { c } else { dag.op(SUB, ctx.zero, c) }),
+        (Some(cx), Some(cy)) => Some(dag.op(op, cx, cy)),
+    };
+    LinForm { coef, cst }
+}
+
+fn lin_form(dag: &mut Dag, ctx: &mut LinCtx, n: NodeId) -> Option<LinForm> {
+    if let Some(v) = ctx.memo.get(&n) {
+        return v.clone();
+    }
+    let v: Option<LinForm> = match dag.nodes[n].kind.clone() {
+        Kind::Leaf(o) => {
+            if invariant_leaf(&o) {
+                Some(LinForm { coef: vec![], cst: Some(n) })
+            } else if matches!(o, Operand::Cm { dim: 3, .. } | Operand::Custom { dim: 3, .. }) {
+                None
+            } else {
+                Some(LinForm { coef: vec![(n, ctx.one)], cst: None })
+            }
+        }
+        Kind::Op { op, a, b } => {
+            let fa = lin_form(dag, ctx, a);
+            let fb = lin_form(dag, ctx, b);
+            match (fa, fb) {
+                (Some(fa), Some(fb)) => {
+                    let a_inv = fa.coef.is_empty();
+                    let b_inv = fb.coef.is_empty();
+                    if a_inv && b_inv {
+                        Some(LinForm { coef: vec![], cst: Some(n) }) // invariant op: itself
+                    } else if op == MUL {
+                        if a_inv {
+                            Some(lin_scale(dag, ctx, &fb, fa.cst.unwrap()))
+                        } else if b_inv {
+                            Some(lin_scale(dag, ctx, &fa, fb.cst.unwrap()))
+                        } else if dag.nodes[n].dim == 1 {
+                            Some(LinForm { coef: vec![(n, ctx.one)], cst: None })
+                        // base x base: new atom
+                        } else {
+                            None
+                        }
+                    } else {
+                        Some(lin_combine(dag, ctx, op, &fa, &fb))
+                    }
+                }
+                _ => None,
+            }
+        }
+    };
+    ctx.memo.insert(n, v.clone());
+    v
+}
+
+/// Linear-term distribution. Every Horner term that is affine in row values,
+/// `c_j = Σ inv_jk·atom_k + inv_j0`, contributes
+/// `vc^j·c_j = Σ (vc^j·inv_jk)·atom_k + vc^j·inv_j0`; summing over j gives
+/// `Σ_k C_k·atom_k + C_0` with every C row-invariant (hoisted to the per-launch
+/// table by `linearize`). The per-row work for the affine part drops to one
+/// mul31 plus an add per distinct atom, and the per-term vc^j mul33 disappears.
+/// Exact (distributivity over the field); the equivalence check verifies it.
+/// Non-affine terms are returned unchanged.
+fn distribute_linear(
+    dag: &mut Dag,
+    terms: &[(NodeId, u64)],
+    vc: NodeId,
+    base: u64,
+) -> (Vec<(NodeId, u64)>, usize, usize) {
+    let one = dag.leaf(&Operand::Num(1));
+    let zero = dag.leaf(&Operand::Num(0));
+    let mut ctx = LinCtx { memo: HashMap::new(), one, zero };
+    let mut acc: Vec<(NodeId, NodeId)> = Vec::new(); // (atom, accumulated coefficient), first-seen order
+    let mut acc_idx: HashMap<NodeId, usize> = HashMap::new();
+    let mut acc_cst: Option<NodeId> = None;
+    let mut kept: Vec<(NodeId, u64)> = Vec::new();
+    let mut n_lin = 0usize;
+    for &(c, p) in terms {
+        let Some(f) = lin_form(dag, &mut ctx, c) else {
+            kept.push((c, p));
+            continue;
+        };
+        // Distribute only when it pays. As-is, a term costs its affine part
+        // (atoms with a unit coefficient are free, base coefficients a mul11+add,
+        // cubic ones a mul31+add33) plus the vc^j product (mul13 for a base
+        // term, mul33 for a cubic one). Distributed, every atom costs a
+        // mul31+add33 (merging across terms can only help). Base-coefficient
+        // packing sums (Sha256f, Keccakf bit words) would get 3x dearer: keep.
+        let mut before = 0u64;
+        for &(_, coef) in &f.coef {
+            before += if coef == one {
+                0
+            } else if dag.nodes[coef].dim == 1 {
+                5
+            } else {
+                15
+            };
+        }
+        let tdim = dag.nodes[c].dim;
+        if p >= 1 {
+            before += if tdim == 3 { 40 } else { 12 };
+        }
+        let after = 15 * f.coef.len() as u64;
+        if after > before {
+            kept.push((c, p));
+            continue;
+        }
+        n_lin += 1;
+        let m: Option<NodeId> = match p {
+            0 => None,
+            1 => Some(vc),
+            j => Some(dag.leaf(&Operand::Pow { base, j })),
+        };
+        let f = match m {
+            Some(m) => lin_scale(dag, &ctx, &f, m),
+            None => f,
+        };
+        for (atom, coef) in f.coef {
+            match acc_idx.get(&atom) {
+                Some(&i) => {
+                    let cur = acc[i].1;
+                    acc[i].1 = dag.op(ADD, cur, coef);
+                }
+                None => {
+                    acc_idx.insert(atom, acc.len());
+                    acc.push((atom, coef));
+                }
+            }
+        }
+        if let Some(cst) = f.cst {
+            acc_cst = Some(match acc_cst {
+                None => cst,
+                Some(a) => dag.op(ADD, a, cst),
+            });
+        }
+    }
+    let n_atoms = acc.len();
+    let mut out: Vec<(NodeId, u64)> = Vec::with_capacity(n_atoms + 1 + kept.len());
+    for (atom, coef) in acc {
+        let t = if coef == one { atom } else { dag.op(MUL, coef, atom) };
+        out.push((t, 0));
+    }
+    if let Some(cst) = acc_cst {
+        out.push((cst, 0));
+    }
+    out.extend(kept);
+    (out, n_lin, n_atoms)
+}
+
+/// Largest power index read anywhere under `root` (Pow leaves), for sizing
+/// the per-launch powers table.
+fn max_pow_used(dag: &Dag, root: NodeId) -> Option<u64> {
+    let mut seen = vec![false; dag.nodes.len()];
+    let mut stack = vec![root];
+    let mut mx: Option<u64> = None;
+    while let Some(n) = stack.pop() {
+        if seen[n] {
+            continue;
+        }
+        seen[n] = true;
+        match &dag.nodes[n].kind {
+            Kind::Leaf(Operand::Pow { j, .. }) => mx = Some(mx.map_or(*j, |m| m.max(*j))),
+            Kind::Op { a, b, .. } => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            _ => {}
+        }
+    }
+    mx
+}
+
+/// Post-order sequence numbers of the nodes reachable from `root`,
+/// visiting `a` before `b` (the clustered term order is baked into the chain).
+fn sequence(dag: &Dag, root: NodeId) -> HashMap<NodeId, usize> {
+    let mut seq: HashMap<NodeId, usize> = HashMap::new();
+    let mut stack: Vec<(NodeId, bool)> = vec![(root, false)];
+    while let Some((n, expanded)) = stack.pop() {
+        if seq.contains_key(&n) || dag.is_leaf(n) {
+            continue;
+        }
+        if expanded {
+            let k = seq.len();
+            seq.insert(n, k);
+        } else {
+            stack.push((n, true));
+            if let Some((a, b)) = dag.children(n) {
+                stack.push((b, false));
+                stack.push((a, false));
+            }
+        }
+    }
+    seq
+}
+
+/// Register-pressure-aware list scheduling. Returns the Op nodes in emission order.
+fn schedule(dag: &Dag, root: NodeId, seq: &HashMap<NodeId, usize>) -> Vec<NodeId> {
+    let rc = refcounts(dag, root);
+    let mut remaining: Vec<u32> = rc.clone();
+    let mut pending: Vec<u32> = vec![0; dag.nodes.len()]; // unscheduled Op children
+    let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); dag.nodes.len()];
+    for &n in seq.keys() {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) {
+                    pending[n] += 1;
+                    parents[c].push(n);
+                }
+            }
+        }
+    }
+    // heap of (score, -seq, node); stale entries are re-scored on pop
+    let score = |n: NodeId, remaining: &[u32]| -> i64 {
+        let mut freed = 0i64;
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) && remaining[c] == 1 {
+                    freed += 1;
+                }
+            }
+        }
+        freed
+    };
+    let mut heap: BinaryHeap<(i64, i64, NodeId)> = BinaryHeap::new();
+    for (&n, &s) in seq.iter() {
+        if pending[n] == 0 {
+            heap.push((score(n, &remaining), -(s as i64), n));
+        }
+    }
+    let mut done = vec![false; dag.nodes.len()];
+    let mut order: Vec<NodeId> = Vec::with_capacity(seq.len());
+    while let Some((sc, ns, n)) = heap.pop() {
+        if done[n] {
+            continue;
+        }
+        let cur = score(n, &remaining);
+        if cur != sc {
+            heap.push((cur, ns, n));
+            continue;
+        }
+        done[n] = true;
+        order.push(n);
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) {
+                    remaining[c] -= 1;
+                }
+            }
+        }
+        for &p in &parents[n] {
+            pending[p] -= 1;
+            if pending[p] == 0 {
+                heap.push((score(p, &remaining), -(seq[&p] as i64), p));
+            }
+        }
+    }
+    debug_assert_eq!(order.len(), seq.len());
+    order
+}
+
+/// Layered order: Op nodes by longest path from the leaves, ascending, tie-broken
+/// by post-order seq. Post-order is depth-first, which on a layered DAG (Poseidon's
+/// uncommitted partial rounds: each round's 12 state values feed all 12 of the
+/// next) keeps every layer's values alive at once; the frees-first greedy scores 0
+/// for all but the last user of a value, so it degenerates to the same order.
+/// Breadth-first by depth computes one layer, then the next: live ~2 layers.
+/// Wrong for tree-shaped terms (leaf level first = huge live), so it is only a
+/// candidate -- the caller keeps whichever order has the lowest max-live.
+fn schedule_layered(dag: &Dag, seq: &HashMap<NodeId, usize>) -> Vec<NodeId> {
+    let mut by_seq: Vec<(usize, NodeId)> = seq.iter().map(|(&n, &s)| (s, n)).collect();
+    by_seq.sort_unstable();
+    let mut depth: HashMap<NodeId, u32> = HashMap::with_capacity(seq.len());
+    for &(_, n) in &by_seq {
+        let mut d = 0u32;
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if let Some(&dc) = depth.get(&c) {
+                    d = d.max(dc + 1);
+                }
+            }
+        }
+        depth.insert(n, d);
+    }
+    let mut keyed: Vec<(u32, usize, NodeId)> = by_seq.iter().map(|&(s, n)| (depth[&n], s, n)).collect();
+    keyed.sort_unstable();
+    keyed.into_iter().map(|(_, _, n)| n).collect()
+}
+
+/// Cost of recomputing `n` from leaves and from the shared nodes worth keeping
+/// live ("expensive": shared and costlier than `cost_max`). Post-order over
+/// `order` so children are costed first.
+fn exclusive_costs(dag: &Dag, order: &[NodeId], rc: &[u32], cost_max: u64) -> Vec<u64> {
+    let mut ex = vec![0u64; dag.nodes.len()];
+    for &n in order {
+        let Kind::Op { op, a, b } = dag.nodes[n].kind else { continue };
+        let mut c = cost(op, dag.nodes[a].dim, dag.nodes[b].dim);
+        for ch in [a, b] {
+            if !dag.is_leaf(ch) && !(rc[ch] > 1 && ex[ch] > cost_max) {
+                c += ex[ch];
+            }
+        }
+        ex[n] = c;
+    }
+    ex
+}
+
+/// Fresh copy of the subtree under `n`, stopping at leaves and at expensive
+/// shared nodes (which stay shared). Nodes beyond `rc`'s range are clones made
+/// earlier in this pass: unshared by construction, so they are copied too.
+fn clone_subtree(dag: &mut Dag, n: NodeId, rc: &[u32], ex: &[u64], cost_max: u64) -> NodeId {
+    let Kind::Op { op, a, b } = dag.nodes[n].kind else { return n };
+    let mut kids = [a, b];
+    for k in kids.iter_mut() {
+        let keep_shared = *k < rc.len() && rc[*k] > 1 && ex[*k] > cost_max;
+        if !dag.is_leaf(*k) && !keep_shared {
+            *k = clone_subtree(dag, *k, rc, ex, cost_max);
+        }
+    }
+    let dim = dag.nodes[n].dim;
+    let id = dag.nodes.len();
+    dag.nodes.push(Node { kind: Kind::Op { op, a: kids[0], b: kids[1] }, dim });
+    id
+}
+
+/// Number of Op nodes `clone_subtree` would create for `n` (same stopping
+/// rule). Cost alone is a bad remat gate: a subtree of many cheap ops scores
+/// low on `cost` yet duplicates a lot of instructions, which is what the
+/// kernels actually issue. Memoized -- the DAG is shared, so the naive
+/// recursion is exponential.
+fn clone_size(dag: &Dag, n: NodeId, rc: &[u32], ex: &[u64], cost_max: u64, memo: &mut HashMap<NodeId, usize>) -> usize {
+    if let Some(&v) = memo.get(&n) {
+        return v;
+    }
+    let Kind::Op { a, b, .. } = dag.nodes[n].kind else { return 0 };
+    let mut sz = 1usize;
+    for k in [a, b] {
+        let keep_shared = k < rc.len() && rc[k] > 1 && ex[k] > cost_max;
+        if !dag.is_leaf(k) && !keep_shared {
+            sz += clone_size(dag, k, rc, ex, cost_max, memo);
+        }
+    }
+    memo.insert(n, sz);
+    sz
+}
+
+/// Duplicate cheap shared subtrees for users that are far apart in the
+/// schedule: recomputing them is cheaper than keeping them live (a register,
+/// or a scratch slot across chunks). Returns the number of clones made.
+/// Remat tiers: (distance window, max recompute cost, max clone size). A use
+/// further than the window from the previous use is served by a fresh clone if
+/// the value is within the tier's cost/size caps. The far tier admits costlier
+/// clones: holding a value across thousands of ops costs a scratch slot per
+/// chunk boundary (and shrinks the adaptive grid), which outweighs a few more
+/// instructions.
+struct RematTier {
+    window: usize,
+    cost_max: u64,
+    ops_max: usize,
+}
+
+fn rematerialize(dag: &mut Dag, root: NodeId, order: &[NodeId], tiers: &[RematTier]) -> usize {
+    let pos: HashMap<NodeId, usize> = order.iter().enumerate().map(|(i, &n)| (n, i)).collect();
+    let rc = refcounts(dag, root);
+    let cost_max = tiers.iter().map(|t| t.cost_max).max().unwrap_or(0);
+    let ops_max = tiers.iter().map(|t| t.ops_max).max().unwrap_or(0);
+    let ex = exclusive_costs(dag, order, &rc, cost_max);
+    // users of each shared node that some tier could clone, in schedule order
+    let mut users: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    for &n in order {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) && rc[c] > 1 && ex[c] <= cost_max {
+                    users.entry(c).or_default().push(n);
+                }
+            }
+        }
+    }
+    // Bound the instructions each clone duplicates, not just their cost.
+    let mut szmemo: HashMap<NodeId, usize> = HashMap::new();
+    let mut cands: Vec<NodeId> =
+        users.keys().copied().filter(|&c| clone_size(dag, c, &rc, &ex, cost_max, &mut szmemo) <= ops_max).collect();
+    cands.sort_by_key(|c| pos[c]);
+    let mut clones = 0usize;
+    for c in cands {
+        let sz = szmemo[&c];
+        let mut us = users[&c].clone();
+        us.sort_by_key(|u| pos[u]);
+        us.dedup();
+        let mut current = c;
+        let mut prev_pos = pos[&us[0]];
+        for &u in &us[1..] {
+            let p = pos[&u];
+            let d = p - prev_pos;
+            let clone_here = tiers.iter().any(|t| d > t.window && ex[c] <= t.cost_max && sz <= t.ops_max);
+            if clone_here {
+                current = clone_subtree(dag, c, &rc, &ex, cost_max);
+                clones += 1;
+            }
+            prev_pos = p;
+            if current != c {
+                if let Kind::Op { a, b, .. } = &mut dag.nodes[u].kind {
+                    if *a == c {
+                        *a = current;
+                    }
+                    if *b == c {
+                        *b = current;
+                    }
+                }
+            }
+        }
+    }
+    clones
+}
+
+/// Diagnostic (EXPS_OPT_DEBUG=1): at the max-live point of `order`, bucket the
+/// live values by how they are held: term-internal (single use, finishing the
+/// current term) vs shared, and for shared ones by exclusive recompute cost and
+/// by distance to their last use. Tells whether pressure comes from CSE keeping
+/// expensive values in flight (clustering/remat problem) or from the term shape.
+fn live_breakdown(dag: &Dag, root: NodeId, order: &[NodeId], label: &str) {
+    let rc = refcounts(dag, root);
+    let ex = exclusive_costs(dag, order, &rc, u64::MAX);
+    let pos: HashMap<NodeId, usize> = order.iter().enumerate().map(|(i, &n)| (n, i)).collect();
+    let mut last_use: HashMap<NodeId, usize> = HashMap::new();
+    for (i, &n) in order.iter().enumerate() {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) {
+                    last_use.insert(c, i);
+                }
+            }
+        }
+    }
+    let mut remaining = rc.clone();
+    let mut live: HashSet<NodeId> = HashSet::new();
+    let mut best = 0usize;
+    let mut best_at = 0usize;
+    let mut best_set: Vec<NodeId> = Vec::new();
+    for (i, &n) in order.iter().enumerate() {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) {
+                    remaining[c] -= 1;
+                    if remaining[c] == 0 {
+                        live.remove(&c);
+                    }
+                }
+            }
+        }
+        if n != root {
+            live.insert(n);
+        }
+        if live.len() > best {
+            best = live.len();
+            best_at = i;
+            best_set = live.iter().copied().collect();
+        }
+    }
+    let mut single = 0usize;
+    let mut shared_cheap = 0usize; // ex <= 16
+    let mut shared_mid = 0usize; // 16 < ex <= 64
+    let mut shared_exp = 0usize; // ex > 64
+    let mut far = 0usize; // last use > 256 ops away
+    let mut dist_sum = 0usize;
+    for &n in &best_set {
+        let d = last_use.get(&n).copied().unwrap_or(best_at).saturating_sub(best_at);
+        dist_sum += d;
+        if d > 256 {
+            far += 1;
+        }
+        if rc[n] <= 1 {
+            single += 1;
+        } else if ex[n] <= 16 {
+            shared_cheap += 1;
+        } else if ex[n] <= 64 {
+            shared_mid += 1;
+        } else {
+            shared_exp += 1;
+        }
+    }
+    // EXPS_OPT_DEBUG=2: structure of the longest-held shared values at the peak
+    if std::env::var("EXPS_OPT_DEBUG").as_deref() == Ok("2") {
+        let mut first_use: HashMap<NodeId, usize> = HashMap::new();
+        for (i, &n) in order.iter().enumerate() {
+            if let Some((a, b)) = dag.children(n) {
+                for c in [a, b] {
+                    if !dag.is_leaf(c) {
+                        first_use.entry(c).or_insert(i);
+                    }
+                }
+            }
+        }
+        let mut rows: Vec<(usize, NodeId)> =
+            best_set.iter().filter(|&&n| rc[n] > 1).map(|&n| (last_use[&n].saturating_sub(pos[&n]), n)).collect();
+        rows.sort_unstable_by(|a, b| b.cmp(a));
+        let mut hist_users: HashMap<u32, usize> = HashMap::new();
+        for &(_, n) in &rows {
+            *hist_users.entry(rc[n]).or_default() += 1;
+        }
+        let mut hv: Vec<_> = hist_users.into_iter().collect();
+        hv.sort_unstable();
+        eprintln!("[exps-opt-debug]   shared-at-peak users histogram (users:count): {hv:?}");
+        for &(span, n) in rows.iter().take(12) {
+            let Kind::Op { op, a, b } = dag.nodes[n].kind else { continue };
+            let mut upos: Vec<usize> = order
+                .iter()
+                .enumerate()
+                .filter(|(_, &u)| matches!(dag.children(u), Some((x, y)) if x == n || y == n))
+                .map(|(i, _)| i)
+                .collect();
+            upos.sort_unstable();
+            let shown: Vec<usize> = upos.iter().copied().take(16).collect();
+            eprintln!(
+                "[exps-opt-debug]   node {n} {}(dim{} ,dim{}) ex={} users={} def@{} first_use@{} last_use@{} span={} uses_at={shown:?}{}",
+                op_name(op), dag.nodes[a].dim, dag.nodes[b].dim, ex[n], rc[n], pos[&n], first_use.get(&n).copied().unwrap_or(0), last_use[&n], span,
+                if upos.len() > 16 { "..." } else { "" }
+            );
+        }
+    }
+    let _ = pos;
+    eprintln!(
+        "[exps-opt-debug] {label}: max-live {best} at op {best_at}/{}: single-use {single}, shared cheap(<=16) {shared_cheap}, mid(17..64) {shared_mid}, expensive(>64) {shared_exp}; far(>256 ops to last use) {far}, mean dist {}",
+        order.len(),
+        dist_sum.checked_div(best).unwrap_or(0)
+    );
+}
+
+/// Max simultaneously live Op values for a given emission order.
+fn live_of_order(dag: &Dag, root: NodeId, order: &[NodeId]) -> usize {
+    let mut remaining = refcounts(dag, root);
+    let mut live = 0usize;
+    let mut best = 0usize;
+    for &n in order {
+        if let Some((a, b)) = dag.children(n) {
+            for c in [a, b] {
+                if !dag.is_leaf(c) {
+                    remaining[c] -= 1;
+                    if remaining[c] == 0 {
+                        live -= 1;
+                    }
+                }
+            }
+        }
+        if n != root {
+            live += 1;
+        }
+        best = best.max(live);
+    }
+    best
+}
+
+/// Plain post-order (just-in-time) schedule.
+fn schedule_seq(seq: &HashMap<NodeId, usize>) -> Vec<NodeId> {
+    let mut v: Vec<(usize, NodeId)> = seq.iter().map(|(&n, &s)| (s, n)).collect();
+    v.sort_unstable();
+    v.into_iter().map(|(_, n)| n).collect()
+}
+
+/// Linearize a schedule into fresh SSA IR.
+/// Is this leaf the same for every row? Challenges, their powers, publics,
+/// air/airgroup values and literals are; columns, constants and Zi are not.
+fn invariant_leaf(o: &Operand) -> bool {
+    matches!(
+        o,
+        Operand::Num(_)
+            | Operand::Ch { .. }
+            | Operand::Pow { .. }
+            | Operand::Pub { .. }
+            | Operand::Av { .. }
+            | Operand::Agv { .. }
+            | Operand::Tab { .. }
+    )
+}
+
+/// Row-invariance of every node: a leaf per `invariant_leaf`, an op iff both
+/// children are invariant. Computed along `order` (topological).
+fn invariant_nodes(dag: &Dag, order: &[NodeId]) -> Vec<bool> {
+    let mut inv = vec![false; dag.nodes.len()];
+    for (i, n) in dag.nodes.iter().enumerate() {
+        if let Kind::Leaf(o) = &n.kind {
+            inv[i] = invariant_leaf(o);
+        }
+    }
+    for &n in order {
+        if let Kind::Op { a, b, .. } = dag.nodes[n].kind {
+            inv[n] = inv[a] && inv[b];
+        }
+    }
+    inv
+}
+
+/// Emit SSA IR for `order`. With hoisting (EXPS_HOIST != 0), every
+/// row-invariant op node leaves the per-row program: it is computed in the
+/// once-per-launch table program instead, and the invariant values that the
+/// row-dependent ops actually consume are exported to table words and read
+/// back as `Operand::Tab`. Measured on the ZisK key, Main's Q spends ~80% of
+/// its instructions on such challenge-only arithmetic, repeated per row.
+fn linearize(
+    dag: &Dag,
+    root: NodeId,
+    order: &[NodeId],
+    template: &Ir,
+    pow: Option<(u64, u64)>,
+    stats: &mut OptStats,
+    allow_hoist: bool,
+) -> Ir {
+    let hoist = allow_hoist && std::env::var("EXPS_HOIST").map_or(true, |v| v != "0");
+    let inv = invariant_nodes(dag, order);
+    let hoisting = hoist && !inv[root];
+    // table program: invariant op nodes in order; exports: those used by a row-dependent op
+    let mut tab: Vec<Instr> = Vec::new();
+    let mut tab_tmp: HashMap<NodeId, u64> = HashMap::new();
+    let mut tab_out: Vec<(u64, u64, u64)> = Vec::new();
+    let mut tab_word: HashMap<NodeId, u64> = HashMap::new();
+    let mut tab_words = 0u64;
+    if hoisting {
+        let toperand = |n: NodeId, tab_tmp: &HashMap<NodeId, u64>| -> Operand {
+            match &dag.nodes[n].kind {
+                Kind::Leaf(o) => o.clone(),
+                Kind::Op { .. } => Operand::Tmp { id: tab_tmp[&n], dim: dag.nodes[n].dim },
+            }
+        };
+        for &n in order {
+            let Kind::Op { op, a, b } = dag.nodes[n].kind else { unreachable!() };
+            if !inv[n] {
+                continue;
+            }
+            let id = tab.len() as u64;
+            tab.push(Instr {
+                op: op_name(op).to_string(),
+                a: toperand(a, &tab_tmp),
+                b: toperand(b, &tab_tmp),
+                dst_is_tmp: true,
+                dst_id: Some(id),
+                ddim: dag.nodes[n].dim,
+                idx: id as usize,
+            });
+            tab_tmp.insert(n, id);
+        }
+        for &n in order {
+            let Kind::Op { a, b, .. } = dag.nodes[n].kind else { unreachable!() };
+            if inv[n] {
+                continue;
+            }
+            for c in [a, b] {
+                if !dag.is_leaf(c) && inv[c] && !tab_word.contains_key(&c) {
+                    let dim = dag.nodes[c].dim;
+                    tab_word.insert(c, tab_words);
+                    tab_out.push((tab_tmp[&c], tab_words, dim));
+                    tab_words += dim;
+                }
+            }
+        }
+    }
+    let mut tmp_of: HashMap<NodeId, u64> = HashMap::new();
+    let mut instrs: Vec<Instr> = Vec::with_capacity(order.len());
+    let operand = |n: NodeId, tmp_of: &HashMap<NodeId, u64>| -> Operand {
+        match &dag.nodes[n].kind {
+            Kind::Leaf(o) => o.clone(),
+            Kind::Op { .. } => match tab_word.get(&n) {
+                Some(&w) => Operand::Tab { idx: w, dim: dag.nodes[n].dim },
+                None => Operand::Tmp { id: tmp_of[&n], dim: dag.nodes[n].dim },
+            },
+        }
+    };
+    let mut idx = 0usize;
+    for &n in order {
+        let Kind::Op { op, a, b } = dag.nodes[n].kind else { unreachable!() };
+        if hoisting && inv[n] {
+            continue;
+        }
+        let is_out = n == root;
+        let id = idx as u64;
+        instrs.push(Instr {
+            op: op_name(op).to_string(),
+            a: operand(a, &tmp_of),
+            b: operand(b, &tmp_of),
+            dst_is_tmp: !is_out,
+            dst_id: if is_out { None } else { Some(id) },
+            ddim: dag.nodes[n].dim,
+            idx,
+        });
+        if !is_out {
+            tmp_of.insert(n, id);
+        }
+        idx += 1;
+    }
+    stats.tab_ops = tab.len();
+    stats.tab_words = tab_words;
+    if std::env::var("EXPS_OPT_DEBUG").is_ok() {
+        let n_tab_opnd =
+            instrs.iter().filter(|i| matches!(i.a, Operand::Tab { .. }) || matches!(i.b, Operand::Tab { .. })).count();
+        let n_tmp_opnd = instrs.iter().filter(|i| i.a.as_tmp().is_some() || i.b.as_tmp().is_some()).count();
+        let max_dst = instrs.iter().filter_map(|i| i.dst_id).max().unwrap_or(0);
+        let max_use =
+            instrs.iter().flat_map(|i| [i.a.as_tmp(), i.b.as_tmp()]).flatten().map(|(t, _)| t).max().unwrap_or(0);
+        eprintln!(
+            "[exps-opt-debug] linearize: instrs {} (order {}), hoisted {}, exported words {}, tab-operand instrs {n_tab_opnd}, tmp-operand instrs {n_tmp_opnd}, max dst id {max_dst}, max used tmp id {max_use}",
+            instrs.len(),
+            order.len(),
+            tab.len(),
+            tab_words
+        );
+    }
+    Ir {
+        instrs,
+        ncols: template.ncols.clone(),
+        n_constants: template.n_constants,
+        n_bits: template.n_bits,
+        pow,
+        tab,
+        tab_out,
+        tab_words,
+    }
+}
+
+/// Rematerialization: a shared value whose recompute cost is at most
+/// `REMAT_COST_MAX` and whose next use is more than `REMAT_WINDOW` ops away is
+/// recomputed for that use instead of kept live.
+const REMAT_WINDOW: usize = 64;
+const REMAT_COST_MAX: u64 = 16;
+/// Max Op nodes one clone may duplicate. Overridable while tuning.
+const REMAT_OPS_MAX: usize = 3;
+/// Far tier (EXPS_REMAT_FAR_WINDOW / _COST_MAX / _OPS_MAX): users this far
+/// apart justify a costlier clone. 0 window disables the tier.
+const REMAT_FAR_COST_MAX: u64 = 64;
+const REMAT_FAR_OPS_MAX: usize = 12;
+
+fn env_usize(k: &str, d: usize) -> usize {
+    std::env::var(k).ok().and_then(|v| v.parse().ok()).unwrap_or(d)
+}
+fn env_u64(k: &str, d: u64) -> u64 {
+    std::env::var(k).ok().and_then(|v| v.parse().ok()).unwrap_or(d)
+}
+
+/// Tail of the pipeline for a fixed root: rematerialize far-apart cheap
+/// shared values (twice: clones can expose new far-apart users), then keep the
+/// candidate schedule with the lowest max-live. Returns (order, clones made,
+/// max-live, schedule name).
+fn finish(dag: &mut Dag, root: NodeId) -> (Vec<NodeId>, usize, usize, &'static str) {
+    // The far remat tier is tried as a second candidate on a DAG copy and kept
+    // only if it lowers the final max-live (Keccakf: 349 -> 39 for +5% cost,
+    // and ncu shows that kernel is memory-bound, so slots matter more than
+    // ops; the compressor gets worse with it and keeps the near tier only).
+    // EXPS_REMAT_FAR_WINDOW forces: 0 = never, N = always with window N.
+    let forced = std::env::var("EXPS_REMAT_FAR_WINDOW").ok().and_then(|v| v.parse::<usize>().ok());
+    // Default: near tier only. Measured on the GPU (221-tx block): the far tier
+    // took Keccakf from 266 to 447 ms/proof (+42% ops outweighed the slot
+    // saving -- the kernel is issue-bound), so the live-based pick was wrong.
+    let try_far = match forced {
+        Some(0) | None => vec![false],
+        Some(_) => vec![true],
+    };
+    let mut best: Option<(Vec<NodeId>, usize, usize, &'static str, Dag)> = None;
+    for far in try_far {
+        let mut d2 = dag.clone();
+        let (o, rm, live, sw) = finish_with(&mut d2, root, far);
+        let better = best.as_ref().is_none_or(|(bo, _, bl, _, _)| (live, o.len()) < (*bl, bo.len()));
+        if better {
+            best = Some((o, rm, live, if far { "far" } else { sw }, d2));
+        }
+    }
+    let (o, rm, live, sw, d2) = best.unwrap();
+    *dag = d2;
+    (o, rm, live, sw)
+}
+
+fn finish_with(dag: &mut Dag, root: NodeId, far: bool) -> (Vec<NodeId>, usize, usize, &'static str) {
+    let mut order = schedule_seq(&sequence(dag, root));
+    let mut remat = 0usize;
+    for _ in 0..2 {
+        let mut tiers = vec![RematTier {
+            window: env_usize("EXPS_REMAT_WINDOW", REMAT_WINDOW),
+            cost_max: env_u64("EXPS_REMAT_COST_MAX", REMAT_COST_MAX),
+            ops_max: env_usize("EXPS_REMAT_OPS_MAX", REMAT_OPS_MAX),
+        }];
+        if far {
+            let far_window = env_usize("EXPS_REMAT_FAR_WINDOW", 1024);
+            tiers.push(RematTier {
+                window: far_window.max(1),
+                cost_max: env_u64("EXPS_REMAT_FAR_COST_MAX", REMAT_FAR_COST_MAX),
+                ops_max: env_usize("EXPS_REMAT_FAR_OPS_MAX", REMAT_FAR_OPS_MAX),
+            });
+        }
+        let n = rematerialize(dag, root, &order, &tiers);
+        remat += n;
+        order = schedule_seq(&sequence(dag, root));
+        if n == 0 {
+            break;
+        }
+    }
+    let seq = sequence(dag, root);
+    let mut best_live = live_of_order(dag, root, &order);
+    let mut winner = "postorder";
+    for (name, cand) in [("greedy", schedule(dag, root, &seq)), ("layered", schedule_layered(dag, &seq))] {
+        let l = live_of_order(dag, root, &cand);
+        if l < best_live {
+            best_live = l;
+            order = cand;
+            winner = name;
+        }
+    }
+    (order, remat, best_live, winner)
+}
+
+/// Outcome of the tail for the chosen root: (dag, root, order, clones made,
+/// max-live, schedule winner, cluster winner).
+type Finished = (Dag, NodeId, Vec<NodeId>, usize, usize, &'static str, &'static str);
+
+/// Optimize the Q IR. Returns the original (cloned) IR untouched if its shape
+/// is not the expected single-output SSA expression.
+pub fn optimize(ir: &Ir) -> (Ir, OptStats) {
+    optimize_opts(ir, true, true)
+}
+
+/// `hoist`/`powers`: whether the target kernel has the per-launch table
+/// (Q kernels do; the standalone non-Q expression kernels do not).
+pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
+    let mut stats = OptStats {
+        ops_before: ir.instrs.len(),
+        cost_before: ir_cost(ir),
+        max_live_before: max_live(ir),
+        ..Default::default()
+    };
+    let Some((mut dag, out)) = build_dag(ir) else {
+        let clone = linearize_identity(ir);
+        stats.ops_after = stats.ops_before;
+        stats.cost_after = stats.cost_before;
+        stats.max_live_after = stats.max_live_before;
+        return (clone, stats);
+    };
+
+    // Horner -> sum of powers (optionally under a trailing `* Zi`).
+    let root = out;
+    let mut pow: Option<(u64, u64)> = None;
+    let mut finished: Option<Finished> = None;
+    if let Some(vc) = combination_challenge(&dag).filter(|_| powers) {
+        let (acc, zi) = match dag.nodes[out].kind {
+            Kind::Op { op: MUL, a, b } if matches!(dag.nodes[b].kind, Kind::Leaf(Operand::Zi)) => (a, Some(b)),
+            Kind::Op { op: MUL, a, b } if matches!(dag.nodes[a].kind, Kind::Leaf(Operand::Zi)) => (b, Some(a)),
+            _ => (out, None),
+        };
+        if let Some(terms) = horner_terms(&dag, acc, vc) {
+            stats.horner_terms = terms.len();
+            if std::env::var("EXPS_OPT_DEBUG").as_deref() == Ok("3") {
+                linear_census(&dag, &terms, &format!("ops {}", ir.instrs.len()));
+            }
+            let Kind::Leaf(Operand::Ch { base }) = dag.nodes[vc].kind else { unreachable!() };
+            let terms = if std::env::var("EXPS_LTD").map_or(true, |v| v != "0") {
+                let (t, n_lin, n_atoms) = distribute_linear(&mut dag, &terms, vc, base);
+                stats.ltd_terms = n_lin;
+                stats.ltd_atoms = n_atoms;
+                t
+            } else {
+                terms
+            };
+            let rc = refcounts(&dag, acc);
+            let pre = schedule_seq(&sequence(&dag, acc));
+            let ex = exclusive_costs(&dag, &pre, &rc, u64::MAX);
+            let cands = cluster_candidates(&dag, &terms, &rc, &ex);
+            // Every candidate term order gets the full tail (chain, remat,
+            // schedule choice) on its own DAG copy; the one with the lowest
+            // FINAL max-live wins (ties: fewer ops). Comparing before remat
+            // picked wrong: the cheap values remat removes dominate there.
+            let mut best_key: Option<(usize, usize)> = None;
+            for (cname, order) in &cands {
+                let mut d2 = dag.clone();
+                let mut max_pow = 0u64;
+                let mut sum: Option<NodeId> = None;
+                for &ti in order {
+                    let (c, p) = terms[ti];
+                    let term = match p {
+                        0 => c,
+                        1 => d2.op(MUL, vc, c),
+                        j => {
+                            max_pow = max_pow.max(j);
+                            let pw = d2.leaf(&Operand::Pow { base, j });
+                            d2.op(MUL, pw, c)
+                        }
+                    };
+                    sum = Some(match sum {
+                        None => term,
+                        Some(s) => d2.op(ADD, s, term),
+                    });
+                }
+                let sum = sum.unwrap();
+                let r = match zi {
+                    Some(z) => d2.op(MUL, sum, z),
+                    None => sum,
+                };
+                let (o, rm, live, sw) = finish(&mut d2, r);
+                let key = (live, o.len());
+                if best_key.is_none_or(|bk| key < bk) {
+                    best_key = Some(key);
+                    // size the table by the powers actually read under the root
+                    // (coefficients fold powers in, so term exponents alone under-count)
+                    let _ = max_pow;
+                    pow = max_pow_used(&d2, r).map(|mj| (base, mj + 1));
+                    finished = Some((d2, r, o, rm, live, sw, cname));
+                }
+            }
+        }
+    }
+    let (dag, root, order, remat, live, sched_winner, cluster_winner) = match finished {
+        Some(f) => f,
+        None => {
+            let (o, rm, live, sw) = finish(&mut dag, root);
+            (dag, root, o, rm, live, sw, "none")
+        }
+    };
+    stats.remat = remat;
+    if std::env::var("EXPS_OPT_DEBUG").is_ok() {
+        eprintln!(
+            "[exps-opt-debug] ops {} terms {} cluster winner: {cluster_winner}, schedule winner: {sched_winner} (max-live {live})",
+            order.len(),
+            stats.horner_terms
+        );
+        live_breakdown(&dag, root, &order, "chosen");
+    }
+    let opt = linearize(&dag, root, &order, ir, pow, &mut stats, hoist);
+    stats.ops_after = opt.instrs.len();
+    stats.cost_after = ir_cost(&opt);
+    stats.max_live_after = max_live(&opt);
+    (opt, stats)
+}
+
+/// Clone an IR verbatim (used when the optimizer declines).
+fn linearize_identity(ir: &Ir) -> Ir {
+    Ir {
+        instrs: ir
+            .instrs
+            .iter()
+            .map(|i| Instr {
+                op: i.op.clone(),
+                a: i.a.clone(),
+                b: i.b.clone(),
+                dst_is_tmp: i.dst_is_tmp,
+                dst_id: i.dst_id,
+                ddim: i.ddim,
+                idx: i.idx,
+            })
+            .collect(),
+        ncols: ir.ncols.clone(),
+        n_constants: ir.n_constants,
+        n_bits: ir.n_bits,
+        pow: ir.pow,
+        tab: Vec::new(),
+        tab_out: Vec::new(),
+        tab_words: 0,
+    }
+}

--- a/setup/exps-codegen/src/opt.rs
+++ b/setup/exps-codegen/src/opt.rs
@@ -117,6 +117,8 @@ pub struct OptStats {
     pub horner_terms: usize,
     /// Inner Horner chains folded (any challenge, anywhere but the root chain).
     pub inner_chains: usize,
+    /// Whether the inner-fold variant was the one kept for this AIR.
+    pub inner_selected: bool,
     pub max_live_before: usize,
     pub max_live_after: usize,
     pub remat: usize,
@@ -1605,6 +1607,7 @@ fn linearize(
         tab,
         tab_out,
         tab_words,
+        pow_in_regs: false,
     }
 }
 
@@ -1716,7 +1719,7 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
         max_live_before: max_live(ir),
         ..Default::default()
     };
-    let Some((mut dag, out)) = build_dag(ir) else {
+    let Some((dag, out)) = build_dag(ir) else {
         let clone = linearize_identity(ir);
         stats.ops_after = stats.ops_before;
         stats.cost_after = stats.cost_before;
@@ -1724,6 +1727,58 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
         return (clone, stats);
     };
 
+    // The inner-chain fold is a per-AIR choice, made like the clustering and
+    // schedule choices: both variants run the whole pipeline on a DAG copy and
+    // the slot-aware rule below keeps one. Measured (1.2.0 key, 66-tx block):
+    // folding lowered Main's cost 13.8% -> 10.8% but took its kernel from 0 to 6
+    // cross-chunk slots -- the launcher grid shrinks with slots -- and the kernel
+    // ran 4% slower; on Binary, Rom and the recursion AIRs it won 25-50%. Slots,
+    // not ops, decide for a latency-bound single-chunk kernel.
+    // EXPS_INNER=0 never folds, EXPS_INNER=1 always folds, unset = auto.
+    let inner_mode = std::env::var("EXPS_INNER").ok();
+    let candidates: Vec<bool> = match inner_mode.as_deref() {
+        _ if !powers => vec![false],
+        Some("0") => vec![false],
+        Some(_) => vec![true],
+        None => vec![false, true],
+    };
+    let mut best: Option<(Ir, OptStats, u64)> = None; // (ir, stats, slots at REF_CHUNK)
+    for inner in candidates {
+        let (cand, cstats) = optimize_variant(ir, dag.clone(), out, hoist, powers, inner, stats.clone());
+        let slots = crate::ir::plan_chunks(&cand, REF_CHUNK, "variant").map(|p| p.total_slots).unwrap_or(u64::MAX);
+        let take = match &best {
+            None => true,
+            Some((_, bstats, bslots)) => {
+                // Prefer fewer slots; more slots only for a large cost win. A
+                // variant that introduces slots into a slot-free kernel must
+                // halve the cost to be taken.
+                let cost_ratio = cstats.cost_after as f64 / bstats.cost_after.max(1) as f64;
+                if slots < *bslots {
+                    cost_ratio < 1.25
+                } else if slots == *bslots {
+                    cstats.cost_after < bstats.cost_after
+                } else if *bslots == 0 {
+                    cost_ratio < 0.5
+                } else {
+                    cost_ratio < 0.8
+                }
+            }
+        };
+        if take {
+            best = Some((cand, cstats, slots));
+        }
+    }
+    let (opt, stats, _) = best.expect("at least one variant");
+    (opt, stats)
+}
+
+/// Reference chunk size for comparing the cross-chunk slot count of variants
+/// (the autotuner picks the real size later; the relative comparison is the signal).
+const REF_CHUNK: usize = 512;
+
+/// One full pipeline run for a fixed inner-fold choice: Horner -> powers with
+/// clustering/remat/schedule search on the root chain, then hoisting and SSA.
+fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: bool, inner: bool, mut stats: OptStats) -> (Ir, OptStats) {
     // Horner -> sum of powers (optionally under a trailing `* Zi`).
     //
     // Two passes, in this order. First every INNER chain, over any challenge and anywhere
@@ -1736,7 +1791,8 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
         _ => (out, None),
     };
     let mut out = out;
-    if powers && std::env::var("EXPS_INNER").map_or(true, |v| v != "0") {
+    stats.inner_selected = inner;
+    if powers && inner {
         let root_chain_head = combination_challenge(&dag).map(|_| strip_zi(&dag, out).0);
         let (new_out, n) = fold_inner_chains(&mut dag, out, root_chain_head);
         stats.inner_chains = n;
@@ -1854,5 +1910,6 @@ fn linearize_identity(ir: &Ir) -> Ir {
         tab: Vec::new(),
         tab_out: Vec::new(),
         tab_words: 0,
+        pow_in_regs: false,
     }
 }

--- a/setup/exps-codegen/src/opt.rs
+++ b/setup/exps-codegen/src/opt.rs
@@ -18,7 +18,7 @@
 
 use crate::field;
 use crate::ir::{Instr, Ir, Operand};
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 
 type NodeId = usize;
 
@@ -115,6 +115,8 @@ pub struct OptStats {
     pub cost_before: u64,
     pub cost_after: u64,
     pub horner_terms: usize,
+    /// Inner Horner chains folded (any challenge, anywhere but the root chain).
+    pub inner_chains: usize,
     pub max_live_before: usize,
     pub max_live_after: usize,
     pub remat: usize,
@@ -873,19 +875,22 @@ fn distribute_linear(
     (out, n_lin, n_atoms)
 }
 
-/// Largest power index read anywhere under `root` (Pow leaves), for sizing
-/// the per-launch powers table.
-fn max_pow_used(dag: &Dag, root: NodeId) -> Option<u64> {
+/// Powers table needed by the `Pow` leaves read under `root`: one `(ch_base, n)`
+/// region per challenge, sorted by base, sized to the largest exponent used.
+fn powers_used(dag: &Dag, root: NodeId) -> Vec<(u64, u64)> {
     let mut seen = vec![false; dag.nodes.len()];
     let mut stack = vec![root];
-    let mut mx: Option<u64> = None;
+    let mut mx: BTreeMap<u64, u64> = BTreeMap::new();
     while let Some(n) = stack.pop() {
         if seen[n] {
             continue;
         }
         seen[n] = true;
         match &dag.nodes[n].kind {
-            Kind::Leaf(Operand::Pow { j, .. }) => mx = Some(mx.map_or(*j, |m| m.max(*j))),
+            Kind::Leaf(Operand::Pow { base, j }) => {
+                let e = mx.entry(*base).or_insert(0);
+                *e = (*e).max(*j);
+            }
             Kind::Op { a, b, .. } => {
                 stack.push(*a);
                 stack.push(*b);
@@ -893,7 +898,170 @@ fn max_pow_used(dag: &Dag, root: NodeId) -> Option<u64> {
             _ => {}
         }
     }
-    mx
+    mx.into_iter().map(|(b, mj)| (b, mj + 1)).collect()
+}
+
+/// Weighted cost of one op, in the same units as `distribute_linear`: a cubic
+/// multiply is the expensive one, an extension-by-base far cheaper.
+fn wcost(op: u8, da: u64, db: u64) -> u64 {
+    let (lo, hi) = (da.min(db), da.max(db));
+    if op == MUL {
+        match (lo, hi) {
+            (1, 1) => 1,
+            (1, 3) => 3,
+            _ => 6,
+        }
+    } else if hi == 3 {
+        3
+    } else {
+        1
+    }
+}
+
+/// Every maximal Horner chain over a single challenge, keyed by the node that
+/// heads it: `(challenge leaf, [(exponent, term)])`. Generalizes `horner_terms`,
+/// which only walks the one chain over `std_vc` that ends at the root, to the
+/// whole DAG and every challenge -- which is what reaches the stage-2 bus
+/// fingerprints `compress_exprs` builds (`e_j = sum_k a_k * alpha^k`), sitting
+/// deep inside the expression rather than at its root.
+///
+/// A `SUB` never extends a chain (it would silently turn `a - b` into `a + b`),
+/// and a chain over one challenge is never extended by a multiply against a
+/// different one (that would invent a power that does not exist).
+fn all_chains(dag: &Dag, order: &[NodeId]) -> HashMap<NodeId, (NodeId, Vec<(u64, NodeId)>)> {
+    let mut chain: HashMap<NodeId, (NodeId, Vec<(u64, NodeId)>)> = HashMap::new();
+    for &v in order {
+        let Kind::Op { op, a, b } = dag.nodes[v].kind else { continue };
+        if op == MUL {
+            for (c, other) in [(a, b), (b, a)] {
+                if !matches!(dag.nodes[c].kind, Kind::Leaf(Operand::Ch { .. })) || other == c {
+                    continue;
+                }
+                let terms = match chain.get(&other) {
+                    // extending this challenge's own chain: every exponent goes up by one
+                    Some((ch, t)) if *ch == c => t.iter().map(|&(p, x)| (p + 1, x)).collect(),
+                    _ => vec![(1u64, other)],
+                };
+                chain.insert(v, (c, terms));
+                break;
+            }
+        } else if op == ADD {
+            let (ca, cb) = (chain.get(&a).cloned(), chain.get(&b).cloned());
+            match (ca, cb) {
+                (Some((ch, mut t)), None) => {
+                    t.push((0, b));
+                    chain.insert(v, (ch, t));
+                }
+                (None, Some((ch, mut t))) => {
+                    t.push((0, a));
+                    chain.insert(v, (ch, t));
+                }
+                _ => {}
+            }
+        }
+    }
+    chain
+}
+
+/// Rewrite every maximal inner Horner chain into `sum_j Pow{ch,j} * term`, returning
+/// the new root and how many chains fired. `skip` is the head of the chain the caller
+/// handles itself (the root constraint combination), left untouched so its clustering,
+/// rematerialization and scheduling still see the shape they expect.
+///
+/// Folding is refused unless it lowers the weighted cost: a chain of two variable terms
+/// costs one `mul31` + one add as Horner, and two `mul31`s + one add folded, so it must
+/// not fire there.
+fn fold_inner_chains(dag: &mut Dag, root: NodeId, skip: Option<NodeId>) -> (NodeId, usize) {
+    let order = post_order(dag, root);
+    let chain = all_chains(dag, &order);
+    let mut folded = 0usize;
+    // children before parents, so a term is already rewritten when its chain is emitted
+    let mut done: HashMap<NodeId, NodeId> = HashMap::new();
+    for &v in &order {
+        let worth = chain.get(&v).filter(|_| Some(v) != skip).and_then(|(ch, terms)| {
+            let n = terms.len();
+            if n < 2 {
+                return None;
+            }
+            // Horner: the outermost term multiplies the raw operand, every later step
+            // multiplies the cubic accumulator, and each remaining term costs one add.
+            let head = terms.iter().max_by_key(|&&(p, _)| p).map(|&(_, x)| x).unwrap();
+            let old = wcost(MUL, 3, dag.nodes[head].dim)
+                + (n as u64 - 2) * wcost(MUL, 3, 3)
+                + terms
+                    .iter()
+                    .filter(|&&(_, x)| x != head)
+                    .map(|&(_, x)| wcost(ADD, 3, dag.nodes[x].dim))
+                    .sum::<u64>();
+            // Folded: one extension-by-operand multiply per non-zero exponent (`ch^0`
+            // needs none) and one add per term after the first.
+            let new: u64 = terms
+                .iter()
+                .filter(|&&(p, _)| p > 0)
+                .map(|&(_, x)| wcost(MUL, 3, dag.nodes[x].dim))
+                .sum::<u64>()
+                + (n as u64 - 1) * wcost(ADD, 3, 3);
+            if new < old { Some((*ch, terms.clone())) } else { None }
+        });
+        let nv = match worth {
+            Some((ch_node, terms)) => {
+                let Kind::Leaf(Operand::Ch { base }) = dag.nodes[ch_node].kind else { unreachable!() };
+                folded += 1;
+                let mut acc: Option<NodeId> = None;
+                for &(p, x) in &terms {
+                    let xr = done[&x];
+                    let term = match p {
+                        0 => xr,
+                        1 => dag.op(MUL, ch_node, xr),
+                        j => {
+                            let pw = dag.leaf(&Operand::Pow { base, j });
+                            dag.op(MUL, pw, xr)
+                        }
+                    };
+                    acc = Some(match acc {
+                        None => term,
+                        Some(a) => dag.op(ADD, a, term),
+                    });
+                }
+                acc.expect("a folded chain always yields at least one term")
+            }
+            None => match dag.nodes[v].kind {
+                Kind::Leaf(_) => v,
+                Kind::Op { op, a, b } => {
+                    let (ra, rb) = (done[&a], done[&b]);
+                    if ra == a && rb == b { v } else { dag.op(op, ra, rb) }
+                }
+            },
+        };
+        done.insert(v, nv);
+    }
+    (done[&root], folded)
+}
+
+/// Children-before-parents order over the nodes reachable from `root`.
+fn post_order(dag: &Dag, root: NodeId) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    let mut seen = vec![false; dag.nodes.len()];
+    let mut stack = vec![(root, false)];
+    while let Some((v, expanded)) = stack.pop() {
+        if expanded {
+            out.push(v);
+            continue;
+        }
+        if seen[v] {
+            continue;
+        }
+        seen[v] = true;
+        stack.push((v, true));
+        if let Kind::Op { a, b, .. } = dag.nodes[v].kind {
+            for c in [a, b] {
+                if !seen[c] {
+                    stack.push((c, false));
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Post-order sequence numbers of the nodes reachable from `root`,
@@ -1326,7 +1494,7 @@ fn linearize(
     root: NodeId,
     order: &[NodeId],
     template: &Ir,
-    pow: Option<(u64, u64)>,
+    pow: Vec<(u64, u64)>,
     stats: &mut OptStats,
     allow_hoist: bool,
 ) -> Ir {
@@ -1557,15 +1725,27 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
     };
 
     // Horner -> sum of powers (optionally under a trailing `* Zi`).
+    //
+    // Two passes, in this order. First every INNER chain, over any challenge and anywhere
+    // in the DAG -- that is what reaches the stage-2 bus fingerprints. Then the root
+    // constraint combination below, which additionally gets clustering, remat and a
+    // schedule search, so it is deliberately left for that machinery.
+    let strip_zi = |dag: &Dag, out: NodeId| match dag.nodes[out].kind {
+        Kind::Op { op: MUL, a, b } if matches!(dag.nodes[b].kind, Kind::Leaf(Operand::Zi)) => (a, Some(b)),
+        Kind::Op { op: MUL, a, b } if matches!(dag.nodes[a].kind, Kind::Leaf(Operand::Zi)) => (b, Some(a)),
+        _ => (out, None),
+    };
+    let mut out = out;
+    if powers && std::env::var("EXPS_INNER").map_or(true, |v| v != "0") {
+        let root_chain_head = combination_challenge(&dag).map(|_| strip_zi(&dag, out).0);
+        let (new_out, n) = fold_inner_chains(&mut dag, out, root_chain_head);
+        stats.inner_chains = n;
+        out = new_out;
+    }
     let root = out;
-    let mut pow: Option<(u64, u64)> = None;
     let mut finished: Option<Finished> = None;
     if let Some(vc) = combination_challenge(&dag).filter(|_| powers) {
-        let (acc, zi) = match dag.nodes[out].kind {
-            Kind::Op { op: MUL, a, b } if matches!(dag.nodes[b].kind, Kind::Leaf(Operand::Zi)) => (a, Some(b)),
-            Kind::Op { op: MUL, a, b } if matches!(dag.nodes[a].kind, Kind::Leaf(Operand::Zi)) => (b, Some(a)),
-            _ => (out, None),
-        };
+        let (acc, zi) = strip_zi(&dag, out);
         if let Some(terms) = horner_terms(&dag, acc, vc) {
             stats.horner_terms = terms.len();
             if std::env::var("EXPS_OPT_DEBUG").as_deref() == Ok("3") {
@@ -1618,10 +1798,7 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
                 let key = (live, o.len());
                 if best_key.is_none_or(|bk| key < bk) {
                     best_key = Some(key);
-                    // size the table by the powers actually read under the root
-                    // (coefficients fold powers in, so term exponents alone under-count)
                     let _ = max_pow;
-                    pow = max_pow_used(&d2, r).map(|mj| (base, mj + 1));
                     finished = Some((d2, r, o, rm, live, sw, cname));
                 }
             }
@@ -1634,6 +1811,10 @@ pub fn optimize_opts(ir: &Ir, hoist: bool, powers: bool) -> (Ir, OptStats) {
             (dag, root, o, rm, live, sw, "none")
         }
     };
+    // Size the table from the powers actually read under the final root: coefficients
+    // fold powers in, so term exponents alone under-count, and the inner pass emits
+    // powers of challenges the root chain never touches.
+    let pow = powers_used(&dag, root);
     stats.remat = remat;
     if std::env::var("EXPS_OPT_DEBUG").is_ok() {
         eprintln!(
@@ -1669,7 +1850,7 @@ fn linearize_identity(ir: &Ir) -> Ir {
         ncols: ir.ncols.clone(),
         n_constants: ir.n_constants,
         n_bits: ir.n_bits,
-        pow: ir.pow,
+        pow: ir.pow.clone(),
         tab: Vec::new(),
         tab_out: Vec::new(),
         tab_words: 0,

--- a/setup/exps-codegen/src/opt.rs
+++ b/setup/exps-codegen/src/opt.rs
@@ -6,11 +6,20 @@
 //!    is rewritten as `Σ vcʲ·cᵢ` with `vcʲ` read from a per-launch powers
 //!    table (`Operand::Pow`). A base-field constraint then costs a `mul13`
 //!    instead of a `mul33`, and the terms become order-independent.
-//! 3. **Term clustering** — terms are ordered greedily so consecutive terms
-//!    share as many subtrees/columns as possible.
-//! 4. **Rematerialization** — shared single-op-on-leaves values whose uses
-//!    are far apart in that order are duplicated instead of kept live.
-//! 5. **List scheduling** — topological order that prefers ops freeing
+//! 3. **Inner-chain folding** — the same rewrite for Horner chains over any
+//!    challenge anywhere in the DAG (bus fingerprints), cost-gated; tried
+//!    with and without, the variant with fewer cross-chunk slots wins.
+//! 4. **Linear-term distribution** — affine terms `Σ inv_k·atom_k` are
+//!    distributed over the powers so their row-invariant coefficients merge
+//!    across terms and leave the per-row work.
+//! 5. **Invariant hoisting** — row-invariant subexpressions are evaluated
+//!    once per launch into the table (`Operand::Tab`) instead of per row.
+//! 6. **Term clustering** — two candidate term orders (live-aware greedy,
+//!    reverse Cuthill–McKee over shared features); each gets the full tail
+//!    below on a DAG copy and the lower final max-live wins.
+//! 7. **Rematerialization** — cheap shared values (≤ 3 ops) whose uses are far
+//!    apart in that order are recomputed instead of kept live.
+//! 8. **List scheduling** — topological order that prefers ops freeing
 //!    registers, tie-broken by the clustered order.
 //!
 //! Field arithmetic is exact, so any topological order of the DAG computes
@@ -31,6 +40,13 @@ enum Kind {
 const ADD: u8 = 0;
 const SUB: u8 = 1;
 const MUL: u8 = 2;
+
+/// Diagnostic verbosity: EXPS_OPT_DEBUG=1 prints the per-AIR schedule/live
+/// summary, 2 adds the longest-held shared values at the live peak. Unset or 0
+/// = silent.
+fn opt_debug() -> u32 {
+    std::env::var("EXPS_OPT_DEBUG").ok().and_then(|v| v.parse().ok()).unwrap_or(0)
+}
 
 fn op_code(op: &str) -> u8 {
     match op {
@@ -130,7 +146,9 @@ pub struct OptStats {
     pub ltd_atoms: usize,
 }
 
-/// Rough instruction cost of one op by operand dims, for reporting only.
+/// Instruction cost of one op by operand dims (cubic multiplies dominate).
+/// Drives the remat candidate selection and the clustering weights, and the
+/// reported cost totals.
 fn cost(op: u8, ad: u64, bd: u64) -> u64 {
     match (op, ad, bd) {
         (MUL, 1, 1) => 4,
@@ -293,81 +311,6 @@ fn refcounts(dag: &Dag, root: NodeId) -> Vec<u32> {
     rc
 }
 
-/// Feature bitset of a term: the shared Op nodes and column leaves it reads.
-fn term_features(dag: &Dag, term: NodeId, feat_idx: &HashMap<NodeId, usize>, words: usize) -> Vec<u64> {
-    let mut bits = vec![0u64; words];
-    let mut stack = vec![term];
-    let mut seen: HashSet<NodeId> = HashSet::new();
-    while let Some(n) = stack.pop() {
-        if !seen.insert(n) {
-            continue;
-        }
-        if let Some(&fi) = feat_idx.get(&n) {
-            bits[fi / 64] |= 1u64 << (fi % 64);
-            if !dag.is_leaf(n) {
-                continue; // a shared subtree is one feature; don't descend
-            }
-        }
-        if let Some((a, b)) = dag.children(n) {
-            stack.push(a);
-            stack.push(b);
-        }
-    }
-    bits
-}
-
-fn popcount_and(a: &[u64], b: &[u64]) -> u32 {
-    a.iter().zip(b).map(|(x, y)| (x & y).count_ones()).sum()
-}
-
-/// Greedy nearest-neighbour ordering of the terms by shared features.
-fn cluster_terms(dag: &Dag, terms: &[(NodeId, u64)], rc: &[u32]) -> Vec<usize> {
-    // features: Op nodes with >1 parent, plus column/const leaves
-    let mut feat_idx: HashMap<NodeId, usize> = HashMap::new();
-    for (i, n) in dag.nodes.iter().enumerate() {
-        let is_feat = match &n.kind {
-            Kind::Op { .. } => rc[i] > 1,
-            Kind::Leaf(Operand::Cm { .. }) | Kind::Leaf(Operand::Custom { .. }) | Kind::Leaf(Operand::Const { .. }) => {
-                true
-            }
-            _ => false,
-        };
-        if is_feat {
-            let k = feat_idx.len();
-            feat_idx.insert(i, k);
-        }
-    }
-    let words = feat_idx.len().div_ceil(64).max(1);
-    let feats: Vec<Vec<u64>> = terms.iter().map(|&(t, _)| term_features(dag, t, &feat_idx, words)).collect();
-
-    let n = terms.len();
-    let mut order: Vec<usize> = Vec::with_capacity(n);
-    let mut used = vec![false; n];
-    // start from the first term (keeps the natural order when nothing is shared)
-    let mut cur = 0usize;
-    used[cur] = true;
-    order.push(cur);
-    for _ in 1..n {
-        let mut best = usize::MAX;
-        let mut best_score = -1i64;
-        for j in 0..n {
-            if used[j] {
-                continue;
-            }
-            let s = popcount_and(&feats[cur], &feats[j]) as i64;
-            // tie-break: natural order, so equal-similarity terms stay sequential
-            if s > best_score || (s == best_score && j < best) {
-                best_score = s;
-                best = j;
-            }
-        }
-        used[best] = true;
-        order.push(best);
-        cur = best;
-    }
-    order
-}
-
 /// Per-term sparse feature lists + feature weights. Features are shared Op
 /// nodes (weight = clamped recompute cost, dim-aware) and column/const leaves
 /// (a reload is one load). A shared subtree is one feature: don't descend.
@@ -500,7 +443,6 @@ fn order_rcm(feats: &[Vec<usize>], nfeat: usize) -> Vec<usize> {
     // BFS from `start` over unvisited nodes; returns (order, last level)
     let bfs = |start: usize, visited: &mut [bool]| -> (Vec<usize>, Vec<usize>) {
         let mut out = vec![start];
-        let mut level = vec![start];
         visited[start] = true;
         let mut head = 0usize;
         let mut last_level: Vec<usize> = vec![start];
@@ -521,11 +463,9 @@ fn order_rcm(feats: &[Vec<usize>], nfeat: usize) -> Vec<usize> {
                 }
             }
             if !next.is_empty() {
-                last_level = next.clone();
-                level = next;
+                last_level = next;
             }
         }
-        let _ = level;
         (out, last_level)
     };
     let mut visited = vec![false; n];
@@ -548,139 +488,18 @@ fn order_rcm(feats: &[Vec<usize>], nfeat: usize) -> Vec<usize> {
     order
 }
 
-/// Candidate term orders. EXPS_CLUSTER=nn|live|rcm forces one; by default both
-/// live and rcm are returned and the caller keeps whichever yields the lower
-/// max-live once the sum chain is actually built and scheduled (the cheap
-/// open-count proxy picked wrong on Main and ArithEq, so the selection is exact).
+/// Candidate term orders. EXPS_CLUSTER=live|rcm forces one; by default both
+/// are returned and the caller keeps whichever yields the lower max-live once
+/// the sum chain is actually built and scheduled (the cheap open-count proxy
+/// picked wrong on Main and ArithEq, so the selection is exact).
 fn cluster_candidates(dag: &Dag, terms: &[(NodeId, u64)], rc: &[u32], ex: &[u64]) -> Vec<(&'static str, Vec<usize>)> {
     let (feats, weight) = term_feature_lists(dag, terms, rc, ex);
     let nfeat = weight.len();
     match std::env::var("EXPS_CLUSTER").as_deref() {
-        Ok("nn") => vec![("nn", cluster_terms(dag, terms, rc))],
         Ok("live") => vec![("live", order_live(&feats, &weight))],
         Ok("rcm") => vec![("rcm", order_rcm(&feats, nfeat))],
         _ => vec![("live", order_live(&feats, &weight)), ("rcm", order_rcm(&feats, nfeat))],
     }
-}
-
-/// Row-invariance census (EXPS_OPT_DEBUG=3). Classifies every node as
-/// Invariant (built only from challenges / powers / publics / air values /
-/// numbers: the same for every row, so computable once per launch), Linear
-/// (an affine form Σ inv_k·atom_k + inv_0 over row-dependent base-field atoms:
-/// columns, constants, Zi, and base×base products) or Opaque (anything else,
-/// e.g. products with cubic columns). A Linear Horner term c_j makes
-/// vc^j·c_j = Σ (vc^j·inv_k)·atom_k: its mul33 disappears, the coefficients go
-/// to the per-launch table and merge across terms sharing an atom. Reports how
-/// much of the Q cost that shape covers, to decide whether the rewrite is worth
-/// building.
-#[derive(Clone)]
-enum Lf {
-    Inv,
-    Lin(HashSet<NodeId>),
-    Opaque,
-}
-
-fn lf_classify(dag: &Dag, n: NodeId, memo: &mut HashMap<NodeId, Lf>) -> Lf {
-    if let Some(v) = memo.get(&n) {
-        return v.clone();
-    }
-    let v = match &dag.nodes[n].kind {
-        Kind::Leaf(op) => match op {
-            Operand::Num(_)
-            | Operand::Ch { .. }
-            | Operand::Pow { .. }
-            | Operand::Pub { .. }
-            | Operand::Av { .. }
-            | Operand::Agv { .. }
-            | Operand::Tab { .. } => Lf::Inv,
-            Operand::Cm { dim: 3, .. } | Operand::Custom { dim: 3, .. } => Lf::Opaque,
-            Operand::Cm { .. } | Operand::Custom { .. } | Operand::Const { .. } | Operand::Zi => {
-                Lf::Lin(HashSet::from([n]))
-            }
-            Operand::Tmp { .. } => Lf::Opaque,
-        },
-        Kind::Op { op, a, b } => {
-            let la = lf_classify(dag, *a, memo);
-            let lb = lf_classify(dag, *b, memo);
-            match (*op, la, lb) {
-                (_, Lf::Inv, Lf::Inv) => Lf::Inv,
-                (ADD | SUB, Lf::Inv, Lf::Lin(s)) | (ADD | SUB, Lf::Lin(s), Lf::Inv) => Lf::Lin(s),
-                (ADD | SUB, Lf::Lin(mut x), Lf::Lin(y)) => {
-                    x.extend(y);
-                    Lf::Lin(x)
-                }
-                (MUL, Lf::Inv, Lf::Lin(s)) | (MUL, Lf::Lin(s), Lf::Inv) => Lf::Lin(s),
-                // base x base is a fresh row-dependent atom; cubic results are not affine
-                (MUL, Lf::Lin(_), Lf::Lin(_)) if dag.nodes[n].dim == 1 => Lf::Lin(HashSet::from([n])),
-                _ => Lf::Opaque,
-            }
-        }
-    };
-    memo.insert(n, v.clone());
-    v
-}
-
-fn linear_census(dag: &Dag, terms: &[(NodeId, u64)], label: &str) {
-    let mut memo: HashMap<NodeId, Lf> = HashMap::new();
-    let (mut n_inv, mut n_lin, mut n_opq) = (0usize, 0usize, 0usize);
-    let mut atoms: HashSet<NodeId> = HashSet::new();
-    // unique mul33 nodes reachable from terms of each class
-    let mut m33_lin: HashSet<NodeId> = HashSet::new();
-    let mut m33_all: HashSet<NodeId> = HashSet::new();
-    let mut cost_lin = 0u64;
-    let mut cost_all = 0u64;
-    let mut seen_all: HashSet<NodeId> = HashSet::new();
-    let mut seen_lin: HashSet<NodeId> = HashSet::new();
-    let mut lin_pow_terms = 0usize; // linear terms with p >= 1: their vc^j mul33 vanishes
-    for &(c, p) in terms {
-        let cls = lf_classify(dag, c, &mut memo);
-        let is_lin = matches!(cls, Lf::Lin(_));
-        match &cls {
-            Lf::Inv => n_inv += 1,
-            Lf::Lin(s) => {
-                n_lin += 1;
-                atoms.extend(s.iter().copied());
-                if p >= 1 {
-                    lin_pow_terms += 1;
-                }
-            }
-            Lf::Opaque => n_opq += 1,
-        }
-        // per-term visited set: shared DAG nodes must not be re-expanded
-        let mut seen_term: HashSet<NodeId> = HashSet::new();
-        let mut stack = vec![c];
-        while let Some(n) = stack.pop() {
-            if !seen_term.insert(n) {
-                continue;
-            }
-            let Kind::Op { op, a, b } = dag.nodes[n].kind else { continue };
-            let cst = cost(op, dag.nodes[a].dim, dag.nodes[b].dim);
-            if seen_all.insert(n) {
-                cost_all += cst;
-                if op == MUL && dag.nodes[a].dim == 3 && dag.nodes[b].dim == 3 {
-                    m33_all.insert(n);
-                }
-            }
-            if is_lin && seen_lin.insert(n) {
-                cost_lin += cst;
-                if op == MUL && dag.nodes[a].dim == 3 && dag.nodes[b].dim == 3 {
-                    m33_lin.insert(n);
-                }
-            }
-            stack.push(a);
-            stack.push(b);
-        }
-    }
-    eprintln!(
-        "[exps-opt-census] {label}: terms {} = inv {n_inv} + lin {n_lin} (with power {lin_pow_terms}) + opaque {n_opq}; distinct atoms in lin terms {}; mul33 inside terms: all {} lin {}; cost inside terms: all {cost_all} lin {cost_lin} ({:.1}%); removable vc^j mul33 ~{} (cost ~{})",
-        terms.len(),
-        atoms.len(),
-        m33_all.len(),
-        m33_lin.len(),
-        if cost_all > 0 { 100.0 * cost_lin as f64 / cost_all as f64 } else { 0.0 },
-        lin_pow_terms,
-        lin_pow_terms as u64 * 40
-    );
 }
 
 /// Symbolic affine form of a row-dependent value: Σ coef_k·atom_k + cst, with
@@ -990,20 +809,17 @@ fn fold_inner_chains(dag: &mut Dag, root: NodeId, skip: Option<NodeId>) -> (Node
             let head = terms.iter().max_by_key(|&&(p, _)| p).map(|&(_, x)| x).unwrap();
             let old = wcost(MUL, 3, dag.nodes[head].dim)
                 + (n as u64 - 2) * wcost(MUL, 3, 3)
-                + terms
-                    .iter()
-                    .filter(|&&(_, x)| x != head)
-                    .map(|&(_, x)| wcost(ADD, 3, dag.nodes[x].dim))
-                    .sum::<u64>();
+                + terms.iter().filter(|&&(_, x)| x != head).map(|&(_, x)| wcost(ADD, 3, dag.nodes[x].dim)).sum::<u64>();
             // Folded: one extension-by-operand multiply per non-zero exponent (`ch^0`
             // needs none) and one add per term after the first.
-            let new: u64 = terms
-                .iter()
-                .filter(|&&(p, _)| p > 0)
-                .map(|&(_, x)| wcost(MUL, 3, dag.nodes[x].dim))
-                .sum::<u64>()
-                + (n as u64 - 1) * wcost(ADD, 3, 3);
-            if new < old { Some((*ch, terms.clone())) } else { None }
+            let new: u64 =
+                terms.iter().filter(|&&(p, _)| p > 0).map(|&(_, x)| wcost(MUL, 3, dag.nodes[x].dim)).sum::<u64>()
+                    + (n as u64 - 1) * wcost(ADD, 3, 3);
+            if new < old {
+                Some((*ch, terms.clone()))
+            } else {
+                None
+            }
         });
         let nv = match worth {
             Some((ch_node, terms)) => {
@@ -1031,7 +847,11 @@ fn fold_inner_chains(dag: &mut Dag, root: NodeId, skip: Option<NodeId>) -> (Node
                 Kind::Leaf(_) => v,
                 Kind::Op { op, a, b } => {
                     let (ra, rb) = (done[&a], done[&b]);
-                    if ra == a && rb == b { v } else { dag.op(op, ra, rb) }
+                    if ra == a && rb == b {
+                        v
+                    } else {
+                        dag.op(op, ra, rb)
+                    }
                 }
             },
         };
@@ -1117,6 +937,8 @@ fn schedule(dag: &Dag, root: NodeId, seq: &HashMap<NodeId, usize>) -> Vec<NodeId
         }
         freed
     };
+    // Key (score, -seq position, node): `seq` is a HashMap, so the unique node id
+    // as the final tiebreak is what keeps the schedule deterministic.
     let mut heap: BinaryHeap<(i64, i64, NodeId)> = BinaryHeap::new();
     for (&n, &s) in seq.iter() {
         if pending[n] == 0 {
@@ -1242,12 +1064,12 @@ fn clone_size(dag: &Dag, n: NodeId, rc: &[u32], ex: &[u64], cost_max: u64, memo:
 /// Duplicate cheap shared subtrees for users that are far apart in the
 /// schedule: recomputing them is cheaper than keeping them live (a register,
 /// or a scratch slot across chunks). Returns the number of clones made.
-/// Remat tiers: (distance window, max recompute cost, max clone size). A use
+/// Remat tier: (distance window, max recompute cost, max clone size). A use
 /// further than the window from the previous use is served by a fresh clone if
-/// the value is within the tier's cost/size caps. The far tier admits costlier
-/// clones: holding a value across thousands of ops costs a scratch slot per
-/// chunk boundary (and shrinks the adaptive grid), which outweighs a few more
-/// instructions.
+/// the value is within the cost/size caps. Clones are appended to `dag.nodes`
+/// directly and users are re-pointed in place, bypassing the hash-consing
+/// `memo`: after this pass `Dag::op` must not be used to build new nodes (it
+/// could CSE a clone back into its original), and nothing downstream does.
 struct RematTier {
     window: usize,
     cost_max: u64,
@@ -1308,7 +1130,7 @@ fn rematerialize(dag: &mut Dag, root: NodeId, order: &[NodeId], tiers: &[RematTi
     clones
 }
 
-/// Diagnostic (EXPS_OPT_DEBUG=1): at the max-live point of `order`, bucket the
+/// Diagnostic (EXPS_OPT_DEBUG>=1): at the max-live point of `order`, bucket the
 /// live values by how they are held: term-internal (single use, finishing the
 /// current term) vs shared, and for shared ones by exclusive recompute cost and
 /// by distance to their last use. Tells whether pressure comes from CSE keeping
@@ -1374,8 +1196,8 @@ fn live_breakdown(dag: &Dag, root: NodeId, order: &[NodeId], label: &str) {
             shared_exp += 1;
         }
     }
-    // EXPS_OPT_DEBUG=2: structure of the longest-held shared values at the peak
-    if std::env::var("EXPS_OPT_DEBUG").as_deref() == Ok("2") {
+    // EXPS_OPT_DEBUG>=2: structure of the longest-held shared values at the peak
+    if opt_debug() >= 2 {
         let mut first_use: HashMap<NodeId, usize> = HashMap::new();
         for (i, &n) in order.iter().enumerate() {
             if let Some((a, b)) = dag.children(n) {
@@ -1413,7 +1235,6 @@ fn live_breakdown(dag: &Dag, root: NodeId, order: &[NodeId], label: &str) {
             );
         }
     }
-    let _ = pos;
     eprintln!(
         "[exps-opt-debug] {label}: max-live {best} at op {best_at}/{}: single-use {single}, shared cheap(<=16) {shared_cheap}, mid(17..64) {shared_mid}, expensive(>64) {shared_exp}; far(>256 ops to last use) {far}, mean dist {}",
         order.len(),
@@ -1452,7 +1273,6 @@ fn schedule_seq(seq: &HashMap<NodeId, usize>) -> Vec<NodeId> {
     v.into_iter().map(|(_, n)| n).collect()
 }
 
-/// Linearize a schedule into fresh SSA IR.
 /// Is this leaf the same for every row? Challenges, their powers, publics,
 /// air/airgroup values and literals are; columns, constants and Zi are not.
 fn invariant_leaf(o: &Operand) -> bool {
@@ -1500,7 +1320,7 @@ fn linearize(
     stats: &mut OptStats,
     allow_hoist: bool,
 ) -> Ir {
-    let hoist = allow_hoist && std::env::var("EXPS_HOIST").map_or(true, |v| v != "0");
+    let hoist = allow_hoist && std::env::var("EXPS_HOIST").ok().is_none_or(|v| v != "0");
     let inv = invariant_nodes(dag, order);
     let hoisting = hoist && !inv[root];
     // table program: invariant op nodes in order; exports: those used by a row-dependent op
@@ -1583,7 +1403,7 @@ fn linearize(
     }
     stats.tab_ops = tab.len();
     stats.tab_words = tab_words;
-    if std::env::var("EXPS_OPT_DEBUG").is_ok() {
+    if opt_debug() >= 1 {
         let n_tab_opnd =
             instrs.iter().filter(|i| matches!(i.a, Operand::Tab { .. }) || matches!(i.b, Operand::Tab { .. })).count();
         let n_tmp_opnd = instrs.iter().filter(|i| i.a.as_tmp().is_some() || i.b.as_tmp().is_some()).count();
@@ -1727,7 +1547,15 @@ const REF_CHUNK: usize = 512;
 
 /// One full pipeline run for a fixed inner-fold choice: Horner -> powers with
 /// clustering/remat/schedule search on the root chain, then hoisting and SSA.
-fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: bool, inner: bool, mut stats: OptStats) -> (Ir, OptStats) {
+fn optimize_variant(
+    ir: &Ir,
+    mut dag: Dag,
+    out: NodeId,
+    hoist: bool,
+    powers: bool,
+    inner: bool,
+    mut stats: OptStats,
+) -> (Ir, OptStats) {
     // Horner -> sum of powers (optionally under a trailing `* Zi`).
     //
     // Two passes, in this order. First every INNER chain, over any challenge and anywhere
@@ -1753,11 +1581,8 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
         let (acc, zi) = strip_zi(&dag, out);
         if let Some(terms) = horner_terms(&dag, acc, vc) {
             stats.horner_terms = terms.len();
-            if std::env::var("EXPS_OPT_DEBUG").as_deref() == Ok("3") {
-                linear_census(&dag, &terms, &format!("ops {}", ir.instrs.len()));
-            }
             let Kind::Leaf(Operand::Ch { base }) = dag.nodes[vc].kind else { unreachable!() };
-            let terms = if std::env::var("EXPS_LTD").map_or(true, |v| v != "0") {
+            let terms = if std::env::var("EXPS_LTD").ok().is_none_or(|v| v != "0") {
                 let (t, n_lin, n_atoms) = distribute_linear(&mut dag, &terms, vc, base);
                 stats.ltd_terms = n_lin;
                 stats.ltd_atoms = n_atoms;
@@ -1765,6 +1590,11 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
             } else {
                 terms
             };
+            // Refcounts / exclusive costs are taken on the pre-distribution
+            // root: the clustering features are the subtrees the terms shared
+            // in the setup's expression. Coefficients created by the
+            // distribution are not features (they are row-invariant and end
+            // up hoisted to the table, so they cost no per-row live range).
             let rc = refcounts(&dag, acc);
             let pre = schedule_seq(&sequence(&dag, acc));
             let ex = exclusive_costs(&dag, &pre, &rc, u64::MAX);
@@ -1776,7 +1606,6 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
             let mut best_key: Option<(usize, usize)> = None;
             for (cname, order) in &cands {
                 let mut d2 = dag.clone();
-                let mut max_pow = 0u64;
                 let mut sum: Option<NodeId> = None;
                 for &ti in order {
                     let (c, p) = terms[ti];
@@ -1784,7 +1613,6 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
                         0 => c,
                         1 => d2.op(MUL, vc, c),
                         j => {
-                            max_pow = max_pow.max(j);
                             let pw = d2.leaf(&Operand::Pow { base, j });
                             d2.op(MUL, pw, c)
                         }
@@ -1803,7 +1631,6 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
                 let key = (live, o.len());
                 if best_key.is_none_or(|bk| key < bk) {
                     best_key = Some(key);
-                    let _ = max_pow;
                     finished = Some((d2, r, o, rm, live, sw, cname));
                 }
             }
@@ -1821,7 +1648,7 @@ fn optimize_variant(ir: &Ir, mut dag: Dag, out: NodeId, hoist: bool, powers: boo
     // powers of challenges the root chain never touches.
     let pow = powers_used(&dag, root);
     stats.remat = remat;
-    if std::env::var("EXPS_OPT_DEBUG").is_ok() {
+    if opt_debug() >= 1 {
         eprintln!(
             "[exps-opt-debug] ops {} terms {} cluster winner: {cluster_winner}, schedule winner: {sched_winner} (max-live {live})",
             order.len(),

--- a/setup/exps-codegen/src/toolchain.rs
+++ b/setup/exps-codegen/src/toolchain.rs
@@ -206,7 +206,6 @@ impl Toolchain {
         compile_flags.extend(defs);
         compile_flags.append(&mut incs);
 
-        let _ = &stark_dir; // validated above; not retained
         Ok(Toolchain { arch_list, gencode, compile_flags })
     }
 

--- a/setup/exps-codegen/src/toolchain.rs
+++ b/setup/exps-codegen/src/toolchain.rs
@@ -21,9 +21,9 @@ pub struct Toolchain {
 /// A bare name only works when the CUDA bin dir is on PATH, which a plain shell
 /// often lacks -- the generator then failed before compiling anything.
 pub fn cuda_bin(name: &str) -> std::path::PathBuf {
-    if let Ok(path) = std::env::var("PATH") {
-        for dir in path.split(':') {
-            let p = std::path::Path::new(dir).join(name);
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            let p = dir.join(name);
             if p.is_file() {
                 return p;
             }
@@ -42,27 +42,27 @@ pub fn cuda_bin(name: &str) -> std::path::PathBuf {
     name.into()
 }
 
+/// Is `nvcc` resolvable the way the generator resolves it (PATH, then
+/// `$CUDA_HOME/bin`, then `/usr/local/cuda/bin`)? The gate callers use before
+/// requesting codegen, so it cannot disagree with what `Toolchain` would find.
+pub fn nvcc_present() -> bool {
+    cuda_bin("nvcc").is_file()
+}
+
 /// Host GPU compute capability as an arch number (e.g. 120). Tries
-/// `__nvcc_device_query` on PATH, then next to nvcc in the usual CUDA
-/// locations, then `nvidia-smi --query-gpu=compute_cap` ("12.0" -> 120).
-/// A bare `__nvcc_device_query` needs /usr/local/cuda/bin on PATH, which a
-/// plain shell often lacks -- that silently built all six major archs.
+/// `__nvcc_device_query` resolved like every other CUDA tool (`cuda_bin`), then
+/// `nvidia-smi --query-gpu=compute_cap` ("12.0" -> 120). A bare
+/// `__nvcc_device_query` needs /usr/local/cuda/bin on PATH, which a plain
+/// shell often lacks -- that silently built all six major archs.
 fn detect_host_arch() -> Option<u32> {
     let digits = |txt: &str| -> Option<u32> {
         let d: String = txt.lines().next().unwrap_or("").chars().filter(|c| c.is_ascii_digit()).collect();
         d.parse::<u32>().ok().filter(|a| (50..2000).contains(a))
     };
-    let mut candidates: Vec<std::path::PathBuf> = vec!["__nvcc_device_query".into()];
-    if let Ok(p) = std::env::var("CUDA_HOME") {
-        candidates.push(std::path::Path::new(&p).join("bin/__nvcc_device_query"));
-    }
-    candidates.push("/usr/local/cuda/bin/__nvcc_device_query".into());
-    for c in candidates {
-        if let Ok(out) = Command::new(&c).output() {
-            if out.status.success() {
-                if let Some(a) = digits(&String::from_utf8_lossy(&out.stdout)) {
-                    return Some(a);
-                }
+    if let Ok(out) = Command::new(cuda_bin("__nvcc_device_query")).output() {
+        if out.status.success() {
+            if let Some(a) = digits(&String::from_utf8_lossy(&out.stdout)) {
+                return Some(a);
             }
         }
     }

--- a/setup/exps-codegen/src/toolchain.rs
+++ b/setup/exps-codegen/src/toolchain.rs
@@ -17,6 +17,70 @@ pub struct Toolchain {
     compile_flags: Vec<String>,
 }
 
+/// Path of a CUDA binary: PATH first, then $CUDA_HOME/bin, then /usr/local/cuda/bin.
+/// A bare name only works when the CUDA bin dir is on PATH, which a plain shell
+/// often lacks -- the generator then failed before compiling anything.
+pub fn cuda_bin(name: &str) -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in path.split(':') {
+            let p = std::path::Path::new(dir).join(name);
+            if p.is_file() {
+                return p;
+            }
+        }
+    }
+    if let Ok(home) = std::env::var("CUDA_HOME") {
+        let p = std::path::Path::new(&home).join("bin").join(name);
+        if p.is_file() {
+            return p;
+        }
+    }
+    let p = std::path::Path::new("/usr/local/cuda/bin").join(name);
+    if p.is_file() {
+        return p;
+    }
+    name.into()
+}
+
+/// Host GPU compute capability as an arch number (e.g. 120). Tries
+/// `__nvcc_device_query` on PATH, then next to nvcc in the usual CUDA
+/// locations, then `nvidia-smi --query-gpu=compute_cap` ("12.0" -> 120).
+/// A bare `__nvcc_device_query` needs /usr/local/cuda/bin on PATH, which a
+/// plain shell often lacks -- that silently built all six major archs.
+fn detect_host_arch() -> Option<u32> {
+    let digits = |txt: &str| -> Option<u32> {
+        let d: String = txt.lines().next().unwrap_or("").chars().filter(|c| c.is_ascii_digit()).collect();
+        d.parse::<u32>().ok().filter(|a| (50..2000).contains(a))
+    };
+    let mut candidates: Vec<std::path::PathBuf> = vec!["__nvcc_device_query".into()];
+    if let Ok(p) = std::env::var("CUDA_HOME") {
+        candidates.push(std::path::Path::new(&p).join("bin/__nvcc_device_query"));
+    }
+    candidates.push("/usr/local/cuda/bin/__nvcc_device_query".into());
+    for c in candidates {
+        if let Ok(out) = Command::new(&c).output() {
+            if out.status.success() {
+                if let Some(a) = digits(&String::from_utf8_lossy(&out.stdout)) {
+                    return Some(a);
+                }
+            }
+        }
+    }
+    if let Ok(out) = Command::new("nvidia-smi").args(["--query-gpu=compute_cap", "--format=csv,noheader"]).output() {
+        if out.status.success() {
+            // "12.0" -> 120, "8.9" -> 89
+            let first = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim().to_string();
+            let mut it = first.split('.');
+            if let (Some(maj), Some(min)) = (it.next(), it.next()) {
+                if let (Ok(m), Ok(n)) = (maj.parse::<u32>(), min.parse::<u32>()) {
+                    return Some(m * 10 + n);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Resolve the requested arch spec into a sorted, de-duplicated arch list.
 /// `auto` (or empty) detects the host GPU and falls back to `major`.
 fn resolve_archs(archspec: &str) -> Vec<u32> {
@@ -25,21 +89,9 @@ fn resolve_archs(archspec: &str) -> Vec<u32> {
         return MAJOR_ARCHS.to_vec();
     }
     if spec.is_empty() || spec == "auto" {
-        // __nvcc_device_query prints the host compute capability (e.g. "120").
-        if let Ok(out) = Command::new("__nvcc_device_query").output() {
-            if out.status.success() {
-                let digits: String = String::from_utf8_lossy(&out.stdout)
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .chars()
-                    .filter(|c| c.is_ascii_digit())
-                    .collect();
-                if let Ok(a) = digits.parse::<u32>() {
-                    eprintln!("[exps-codegen] auto-detected host GPU arch: sm_{a}");
-                    return vec![a];
-                }
-            }
+        if let Some(a) = detect_host_arch() {
+            eprintln!("[exps-codegen] auto-detected host GPU arch: sm_{a}");
+            return vec![a];
         }
         eprintln!("[exps-codegen] arch auto-detect failed -> building 'major': {MAJOR_ARCHS:?}");
         return MAJOR_ARCHS.to_vec();
@@ -165,7 +217,7 @@ impl Toolchain {
     /// Compile one TU to an object. `extra_inc` (the autotuner probe dir) is
     /// searched in addition to the standard includes. Returns (ok, stderr).
     pub fn compile_tu(&self, cuf: &Path, obj: &Path, extra_inc: Option<&Path>) -> Result<(bool, String)> {
-        let mut cmd = Command::new("nvcc");
+        let mut cmd = Command::new(cuda_bin("nvcc"));
         cmd.arg("-c").args(&self.compile_flags).arg(cuf).arg("-o").arg(obj);
         if let Some(inc) = extra_inc {
             cmd.arg(format!("-I{}", inc.display()));
@@ -176,7 +228,7 @@ impl Toolchain {
 
     /// Link pre-compiled objects into a shared library (uses only gencode).
     pub fn link_objs(&self, objs: &[PathBuf], dest: &Path) -> Result<()> {
-        let out = Command::new("nvcc")
+        let out = Command::new(cuda_bin("nvcc"))
             .arg("-shared")
             .args(&self.gencode)
             .args(objs)
@@ -193,7 +245,7 @@ impl Toolchain {
     /// Compile sources and link them into a shared library in one nvcc call
     /// (the no-autotune fallback, where no objects were kept).
     pub fn compile_link_cus(&self, cus: &[PathBuf], dest: &Path) -> Result<()> {
-        let out = Command::new("nvcc")
+        let out = Command::new(cuda_bin("nvcc"))
             .arg("-shared")
             .args(&self.compile_flags)
             .args(cus)

--- a/setup/pil2-stark/src/commands/gen_exps.rs
+++ b/setup/pil2-stark/src/commands/gen_exps.rs
@@ -48,6 +48,7 @@ pub fn run_gen_exps(opts: &GenExpsOptions) -> Result<()> {
         stark_src: opts.stark_src.clone(),
         keep_dir: None,
         dry_run: false,
+        optimize: true,
     };
     let summary = proofman_exps_codegen::generate_all(&opts.proving_key, &cfg)?;
     tracing::info!(

--- a/setup/pil2-stark/src/commands/gen_exps.rs
+++ b/setup/pil2-stark/src/commands/gen_exps.rs
@@ -35,7 +35,7 @@ pub struct GenExpsOptions {
 pub fn run_gen_exps(opts: &GenExpsOptions) -> Result<()> {
     if !nvcc_present() {
         tracing::warn!(
-            "gen-exps requested but nvcc not found on PATH; skipping expression kernel codegen (AIRs use the interpreter)"
+            "gen-exps requested but nvcc not found on PATH, $CUDA_HOME/bin or /usr/local/cuda/bin; skipping expression kernel codegen (AIRs use the interpreter)"
         );
         return Ok(());
     }

--- a/setup/pil2-stark/src/commands/setup.rs
+++ b/setup/pil2-stark/src/commands/setup.rs
@@ -53,11 +53,12 @@ pub struct SetupOptions {
     pub exps_stark_src: Option<String>,
 }
 
-/// True if the CUDA `nvcc` compiler is resolvable on PATH. Used to gate
-/// `--gen-exps` so a setup run on a machine without the CUDA toolchain skips
-/// expression-kernel codegen cleanly instead of erroring mid-compile.
+/// True if the CUDA `nvcc` compiler is resolvable the way the expression
+/// codegen resolves it (PATH, `$CUDA_HOME/bin`, `/usr/local/cuda/bin`). Used
+/// to gate `--gen-exps` so a setup run on a machine without the CUDA toolchain
+/// skips expression-kernel codegen cleanly instead of erroring mid-compile.
 pub(crate) fn nvcc_present() -> bool {
-    which::which("nvcc").is_ok()
+    proofman_exps_codegen::nvcc_present()
 }
 
 /// Run the non-recursive setup pipeline.
@@ -411,10 +412,11 @@ mod tests {
     #[test]
     fn nvcc_present_returns_bool_without_panicking() {
         // Can't assert true/false (host-dependent), but it must not panic and
-        // must agree with whether `nvcc` is actually resolvable on PATH.
+        // must never be false when nvcc is on PATH (the generator looks there first).
         let got = nvcc_present();
-        let actual = which::which("nvcc").is_ok();
-        assert_eq!(got, actual);
+        if which::which("nvcc").is_ok() {
+            assert!(got);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Optimizes the generated GPU expression kernels (`setup/exps-codegen`): the Q (cExp) kernels and the stage-2 bus/hint expression kernels. The setup's expression IR is rewritten by exact field identities only, every output is equivalence-checked against the original on random assignments before it is compiled, and an AIR whose rewrite fails the check or the decline heuristic keeps the setup's expression.

### What the optimizer does (`opt.rs`)
- CSE on a hash-consed DAG (commutative canonicalization, constant folding).
- Horner → powers: `acc = vc·acc + c_i` becomes `Σ vc^j·c_i` with `vc^j` read from a per-launch table (`Operand::Pow`); base-field constraints cost a `mul13` instead of a `mul33`.
- Inner-chain folding: the same rewrite for Horner chains over any challenge (bus fingerprints), cost-gated, and selected per AIR — both variants are built and the one with fewer cross-chunk scratch slots wins (keeps the fold on Keccakf/Sha256f/recursive AIRs, avoids the Main regression it caused).
- Linear-term distribution and row-invariant hoisting: row-invariant subexpressions go to the per-launch table (`Operand::Tab`, evaluated once by the table kernel).
- Live-aware term clustering (two candidate orders, exact final-live selection), bounded rematerialization, list scheduling.
- Adaptive chunk boundaries (DP at live-range minima) and an autotuner that bisects the largest spill-free chunk size (`cuobjdump` STACK gate).
- Stage-2 kernels: same optimizer (no table), challenge powers computed once per thread into registers.

### Numbers (RTX 5090, 66-tx block, aggregation on, 1.2.0-alpha key)
| | baseline | optimized | |
|---|---:|---:|---:|
| Q kernels (nsys, `-t 1`) | 1540 ms | 733 ms | −52% |
| stage-2 kernels | 284 ms | 250 ms | −12% |
| all expression kernels | 1824 ms | 984 ms | −46% |
| Proof Time, `-t 1` | 11.96 s | 10.97 s | −8.3% |
| **Proof Time, default streams (6-run medians)** | **10.56 s** | **9.88 s** | **−6.4%** |

221-tx block without aggregation (1.1.0 key): Q kernels 1741 → 618 ms (−64.5%, Main −81%). All proofs verified.

Measured and rejected (not in the tree): `__launch_bounds__` register caps (+11%), `__ldg` table reads (0), a costlier rematerialization tier (Keccakf +68%), batched Montgomery inverse for stage-2 (+5%), cost-weighted chunking (ncu: c10 of recursive2 is 4× the instructions, not slower per instruction), 2 rows per thread (+42%: the register doubling halves the chunk size and the scratch traffic eats the ILP).

### Usage
`proofman-cli gen-exps --proving-key <provingKey>` regenerates every `.exps.so` (host GPU arch by default, `--arch major` for a distributable set; ~7 min for the ZisK key on one arch). `--no-opt` emits the setup's expression verbatim for A/B. `EXPS_INNER=0|1`, `EXPS_HOIST=0`, `EXPS_LTD=0`, `EXPS_X_OPT=0`, `EXPS_CLUSTER=live|rcm`, `EXPS_ADAPTIVE_CHUNKS=0`, `EXPS_NO_DECLINE=1`, `EXPS_OPT_DEBUG=1|2` are kill switches / diagnostics; defaults are the measured configuration.

### Known follow-ups (perf only, not correctness)
- `fold_inner_chains` cost model assumes the chain's partial accumulators are single-use; a shared intermediate makes the fold a net loss for that chain.
- Clustering features are taken on the pre-distribution DAG (documented in code).
- The crate logs with `eprintln!` like the rest of the codegen path; routing through `tracing` is a separate change.

## Test plan
- [x] `cargo clippy` / `cargo fmt --check` / `cargo test` on `proofman-exps-codegen`
- [x] Full ZisK 1.2.0-alpha key regenerated from this tree: 56 kernels, 0 equivalence mismatches; per-kernel REG/STACK identical to the benchmarked set
- [x] 66-tx block with aggregation, GPU, default streams: proof verified (6 runs per configuration for the medians above)
- [x] Plonk/final proofs verified on the same block