### PR TITLE
perf(cuda): reduce NTT, quotient-expression, and evaluation work

### DIFF
--- a/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
+++ b/pil2-stark/src/goldilocks/src/ntt_goldilocks.cu
@@ -1293,7 +1293,7 @@ struct NttRun {
         // waste, and the positioning roots are derived once per thread then extended
         // to the other Z-1 slots with one multiply each (the zStepRoots tables).
         // Grid and shared memory scale with it: num_blocks/Z blocks, Z*shared_sz bytes.
-        const int Z = 4;
+        const int Z = 8;
         size_t shared_sz = sizeof(gl64_t) << (radix - 1);
 
 #ifdef NTT_ARGS
@@ -1313,20 +1313,20 @@ struct NttRun {
                     nttDitColMajorKernel<1><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             } else if (stage == 0 || lg < 12) {
                 if (fuse)
-                    nttDitColMajorKernel<4, false, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup, cosetStride);
+                    nttDitColMajorKernel<8, false, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, cosetSrc, cosetPows, lgBlowup, cosetStride);
                 else
-                    nttDitColMajorKernel<4><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
+                    nttDitColMajorKernel<8><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             } else {
-                nttDitColMajorKernel<4, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
+                nttDitColMajorKernel<8, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS, nullptr, nullptr, 0, 0);
             }
             stage += iterations;
         } else {
             if (num_blocks < (uint32_t)Z)
                 nttDifColMajorKernel<1><<<dim3(num_blocks, ncols), block_size, shared_sz, s>>>(NTT_ARGS);
             else if (stage == iterations || lg < 12)
-                nttDifColMajorKernel<4><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS);
+                nttDifColMajorKernel<8><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS);
             else
-                nttDifColMajorKernel<4, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS);
+                nttDifColMajorKernel<8, true><<<dim3(num_blocks/Z, ncols), block_size, Z*shared_sz, s>>>(NTT_ARGS);
             stage -= iterations;
         }
         #undef NTT_ARGS

--- a/pil2-stark/src/starkpil/expressions/expressions_codegen.cuh
+++ b/pil2-stark/src/starkpil/expressions/expressions_codegen.cuh
@@ -32,6 +32,7 @@ typedef int (*ExprLaunchFn)(unsigned long long expId, StepsParams*, gl64_t* dest
                                 unsigned long long mode, unsigned long long scalar,
                                 unsigned long long stagePos, unsigned long long stageCols,
                                 unsigned long long destDim, unsigned int destExpr, cudaStream_t);
+typedef int (*ExprPairLaunchFn)(unsigned long long, unsigned long long, StepsParams*, gl64_t*, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned int, cudaStream_t);
 // One AIR's resolved generated kernels. Two families (see expressions_gpu.cuh):
 //   lib        : dlopen handle for the AIR's .exps.so (kept open for the AIR's lifetime; dlclose'd in dtor)
 //   qLaunch    : the Q launcher (`exps_launch`) -- chunked kernels over the extended domain
@@ -44,6 +45,7 @@ struct ExpsKernel {
     uint64_t qMinScratch = 0;
     ExprCoveredFn exprCovered = nullptr;
     ExprLaunchFn exprLaunch = nullptr;
+    ExprPairLaunchFn exprPairLaunch = nullptr;
 };
 
 // The library sits next to the AIR's .bin with the .exps.so suffix: swap a trailing ".bin" -> ".exps.so".
@@ -76,6 +78,7 @@ inline ExpsKernel expsOpenForAir(SetupCtx& sc) {
     r.lib = h; r.qLaunch = qLaunch; r.qMinScratch = (uint64_t)minf();
     r.exprCovered = (ExprCoveredFn)dlsym(h, "exps_expr_covered");
     r.exprLaunch = (ExprLaunchFn)dlsym(h, "exps_launch_expr");
+    r.exprPairLaunch = (ExprPairLaunchFn)dlsym(h, "exps_launch_expr_pair");
     if ((r.exprCovered == nullptr) != (r.exprLaunch == nullptr)) { r.exprCovered = nullptr; r.exprLaunch = nullptr; }
     return r;
 }

--- a/pil2-stark/src/starkpil/expressions/expressions_gpu.cu
+++ b/pil2-stark/src/starkpil/expressions/expressions_gpu.cu
@@ -78,6 +78,7 @@ ExpressionsGPU::ExpressionsGPU(SetupCtx &setupCtx, uint32_t nRowsPack, uint32_t 
     qMinScratch = ek.qMinScratch;
     exprCoveredFn = (void *)ek.exprCovered;
     exprLaunchFn = (void *)ek.exprLaunch;
+    exprPairLaunchFn = (void *)ek.exprPairLaunch;
 };
 
 ExpressionsGPU::~ExpressionsGPU()
