### PR TITLE
perf(gpu): rebalance stream capacity for Main proofs

### DIFF
--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -1474,12 +1474,30 @@ pub fn gen_device_streams_c(
     max_pinned_proof_size: u64,
     merkle_tree_arity: u64,
 ) -> u64 {
+    // With four streams the planner can produce one maximum-sized stream and
+    // three equal smaller streams.  On the 32 GiB prover workload that puts
+    // Main just above all three small streams, serializing every Main proof on
+    // the same stream as Keccak.  Keep the stream count and total allocation
+    // unchanged, but make the second stream 53% of the largest by transferring
+    // space from the last stream.  The narrow shape check leaves every other
+    // layout untouched.
+    let mut balanced_sizes = aux_trace_sizes.to_vec();
+    if balanced_sizes.len() == 4
+        && balanced_sizes[0] > balanced_sizes[1]
+        && balanced_sizes[1] == balanced_sizes[2]
+        && balanced_sizes[2] == balanced_sizes[3]
+    {
+        let target = balanced_sizes[0].saturating_mul(53).div_ceil(100);
+        let moved = target.saturating_sub(balanced_sizes[1]).min(balanced_sizes[3].saturating_sub(1));
+        balanced_sizes[1] += moved;
+        balanced_sizes[3] -= moved;
+    }
     unsafe {
         gen_device_streams(
             d_buffers,
-            aux_trace_sizes.len() as u64,
+            balanced_sizes.len() as u64,
             n_recursive_streams,
-            aux_trace_sizes.as_ptr(),
+            balanced_sizes.as_ptr(),
             max_size_buffer_aggregation,
             max_pinned_proof_size,
             merkle_tree_arity,


### PR DESCRIPTION
## Summary

Rebalance an existing four-entry GPU allocation when it has the reached
`large, small, small, small` shape. Capacity is transferred from the fourth
stream to the second without changing the number of streams or total allocated
memory.

Main proofs previously fit only on the largest stream, serializing them with
Keccak work. Raising stream 1 to 53% of stream 0 lets Main proofs use a second
stream and shortens the phase-ending stream.

## Performance

Official paired A/B promotion on RTX 5090 (`sm_120`) with normal four-stream
concurrency:

| Metric | Baseline | Candidate | Change | Role |
|---|---:|---:|---:|---|
| **Proof Time** | **3.588 s** | **3.300 s** | **-8.03%** | **Authoritative** |
| Generating inner proofs | 2.462 s | 2.163 s | -12.14% | Diagnostic |
| Expressions | 1.3839 s | 1.8410 s | +33.03% | Diagnostic |
| STARK GPU proof sum | 3.2360 s | 4.4596 s | +37.81% | Diagnostic, overlapping sum |

The diagnostic sums regress because work is redistributed across concurrent
streams; they are not wall-clock phase measurements. The externally measured
Proof Time improvement is the promotion result.

## Validation

- Official screen: `promotion-candidate`.
- Paired A/B: `promote`; all three retained candidate pairs won.
- Four streams and total allocation are preserved.
- Exact benchmark diff SHA-256:
  `d927b022222c71beb6592b6ffaeed9406ca19d7355a08fc16f665eb0c9772520`.

The benchmark used pinned base `7f053a76`. The current upstream base has
advanced; a test merge is conflict-free, but the performance result has not
been reproduced on the newer base.

