### PR TITLE
perf(exps-codegen): size generated kernel grids to the actual work

### DIFF
--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -11,6 +11,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// CUDA threads/block of the generated kernels (single source of truth, baked into each launcher).
 pub const GEN_BLK: u64 = 256;
+/// Grid cap for the trace-domain expression launchers (singles AND pairs — same work class, same
+/// prologue-vs-rows tradeoff, one policy). Empirical, not a hardware bound: challenge powers are
+/// rebuilt per THREAD, so a bigger grid trades rows per thread against redundant prologue work.
+/// Per-air tuning belongs in autotune.rs.
+pub const EXPR_GRID_CAP: u64 = 2048;
 /// Chunk kernels bundled per .cu — amortizes the gen_common.cuh header parse across the batch.
 pub const CHUNKS_PER_TU: usize = 8;
 
@@ -774,10 +779,9 @@ extern "C" int exps_launch_expr(unsigned long long expId, StepsParams* P, gl64_t
     unsigned long long mode, unsigned long long scalar,
     unsigned long long stagePos, unsigned long long stageCols,
     unsigned long long destDim, unsigned int destExpr, cudaStream_t stream) {{
-  // Empirical cap, not a hardware bound: challenge powers are rebuilt per THREAD, so a bigger
-  // grid trades rows per thread against redundant prologue work. Per-air tuning: autotune.rs.
+  // Cap rationale: see EXPR_GRID_CAP in emit.rs (shared with the pair launcher below).
   uint64_t grid = (N + {GEN_BLK}ull - 1) / {GEN_BLK}ull;
-  if (grid > 2048ull) grid = 2048ull;
+  if (grid > {EXPR_GRID_CAP}ull) grid = {EXPR_GRID_CAP}ull;
   if (grid < 1ull) grid = 1ull;
   switch (expId) {{
 {}
@@ -785,7 +789,7 @@ extern "C" int exps_launch_expr(unsigned long long expId, StepsParams* P, gl64_t
   }}
 }}
 extern "C" int exps_launch_expr_pair(unsigned long long numId, unsigned long long denId, StepsParams* P, gl64_t* dest, unsigned long long N, unsigned long long destDomain, unsigned long long off_cm1, unsigned long long off_cm2, unsigned long long off_cm3, unsigned long long stagePos, unsigned long long stageCols, unsigned long long destDim, unsigned int destExpr, cudaStream_t stream) {{
-  uint64_t grid=(N+{GEN_BLK}ull-1)/{GEN_BLK}ull; if(grid>512ull)grid=512ull; if(grid<1ull)grid=1ull;
+  uint64_t grid=(N+{GEN_BLK}ull-1)/{GEN_BLK}ull; if(grid>{EXPR_GRID_CAP}ull)grid={EXPR_GRID_CAP}ull; if(grid<1ull)grid=1ull;
 {}
   return 0;
 }}

--- a/setup/exps-codegen/src/emit.rs
+++ b/setup/exps-codegen/src/emit.rs
@@ -447,8 +447,13 @@ void launch_gen_{sym}(StepsParams* d_params, gl64_t* q, gl64_t* scratch, uint64_
   const uint64_t BLK = {GEN_BLK}ull;
 {guard}
 {prologue}
+  // Grid sets how many WAVES the domain is split into, and each wave waits for the previous one
+  // (shared scratch). Occupancy saturates well below the scratch limit, so take what the scratch
+  // allows but never more blocks than there is work for: extra waves only add serialization.
   uint64_t grid = {total_slots}ull ? (scratchElems / ({total_slots}ull*BLK)) : 512ull;
-  if (grid > 512ull) grid = 512ull;
+  const uint64_t need = (NExt + BLK - 1) / BLK;
+  if (grid > need) grid = need;
+  if (grid < 1ull) grid = 1ull;
   const uint64_t WAVE = grid * BLK;
   for (uint64_t base=0; base<NExt; base+=WAVE) {{
 {}
@@ -769,8 +774,10 @@ extern "C" int exps_launch_expr(unsigned long long expId, StepsParams* P, gl64_t
     unsigned long long mode, unsigned long long scalar,
     unsigned long long stagePos, unsigned long long stageCols,
     unsigned long long destDim, unsigned int destExpr, cudaStream_t stream) {{
+  // Empirical cap, not a hardware bound: challenge powers are rebuilt per THREAD, so a bigger
+  // grid trades rows per thread against redundant prologue work. Per-air tuning: autotune.rs.
   uint64_t grid = (N + {GEN_BLK}ull - 1) / {GEN_BLK}ull;
-  if (grid > 512ull) grid = 512ull;
+  if (grid > 2048ull) grid = 2048ull;
   if (grid < 1ull) grid = 1ull;
   switch (expId) {{
 {}


### PR DESCRIPTION
The two emitted launchers both clamped the grid to a hard 512 blocks, which was wrong in opposite directions:

- launch_gen_*: grid counts how many waves the domain is split into, and waves serialize on the shared scratch. Capping at 512 while ignoring NExt left small domains running more waves than they had work for, so bound the grid by the work instead.
- exps_launch_expr: challenge powers are rebuilt per thread, so a larger grid trades rows per thread against redundant prologue work. Raise the cap to 2048; per-air tuning stays in autotune.rs.