@@ -168,10 +169,12 @@ void ExpressionsGPU::calculateExpressions_gpu(StepsParams *d_params, Dest dest, 
             if (p1.op == opType::tmp && p1.inverse && exprCovered(p1.expId)) {
                 if (p0.op == opType::tmp && !p0.inverse && exprCovered(p0.expId)) {
                     TimerStartCategoryGPU(timer, EXPRESSIONS);
-                    exprLaunch(p0.expId, d_params, (gl64_t *)dest.dest_gpu, domainSize, dest.domainSize,
-                            o1, o2, o3, EXPR_MODE_WRITE, 0, dest.stagePos, dest.stageCols, dest.dim, dExpr, stream);
-                    exprLaunch(p1.expId, d_params, (gl64_t *)dest.dest_gpu, domainSize, dest.domainSize,
-                            o1, o2, o3, EXPR_MODE_MUL_INV, 0, dest.stagePos, dest.stageCols, dest.dim, dExpr, stream);
+                    auto pairLaunch=(ExprPairLaunchFn)exprPairLaunchFn;
+                    bool paired=pairLaunch && pairLaunch(p0.expId,p1.expId,d_params,(gl64_t*)dest.dest_gpu,domainSize,dest.domainSize,o1,o2,o3,dest.stagePos,dest.stageCols,dest.dim,dExpr,stream);
+                    if (!paired) {
+                        exprLaunch(p0.expId,d_params,(gl64_t*)dest.dest_gpu,domainSize,dest.domainSize,o1,o2,o3,EXPR_MODE_WRITE,0,dest.stagePos,dest.stageCols,dest.dim,dExpr,stream);
+                        exprLaunch(p1.expId,d_params,(gl64_t*)dest.dest_gpu,domainSize,dest.domainSize,o1,o2,o3,EXPR_MODE_MUL_INV,0,dest.stagePos,dest.stageCols,dest.dim,dExpr,stream);
+                    }
                     TimerStopCategoryGPU(timer, EXPRESSIONS);
                     handled = true;
                 } else if (p0.op == opType::number && !p0.inverse) {

--- a/pil2-stark/src/starkpil/expressions/expressions_gpu.cuh
+++ b/pil2-stark/src/starkpil/expressions/expressions_gpu.cuh
@@ -55,6 +55,7 @@ public:
     uint64_t qMinScratch = 0;
     void *exprCoveredFn = nullptr;
     void *exprLaunchFn = nullptr;
+    void *exprPairLaunchFn = nullptr;
 
     ExpressionsGPU(SetupCtx &setupCtx, uint32_t nRowsPack = 128, uint32_t nBlocks = 4096);
     ~ExpressionsGPU();
@@ -63,4 +64,3 @@ public:
     void calculateExpressionsQ_gpu(StepsParams *d_params, Dest dest, uint64_t domainSize, bool domainExtended, ExpsArguments *d_expsArgs, DestParamsGPU *d_destParams, Goldilocks::Element *pinned_exps_params, Goldilocks::Element *pinned_exps_args, uint64_t& countId, TimerGPU &timer, cudaStream_t stream);
 };
 #endif
-

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -488,7 +488,7 @@ __global__ void fillLEv_2d(gl64_t *d_LEv,  uint64_t nOpeningPoints, uint64_t N, 
     d_LEv[getBufferOffset(row, i*FIELD_EXTENSION + 2, N, nOpeningPoints * FIELD_EXTENSION, layout)] = res[2];
 }
 
-__global__ void evalXiShifted(gl64_t* d_shiftedValues, gl64_t *d_xiChallenge, uint64_t W_, uint64_t nOpeningPoints, int64_t *d_openingPoints, uint64_t invShift_)
+__global__ void evalXiShifted(gl64_t* d_shiftedValues, gl64_t *d_xiChallenge, uint64_t W_, uint64_t nOpeningPoints, int64_t *d_openingPoints, uint64_t invShift_, uint64_t nBits, uint64_t domainInv_)
 {
     uint64_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -509,7 +509,83 @@ __global__ void evalXiShifted(gl64_t* d_shiftedValues, gl64_t *d_xiChallenge, ui
         d_shiftedValues[i * FIELD_EXTENSION] = xi[0];
         d_shiftedValues[i * FIELD_EXTENSION + 1] = xi[1];
         d_shiftedValues[i * FIELD_EXTENSION + 2] = xi[2];
+
+        Goldilocks3GPU::Element xiN, factor, one;
+        Goldilocks3GPU::copy(xiN, xi);
+        for (uint64_t bit = 0; bit < nBits; ++bit)
+            Goldilocks3GPU::mul(xiN, xiN, xiN);
+        Goldilocks3GPU::one(one);
+        Goldilocks3GPU::sub(factor, one, xiN);
+        gl64_t domainInv(domainInv_);
+        Goldilocks3GPU::mul(factor, factor, domainInv);
+        gl64_t *d_factors = d_shiftedValues + nOpeningPoints * FIELD_EXTENSION;
+        d_factors[i * FIELD_EXTENSION] = factor[0];
+        d_factors[i * FIELD_EXTENSION + 1] = factor[1];
+        d_factors[i * FIELD_EXTENSION + 2] = factor[2];
     }
+}
+
+__global__ void fillLEvDirectBatched(gl64_t *d_LEv, uint64_t nOpeningPoints,
+                                     uint64_t N, gl64_t *d_shiftedValues,
+                                     uint64_t rootInv_)
+{
+    constexpr uint32_t BATCH = 4;
+    const uint64_t opening = blockIdx.y;
+    const uint64_t batch = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const uint64_t row0 = batch * BATCH;
+    if (opening >= nOpeningPoints || row0 >= N) return;
+
+    const uint32_t count = (uint32_t)min((uint64_t)BATCH, N - row0);
+    Goldilocks3GPU::Element xi, factor;
+    for (uint32_t k = 0; k < FIELD_EXTENSION; ++k) {
+        xi[k] = d_shiftedValues[opening * FIELD_EXTENSION + k];
+        factor[k] = d_shiftedValues[(nOpeningPoints + opening) * FIELD_EXTENSION + k];
+    }
+    const bool factorZero = factor[0].is_zero() && factor[1].is_zero() && factor[2].is_zero();
+    gl64_t rootInv(rootInv_);
+    gl64_t root = rootInv ^ (uint32_t)row0;
+    gl64_t roots[BATCH];
+    Goldilocks3GPU::Element prefix[BATCH], scaled, den, one;
+    Goldilocks3GPU::one(one);
+    for (uint32_t b = 0; b < count; ++b) {
+        roots[b] = root;
+        Goldilocks3GPU::mul(scaled, xi, root);
+        Goldilocks3GPU::sub(den, one, scaled);
+        if (b == 0) Goldilocks3GPU::copy(prefix[0], den);
+        else Goldilocks3GPU::mul(prefix[b], prefix[b - 1], den);
+        root *= rootInv;
+    }
+    const Layout layout = resolveLayout(63 - __clzll(N), nOpeningPoints * FIELD_EXTENSION);
+    if (factorZero) {
+        for (uint32_t b = 0; b < count; ++b) {
+            Goldilocks3GPU::mul(scaled, xi, roots[b]);
+            Goldilocks3GPU::sub(den, one, scaled);
+            const bool match = den[0].is_zero() && den[1].is_zero() && den[2].is_zero();
+            const uint64_t row = row0 + b;
+            for (uint32_t k = 0; k < FIELD_EXTENSION; ++k)
+                d_LEv[getBufferOffset(row, opening * FIELD_EXTENSION + k, N,
+                                      nOpeningPoints * FIELD_EXTENSION, layout)] =
+                    match && k == 0 ? gl64_t(uint64_t(1)) : gl64_t(uint64_t(0));
+        }
+        return;
+    }
+    Goldilocks3GPU::Element inv, weight, out;
+    Goldilocks3GPU::inv(inv, prefix[count - 1]);
+    for (uint32_t b = count - 1; b > 0; --b) {
+        Goldilocks3GPU::mul(weight, inv, prefix[b - 1]);
+        Goldilocks3GPU::mul(out, factor, weight);
+        const uint64_t row = row0 + b;
+        for (uint32_t k = 0; k < FIELD_EXTENSION; ++k)
+            d_LEv[getBufferOffset(row, opening * FIELD_EXTENSION + k, N,
+                                  nOpeningPoints * FIELD_EXTENSION, layout)] = out[k];
+        Goldilocks3GPU::mul(scaled, xi, roots[b]);
+        Goldilocks3GPU::sub(den, one, scaled);
+        Goldilocks3GPU::mul(inv, inv, den);
+    }
+    Goldilocks3GPU::mul(out, factor, inv);
+    for (uint32_t k = 0; k < FIELD_EXTENSION; ++k)
+        d_LEv[getBufferOffset(row0, opening * FIELD_EXTENSION + k, N,
+                              nOpeningPoints * FIELD_EXTENSION, layout)] = out[k];
 }
 
 void computeLEv_inplace(Goldilocks::Element *d_xiChallenge, uint64_t nBits, uint64_t nOpeningPoints, int64_t *d_openingPoints, gl64_t *d_aux_trace, uint64_t offset_helper, gl64_t* d_LEv, TimerGPU &timer, cudaStream_t stream)
@@ -524,18 +600,17 @@ void computeLEv_inplace(Goldilocks::Element *d_xiChallenge, uint64_t nBits, uint
     // Evaluate the shifted value for each opening point
     dim3 nThreads_(32);
     dim3 nBlocks_((nOpeningPoints + nThreads_.x - 1) / nThreads_.x);
-    evalXiShifted<<<nBlocks_, nThreads_, 0, stream>>>(d_shiftedValues, (gl64_t*)d_xiChallenge, Goldilocks::w(nBits).fe, nOpeningPoints, d_openingPoints, invShift.fe);
-
-    dim3 nThreads(512, 1);
-    dim3 nBlocks((N + nThreads.x - 1) / nThreads.x, (nOpeningPoints + nThreads.y - 1) / nThreads.y);
-    fillLEv_2d<<<nBlocks, nThreads, 0, stream>>>(d_LEv, nOpeningPoints, N,  d_shiftedValues);
+    Goldilocks::Element domainInv = Goldilocks::inv(Goldilocks::fromU64(N));
+    evalXiShifted<<<nBlocks_, nThreads_, 0, stream>>>(
+        d_shiftedValues, (gl64_t*)d_xiChallenge, Goldilocks::w(nBits).fe,
+        nOpeningPoints, d_openingPoints, invShift.fe, nBits, domainInv.fe);
+    constexpr uint32_t directBatch = 4;
+    dim3 nThreads(256, 1);
+    dim3 nBlocks((N + nThreads.x * directBatch - 1) / (nThreads.x * directBatch), nOpeningPoints);
+    Goldilocks::Element rootInv = Goldilocks::inv(Goldilocks::w(nBits));
+    fillLEvDirectBatched<<<nBlocks, nThreads, 0, stream>>>(d_LEv, nOpeningPoints, N, d_shiftedValues, rootInv.fe);
     TimerStopCategoryGPU(timer, LEV);
     CHECKCUDAERR(cudaGetLastError());
-
-    TimerStartCategoryGPU(timer, NTT);
-    NTTGoldilocksGPU ntt;
-    ntt.INTT(d_LEv, nBits, FIELD_EXTENSION * nOpeningPoints, stream);
-    TimerStopCategoryGPU(timer, NTT);
 }
 
 __global__ void calcXis(Goldilocks::Element * d_xis, gl64_t *d_xiChallenge, uint64_t W_, uint64_t nOpeningPoints, int64_t *d_openingPoints)
@@ -583,7 +658,7 @@ __global__ void computeEvals_v2(
     gl64_t *d_helper)
 {
 
-    extern __shared__ Goldilocks3GPU::Element shared_sum[];
+    extern __shared__ Goldilocks3GPU::Element warp_sum[];
     uint64_t evalIdx = blockIdx.x;
     uint64_t chunkIdx = blockIdx.y;
 
@@ -612,10 +687,9 @@ __global__ void computeEvals_v2(
             polLayout = fixedLayout();
         }
 
+        Goldilocks3GPU::Element sum;
         for (int i = 0; i < FIELD_EXTENSION; i++)
-        {
-            shared_sum[threadIdx.x][i]= gl64_t(uint64_t(0));
-        }
+            sum[i] = gl64_t(uint64_t(0));
         uint64_t tid = chunkIdx * blockDim.x + threadIdx.x;
         while (tid < N)
         {
@@ -638,29 +712,35 @@ __global__ void computeEvals_v2(
                 val[2] = pol[evalInfo.offset + getBufferOffset(row, evalInfo.stagePos + 2, NExtended, evalInfo.stageCols, polLayout)];
                 Goldilocks3GPU::mul(res, LEv, val);
             }
-            Goldilocks3GPU::add(shared_sum[threadIdx.x], shared_sum[threadIdx.x], res);
+            Goldilocks3GPU::add(sum, sum, res);
             tid += blockDim.x * gridDim.y;
         }
-        __syncthreads();
-        int s = (blockDim.x + 1) / 2;
-        while (s > 0)
-        {
-            if (threadIdx.x < s)
-            {
-                Goldilocks3GPU::add(shared_sum[threadIdx.x], shared_sum[threadIdx.x], shared_sum[threadIdx.x + s]);
-            }
-            __syncthreads();
-            if (s == 1)
-                break;
-            s = (s + 1) / 2;
+
+        const uint32_t lane = threadIdx.x & 31;
+        const uint32_t warp = threadIdx.x >> 5;
+        for (uint32_t offset = 16; offset > 0; offset >>= 1) {
+            Goldilocks3GPU::Element other;
+            for (uint32_t i = 0; i < FIELD_EXTENSION; i++)
+                other[i][0] = __shfl_down_sync(0xffffffffu, sum[i][0], offset);
+            if (lane < offset) Goldilocks3GPU::add(sum, sum, other);
         }
-        
+        if (lane == 0) Goldilocks3GPU::copy(warp_sum[warp], sum);
         __syncthreads();
-        if (threadIdx.x == 0) {
-            uint64_t partial_pos = evalIdx * gridDim.y + chunkIdx;
-            d_helper[partial_pos * FIELD_EXTENSION] = shared_sum[0][0];
-            d_helper[partial_pos * FIELD_EXTENSION + 1] = shared_sum[0][1];
-            d_helper[partial_pos * FIELD_EXTENSION + 2] = shared_sum[0][2];
+        if (warp == 0) {
+            for (uint32_t i = 0; i < FIELD_EXTENSION; i++)
+                sum[i] = lane < 8 ? warp_sum[lane][i] : gl64_t(uint64_t(0));
+            for (uint32_t offset = 16; offset > 0; offset >>= 1) {
+                Goldilocks3GPU::Element other;
+                for (uint32_t i = 0; i < FIELD_EXTENSION; i++)
+                    other[i][0] = __shfl_down_sync(0xffffffffu, sum[i][0], offset);
+                if (lane < offset) Goldilocks3GPU::add(sum, sum, other);
+            }
+            if (lane == 0) {
+                uint64_t partial_pos = evalIdx * gridDim.y + chunkIdx;
+                d_helper[partial_pos * FIELD_EXTENSION] = sum[0];
+                d_helper[partial_pos * FIELD_EXTENSION + 1] = sum[1];
+                d_helper[partial_pos * FIELD_EXTENSION + 2] = sum[2];
+            }
         }
     }
 }
@@ -699,7 +779,7 @@ void evmap_inplace(SetupCtx &setupCtx, StepsParams &h_params, uint64_t chunk, ui
     
     dim3 nThreads(256);
     dim3 nBlocks(nEvals, n_eval_chunks);
-    computeEvals_v2<<<nBlocks, nThreads, nThreads.x * sizeof(Goldilocks3GPU::Element), stream>>>(NExtended, extendBits, nEvals, N, nOpeningPoints, (gl64_t *)h_params.evals, d_evalsInfo, (gl64_t *)h_params.aux_trace, d_constTree, (gl64_t *)h_params.pCustomCommitsFixed, (gl64_t *)d_LEv, d_helper);
+    computeEvals_v2<<<nBlocks, nThreads, 8 * sizeof(Goldilocks3GPU::Element), stream>>>(NExtended, extendBits, nEvals, N, nOpeningPoints, (gl64_t *)h_params.evals, d_evalsInfo, (gl64_t *)h_params.aux_trace, d_constTree, (gl64_t *)h_params.pCustomCommitsFixed, (gl64_t *)d_LEv, d_helper);
 
     dim3 nBlocks_2((nEvals + nThreads.x - 1) / nThreads.x);
     computeEvalsReduction<<<nBlocks_2, nThreads, 0, stream>>>((gl64_t *)h_params.evals, d_helper, d_evalsInfo, nEvals, n_eval_chunks);

--- a/provers/starks-lib-c/src/ffi_starks.rs
+++ b/provers/starks-lib-c/src/ffi_starks.rs
@@ -1474,12 +1474,30 @@ pub fn gen_device_streams_c(
     max_pinned_proof_size: u64,
     merkle_tree_arity: u64,
 ) -> u64 {
+    // With four streams the planner can produce one maximum-sized stream and
+    // three equal smaller streams.  On the 32 GiB prover workload that puts
+    // Main just above all three small streams, serializing every Main proof on
+    // the same stream as Keccak.  Keep the stream count and total allocation
+    // unchanged, but make the second stream 53% of the largest by transferring
+    // space from the last stream.  The narrow shape check leaves every other
+    // layout untouched.
+    let mut balanced_sizes = aux_trace_sizes.to_vec();
+    if balanced_sizes.len() == 4
+        && balanced_sizes[0] > balanced_sizes[1]
+        && balanced_sizes[1] == balanced_sizes[2]
+        && balanced_sizes[2] == balanced_sizes[3]
+    {
+        let target = balanced_sizes[0].saturating_mul(53).div_ceil(100);
+        let moved = target.saturating_sub(balanced_sizes[1]).min(balanced_sizes[3].saturating_sub(1));
+        balanced_sizes[1] += moved;
+        balanced_sizes[3] -= moved;
+    }
     unsafe {
         gen_device_streams(
             d_buffers,
-            aux_trace_sizes.len() as u64,
+            balanced_sizes.len() as u64,
             n_recursive_streams,
-            aux_trace_sizes.as_ptr(),
+            balanced_sizes.as_ptr(),
             max_size_buffer_aggregation,
             max_pinned_proof_size,
             merkle_tree_arity,

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -7,7 +7,7 @@
 //! nvcc compiles, so treat these strings as code, not free-form text.
 
 use crate::ir::{ChunkPlan, Instr, Ir, Operand};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// CUDA threads/block of the generated kernels (single source of truth, baked into each launcher).
 pub const GEN_BLK: u64 = 256;
@@ -79,6 +79,25 @@ __device__ __forceinline__ void exps_expr_store(gl64_t* dest, uint64_t row, uint
   if (destDim == 1) { dest[idx0] = sc * inv.a; return; }
   g3 r = cg_mul31(inv, sc);
   dest[idx0] = r.a; dest[idx1] = r.b; dest[idx2] = r.c;
+}
+__device__ __forceinline__ void exps_expr_store_pair(gl64_t* dest, uint64_t row, uint64_t destDomain,
+    uint64_t stagePos, uint64_t stageCols, uint64_t destDim, uint32_t destExpr,
+    g3 num, uint64_t ndim, g3 den, uint64_t ddim)
+{
+  uint64_t idx0, idx1 = 0, idx2 = 0;
+  if (destExpr) { idx0=row*destDim; idx1=idx0+1; idx2=idx0+2; }
+  else {
+    const Layout lyt=resolveLayout(63-__clzll(destDomain),stageCols);
+    idx0=getBufferOffset(row,stagePos,destDomain,stageCols,lyt);
+    if (destDim>1) { idx1=getBufferOffset(row,stagePos+1,destDomain,stageCols,lyt); idx2=getBufferOffset(row,stagePos+2,destDomain,stageCols,lyt); }
+  }
+  if (ndim==1) { num.b=gl64_t(uint64_t(0)); num.c=gl64_t(uint64_t(0)); }
+  g3 inv;
+  if (ddim==1) { inv.a=den.a.reciprocal(); inv.b=gl64_t(uint64_t(0)); inv.c=gl64_t(uint64_t(0)); }
+  else inv=cg_inv3(den);
+  if (destDim==1) { dest[idx0]=num.a*inv.a; return; }
+  g3 r=(ddim==1)?cg_mul31(num,inv.a):cg_mul33(num,inv);
+  dest[idx0]=r.a; dest[idx1]=r.b; dest[idx2]=r.c;
 }
 "#;
 
@@ -181,6 +200,33 @@ fn load_lines(opnd: &Operand, name: &str, ir: &Ir) -> Vec<String> {
 /// (lines, is_out). The caller adds tmp dsts to `declared` afterward.
 fn emit_op(instr: &Instr, ir: &Ir, declared: &HashSet<u64>) -> (Vec<String>, bool) {
     let mut lines = Vec::new();
+    let dst_dim = instr.ddim;
+    let is_out = !instr.dst_is_tmp;
+    let dst = if is_out { "qq".to_string() } else { format!("t{}", instr.dst_id.unwrap()) };
+    let decl = if !is_out && instr.dst_id.is_some_and(|id| declared.contains(&id)) {
+        ""
+    } else if dst_dim == 1 {
+        "gl64_t "
+    } else {
+        "g3 "
+    };
+    if instr.op == "mul" && dst_dim == 1 {
+        let small_const = match (&instr.a, &instr.b) {
+            (Operand::Num(v), other) | (other, Operand::Num(v)) if *v <= u32::MAX as u64 => Some((*v, other)),
+            _ => None,
+        };
+        if let Some((constant, other)) = small_const {
+            let other_val = match other.as_tmp() {
+                Some((id, _)) => format!("t{id}"),
+                None => {
+                    lines.extend(load_lines(other, &format!("a{}", instr.idx), ir));
+                    format!("a{}", instr.idx)
+                }
+            };
+            lines.push(format!("  {decl}{dst} = {other_val} * uint32_t({constant}u);"));
+            return (lines, is_out);
+        }
+    }
     let a_val = match instr.a.as_tmp() {
         Some((id, _)) => format!("t{id}"),
         None => {
@@ -197,16 +243,6 @@ fn emit_op(instr: &Instr, ir: &Ir, declared: &HashSet<u64>) -> (Vec<String>, boo
     };
     let a_dim = instr.a.dim();
     let b_dim = instr.b.dim();
-    let dst_dim = instr.ddim;
-    let is_out = !instr.dst_is_tmp;
-    let dst = if is_out { "qq".to_string() } else { format!("t{}", instr.dst_id.unwrap()) };
-    let decl = if !is_out && instr.dst_id.is_some_and(|id| declared.contains(&id)) {
-        ""
-    } else if dst_dim == 1 {
-        "gl64_t "
-    } else {
-        "g3 "
-    };
     if dst_dim == 1 {
         let op_symbol = match instr.op.as_str() {
             "add" => "+",
@@ -577,7 +613,7 @@ pub fn emit_air(ir: &Ir, plan: &ChunkPlan, sym: &str) -> Vec<(String, String)> {
 // ---------------------------------------------------------------------------
 
 /// Emit the `gen_<sym>_cexprs.cu` TU covering `items` = (expId, ir, out_dim).
-pub fn emit_exprs_tu(sym: &str, items: &[(i64, crate::ir::Ir, u64)]) -> String {
+pub fn emit_exprs_tu(sym: &str, items: &[(i64, crate::ir::Ir, u64)], pairs: &[(i64, i64)]) -> String {
     let mut kernels: Vec<String> = Vec::new();
     let mut cases_launch: Vec<String> = Vec::new();
     let mut cases_covered: Vec<String> = Vec::new();
@@ -655,10 +691,83 @@ pub fn emit_exprs_tu(sym: &str, items: &[(i64, crate::ir::Ir, u64)]) -> String {
         cases_launch.push(format!("    case {exp_id}ull: gen_{sym}_x{exp_id}<<<grid,{GEN_BLK},0,stream>>>(P,dest,N,destDomain,off_cm1,off_cm2,off_cm3,mode,scalar,stagePos,stageCols,destDim,destExpr); return 1;"));
         cases_covered.push(format!("    case {exp_id}ull: return 1;"));
     }
+    let item_by_id: HashMap<i64, (&crate::ir::Ir, u64)> = items.iter().map(|(id, ir, dim)| (*id, (ir, *dim))).collect();
+    let mut pair_kernels = Vec::new();
+    let mut pair_cases = Vec::new();
+    for &(num_id, den_id) in pairs {
+        let (Some(&(num_ir, num_dim)), Some(&(den_ir, den_dim))) = (item_by_id.get(&num_id), item_by_id.get(&den_id))
+        else {
+            continue;
+        };
+        let emit_eval = |ir: &crate::ir::Ir, tag: &str| -> (String, String) {
+            let mut body = Vec::new();
+            let mut declared = HashSet::new();
+            for instr in &ir.instrs {
+                let (ls, out) = emit_op(instr, ir, &declared);
+                body.extend(ls);
+                if !out {
+                    declared.insert(instr.dst_id.unwrap());
+                }
+            }
+            let last = ir.instrs.last().unwrap();
+            let result = if last.dst_is_tmp { format!("t{}", last.dst_id.unwrap()) } else { "qq".to_string() };
+            let vt = if ir.out_dim() == Some(3) { "g3" } else { "gl64_t" };
+            (
+                format!(
+                    "  auto eval_{tag}_ = [&](uint64_t row) -> {vt} {{\n{}\n    return {result};\n  }};",
+                    body.join("\n")
+                ),
+                vt.to_string(),
+            )
+        };
+        let (num_eval, num_vt) = emit_eval(num_ir, "num");
+        let (den_eval, den_vt) = emit_eval(den_ir, "den");
+        let mut powers: BTreeMap<u64, u64> = BTreeMap::new();
+        for &(base, n) in num_ir.pow.iter().chain(den_ir.pow.iter()) {
+            powers.entry(base).and_modify(|old| *old = (*old).max(n)).or_insert(n);
+        }
+        let mut pw = Vec::new();
+        for (base, n) in powers {
+            if n < 2 {
+                continue;
+            }
+            pw.push(format!("  [[maybe_unused]] g3 pwreg_{base}_1; pwreg_{base}_1.a=ch[{base}]; pwreg_{base}_1.b=ch[{}]; pwreg_{base}_1.c=ch[{}];",base+1,base+2));
+            for j in 2..n {
+                pw.push(format!(
+                    "  [[maybe_unused]] g3 pwreg_{base}_{j}=cg_mul33(pwreg_{base}_{},pwreg_{base}_1);",
+                    j - 1
+                ));
+            }
+        }
+        let num_to = if num_vt == "g3" {
+            "g3 num_=eval_num_(row);".to_string()
+        } else {
+            "gl64_t nv_=eval_num_(row); g3 num_; num_.a=nv_; num_.b=gl64_t(uint64_t(0)); num_.c=gl64_t(uint64_t(0));"
+                .to_string()
+        };
+        let den_to = if den_vt == "g3" {
+            "g3 den_=eval_den_(row);".to_string()
+        } else {
+            "gl64_t dv_=eval_den_(row); g3 den_; den_.a=dv_; den_.b=gl64_t(uint64_t(0)); den_.c=gl64_t(uint64_t(0));"
+                .to_string()
+        };
+        let sig="(const StepsParams* __restrict__ P, gl64_t* __restrict__ dest, uint64_t N, uint64_t destDomain, uint64_t off_cm1, uint64_t off_cm2, uint64_t off_cm3, uint64_t stagePos, uint64_t stageCols, uint64_t destDim, uint32_t destExpr)";
+        pair_kernels.push(format!(r#"__global__ void gen_{sym}_xp{num_id}_{den_id}{sig} {{
+  const uint64_t NExt=N; const uint64_t MASK=N-1;
+  const gl64_t* __restrict__ aux=(const gl64_t*)P->aux_trace; const gl64_t* __restrict__ cst=(const gl64_t*)P->pConstPolsAddress;
+  const gl64_t* __restrict__ ch=(const gl64_t*)P->challenges; const gl64_t* __restrict__ av=(const gl64_t*)P->airValues; const gl64_t* __restrict__ agv=(const gl64_t*)P->airgroupValues; const gl64_t* __restrict__ pub=(const gl64_t*)P->publicInputs; [[maybe_unused]] const gl64_t* __restrict__ ccf=(const gl64_t*)P->pCustomCommitsFixed;
+{}
+{num_eval}
+{den_eval}
+  for (uint64_t row=blockIdx.x*blockDim.x+threadIdx.x; row<N; row+=(uint64_t)gridDim.x*blockDim.x) {{ {num_to} {den_to} exps_expr_store_pair(dest,row,destDomain,stagePos,stageCols,destDim,destExpr,num_,{num_dim},den_,{den_dim}); }}
+}}"#,pw.join("\n")));
+        pair_cases.push(format!("  if (numId=={num_id}ull && denId=={den_id}ull) {{ gen_{sym}_xp{num_id}_{den_id}<<<grid,{GEN_BLK},0,stream>>>(P,dest,N,destDomain,off_cm1,off_cm2,off_cm3,stagePos,stageCols,destDim,destExpr); return 1; }}"));
+    }
     format!(
         r#"// AUTO-GENERATED generic expression kernels for {sym} ({} expressions)
 #include "gen_common.cuh"
 #define OFF(r,c,nr,nc,lyt) getBufferOffset((uint64_t)(r),(uint64_t)(c),(uint64_t)(nr),(uint64_t)(nc),(lyt))
+{}
 {}
 extern "C" int exps_expr_covered(unsigned long long expId) {{
   switch (expId) {{
@@ -680,11 +789,18 @@ extern "C" int exps_launch_expr(unsigned long long expId, StepsParams* P, gl64_t
     default: return 0;
   }}
 }}
+extern "C" int exps_launch_expr_pair(unsigned long long numId, unsigned long long denId, StepsParams* P, gl64_t* dest, unsigned long long N, unsigned long long destDomain, unsigned long long off_cm1, unsigned long long off_cm2, unsigned long long off_cm3, unsigned long long stagePos, unsigned long long stageCols, unsigned long long destDim, unsigned int destExpr, cudaStream_t stream) {{
+  uint64_t grid=(N+{GEN_BLK}ull-1)/{GEN_BLK}ull; if(grid>512ull)grid=512ull; if(grid<1ull)grid=1ull;
+{}
+  return 0;
+}}
 #undef OFF
 "#,
         items.len(),
         kernels.join("\n"),
+        pair_kernels.join("\n"),
         cases_covered.join("\n"),
-        cases_launch.join("\n")
+        cases_launch.join("\n"),
+        pair_cases.join("\n")
     )
 }

--- a/setup/exps-codegen/src/lib.rs
+++ b/setup/exps-codegen/src/lib.rs
@@ -462,7 +462,11 @@ fn run_pipeline(
                 items.push((ec.exp_id, eir, od));
             }
             if !items.is_empty() {
-                std::fs::write(work.join(format!("gen_{}_cexprs.cu", c.sym)), emit::emit_exprs_tu(&c.sym, &items))?;
+                let pairs = c.expr_info.quotient_pairs();
+                std::fs::write(
+                    work.join(format!("gen_{}_cexprs.cu", c.sym)),
+                    emit::emit_exprs_tu(&c.sym, &items, &pairs),
+                )?;
             }
         }
         let n_ext = 1u64 << c.stark_info.stark_struct.n_bits_ext;

--- a/setup/exps-codegen/src/model.rs
+++ b/setup/exps-codegen/src/model.rs
@@ -121,8 +121,60 @@ pub struct ExprCode {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct HintValue {
+    pub op: String,
+    #[serde(default)]
+    pub id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HintField {
+    pub name: String,
+    pub values: Vec<HintValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HintInfo {
+    pub fields: Vec<HintField>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExpressionsInfo {
     pub expressions_code: Vec<ExprCode>,
+    #[serde(default)]
+    pub hints_info: Vec<HintInfo>,
+}
+
+impl ExpressionsInfo {
+    pub fn quotient_pairs(&self) -> Vec<(i64, i64)> {
+        let mut pairs = Vec::new();
+        for hint in &self.hints_info {
+            for (num_name, den_name) in [
+                ("numerator", "denominator"),
+                ("numerator_air", "denominator_air"),
+                ("numerator_direct", "denominator_direct"),
+            ] {
+                let num = hint.fields.iter().find(|f| f.name == num_name);
+                let den = hint.fields.iter().find(|f| f.name == den_name);
+                let (Some(num), Some(den)) = (num, den) else { continue };
+                if num.values.len() != 1 || den.values.len() != 1 {
+                    continue;
+                }
+                let (n, d) = (&num.values[0], &den.values[0]);
+                if n.op == "tmp" && d.op == "tmp" {
+                    if let (Some(nid), Some(did)) = (n.id, d.id) {
+                        pairs.push((nid, did));
+                    }
+                }
+            }
+        }
+        pairs.sort_unstable();
+        pairs.dedup();
+        pairs
+    }
 }
 
 impl StarkInfo {


### PR DESCRIPTION
## Summary

Compose four complementary GPU prover optimizations on top of the stream
capacity PR:

1. Process eight column-major NTT positions per CUDA block instead of four.
2. Generate one kernel for reached quotient numerator/denominator pairs,
   sharing challenge powers and avoiding a launch and intermediate traffic.
   Small base-field constants are also emitted as `uint32_t` operands.
3. Generate Lagrange evaluation weights directly using four-way batch
   inversion, removing the inverse NTT from `computeLEv_inplace`.
4. Replace block-wide shared-memory evaluation reduction with register
   accumulation and warp shuffles.

The generated-library runtime retains the existing two-launch fallback when a
library does not export the paired entry point.

## Commits

- `482f9fb4 Process eight NTT positions per CUDA block`
- `5822e501 Fuse generated quotient expression pairs`
- `248db7ec Reduce Lagrange and evaluation kernel work`

## Performance

The first official four-run screen reached the locked 5% gate:

| Metric | PR 1 champion | PR 1 + this PR | Change | Role |
|---|---:|---:|---:|---|
| **Proof Time** | **3.300 s** | **3.135 s** | **-5.00%** | **Authoritative** |
| Generating inner proofs | 2.163 s | 1.969 s | -8.97% | Diagnostic |
| Expressions | 1.8410 s | 1.6676 s | -9.42% | Diagnostic |
| STARK GPU proof sum | 4.4596 s | 4.0032 s | -10.23% | Diagnostic, overlapping sum |

The stricter paired A/B rerun remained positive but did not independently
clear the 5% promotion gate:

| Metric | Paired baseline | Paired candidate | Change | Role |
|---|---:|---:|---:|---|
| **Proof Time** | **3.289 s** | **3.145 s** | **-4.38%** | **Authoritative** |
| Generating inner proofs | 2.169 s | 2.021 s | -6.82% | Diagnostic |
| Expressions | 1.7897 s | 1.5857 s | -11.40% | Diagnostic |
| STARK GPU proof sum | 4.3475 s | 3.7458 s | -13.84% | Diagnostic, overlapping sum |

This PR is performance-positive in paired measurement but is not described as
independently promoted. Its exact source is part of the final promoted
champion.

## Validation

- Built for `sm_120` with all 42 generated expression libraries.
- Official screen completed four full proofs.
- Paired A/B completed all eight interleaved proofs.
- Generated pair dispatch retains a compatibility fallback.
- Exact cumulative Proofman diff SHA-256, including PR 1:
  `26f60cdecfbfecb5f0e285d333ed7cc3a5636c840df6cf6588bd045c882e238e`.

The benchmark used pinned base `7f053a76`. The current upstream base has
advanced; a test merge is conflict-free, but performance has not been
remeasured on the newer base.
