### PR TITLE
perf: schedule heavier GPU tables first

### DIFF
--- a/common/src/proof_ctx.rs
+++ b/common/src/proof_ctx.rs
@@ -630,14 +630,27 @@ impl<F: PrimeField64> ProofCtx<F> {
 
     pub fn dctx_get_my_tables(&self) -> Vec<usize> {
         let dctx = self.dctx.read().unwrap();
-        dctx.instances
+        let mut tables = dctx
+            .instances
             .iter()
             .enumerate()
             .filter(|(id, inst)| {
                 inst.table && (dctx.process_instances.contains(id) || inst.shared) && !dctx.is_skipped_instance(*id)
             })
             .map(|(id, _)| id)
-            .collect()
+            .collect::<Vec<_>>();
+
+        // Table witnesses are materialized serially, while each completed table can already be
+        // committed by a contribution worker. Start the heaviest GPU table first so more of its
+        // materialization and commit can overlap the remaining, smaller table work. Keep CPU table
+        // ordering unchanged and use the existing deterministic proof-cost estimate as the key.
+        if self.gpu {
+            tables.sort_unstable_by(|&a, &b| {
+                dctx.instances[b].total_weight().cmp(&dctx.instances[a].total_weight()).then_with(|| a.cmp(&b))
+            });
+        }
+
+        tables
     }
 
     pub fn dctx_get_process_instances(&self) -> Vec<usize> {


### PR DESCRIPTION
## Summary

- order GPU table instances by descending `InstanceInfo::total_weight()`
- preserve the existing table order for CPU proving
- use the instance ID as a deterministic tie-breaker

## Why

Table witnesses are materialized serially, while a contribution worker can start committing a table as soon as its materialization completes. Starting the heavier GPU table first lets its downstream commit overlap materialization of the remaining smaller tables.

This changes scheduling only; table membership, proof work, streams, and CPU behavior are unchanged.

## Performance

Measured on the pinned ZisK RTX 5090 (`sm_120`) workload with the normal four-stream policy and without `-y`. Proof Time was the authoritative metric. The paired protocol alternated the previous champion (A) and candidate (B), discarded A1/B1, and retained three runs per arm.

| Metric | Previous | Candidate | Change |
| --- | ---: | ---: | ---: |
| Proof Time | 3.113 s | 2.939 s | **5.589% faster** |
| Generating inner proofs | 1.998 s | 1.955 s | 2.152% faster |

Retained Proof Time values:

- previous: 3.113 s, 3.134 s, 3.068 s
- candidate: 3.017 s, 2.939 s, 2.930 s

All three retained pairs improved. Generated-expression coverage passed for all 42 AIRs, and the hash-family and immutable proving-key checks passed.

The performance measurement was made on the pinned `pre-develop-1.2.0-alpha` workload. This patch applies cleanly to `pre-develop-1.3.0-alpha`; the checks below validate source compatibility on that target branch.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p proofman-common --no-default-features`
- `cargo test -p proofman-common --no-default-features --lib` — 62 passed
