### PR TITLE
Perf/stream carve optional aggregation pool

### DIFF
--- a/common/src/gpu_stream_layout.rs
+++ b/common/src/gpu_stream_layout.rs
@@ -1,16 +1,14 @@
 //! Cutting the per-GPU aux-trace budget into stream size classes.
 //!
-//! Per-air aux-trace requirements are far from uniform — one outlier air can need several times the
-//! next largest — so sizing every stream to the maximum buys concurrency at the outlier's price. The
-//! budget is instead cut into two classes: *large*, sized to the biggest air so nothing is homeless,
-//! and *regular*, sized to whichever smaller air requirement carves best. A proof runs on any stream
-//! at least as large as it needs, so an air between the two sizes has only the large streams.
+//! Sizing every stream to the largest air buys concurrency at that air's price, so the budget is cut
+//! into two classes: *large*, sized to the biggest air so nothing is homeless, and *regular*, sized
+//! to a smaller air. A proof runs on any stream at least as large as it needs.
 //!
-//! The large size is fixed by the airs; the regular size and the split of streams between the two are
-//! searched together by [`makespan_floor`]. Whatever they leave becomes recursive streams.
+//! Which airs a proof instantiates, and how often, is not known this early — a proving key carries
+//! airs a given run never proves — so nothing here weighs a carve by the work it would run.
 //!
 //! Every class is floored at the largest compressor / vadcop_final / recursive launch, since those
-//! share the non-recursive streams with basics (see `RecursiveScheduler::next_nonrecursive`).
+//! share these streams with basics (see `RecursiveScheduler::next_nonrecursive`).
 
 /// One aux-trace size class: `count` streams of `size` field elements each.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,27 +20,24 @@ pub struct StreamClass {
 /// How one GPU's aux-trace budget is cut up.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StreamLayout {
-    /// The large and (when funded) regular class, in that order — at most two entries. Both host
-    /// basic *and* compressor/vadcop_final launches. Never empty, and `basic[0].size` covers the
-    /// largest air, so no proof is left without a home.
+    /// Large then regular, at most two entries. Never empty, and `basic[0].size` covers the largest
+    /// air and the class floor, so no launch is left without a home.
     pub basic: Vec<StreamClass>,
-    /// Recursive1/recursive2-only streams.
+    /// Aggregation-only streams; `count` is 0 when the pool does not pay for itself.
     pub recursive: StreamClass,
-    /// Budget left over: smaller than any class that could still have been cut.
+    /// Workers that take only aggregation work, or rec1/rec2 waits for the basic queue to drain.
+    pub aggregation_workers: usize,
+    /// Budget the class sizes and the stream caps leave unspendable.
     pub unused: usize,
 }
 
-/// Recursive streams kept funded before any basic stream beyond the first is cut. Basic streams are
-/// funded first, so without a floor they spend the last byte and aggregation's small proofs end up
-/// running a handful at a time in whatever huge basic class is free. A floor, not a reservation:
-/// the remainder still becomes recursive streams up to the caller's cap.
+/// Kept funded before any basic stream beyond the first, which would otherwise spend the last byte.
+/// A floor, not a reservation: the remainder still becomes recursive streams.
 const RECURSIVE_STREAM_FLOOR: usize = 1;
 
-/// How much worse than the best makespan floor a carve may be and still win by being more large-heavy
-/// — up to the uniform carve, which drops the regular class altogether. A difference this small is
-/// inside the noise of size-as-cost (a hot outlier air costs far more than one instance of it), and
-/// the large streams are the only home the biggest airs have.
-const LARGE_HEAVY_SLACK: f64 = 1.2;
+/// A class under `large / FLEET_FLOOR` is dust: it earns one spare stream, never a fleet. Fitted
+/// between two measured shapes — 3.2 GB against 14.5 keeps its fleet, 1.0 GB against 14.5 does not.
+const FLEET_FLOOR: usize = 8;
 
 impl StreamLayout {
     pub fn n_basic_streams(&self) -> usize {
@@ -55,47 +50,58 @@ impl StreamLayout {
     }
 }
 
-/// The makespan floor: for each air, the work that *only* streams that big can take (every air at
-/// least as large) over how many such streams there are. The largest of those ratios is what no
-/// schedule can beat. Air size stands in for air cost — no instance is planned this early.
-///
-/// Counting hosted work instead rates `1 x 14.5 + 4 x 6.23` best on a 40 GB card: half the work — the
-/// 14.5 and 12 GB airs — waits on the single large stream while the cheap airs get five.
-/// Scaled, not divided, so the compare stays in exact integers. `basic_sizes_desc` must be sorted
-/// largest first — the running `work` is the total of every air at least as large as this one;
-/// [`plan_stream_layout`] sorts before calling.
-fn makespan_floor(basic: &[StreamClass], basic_sizes_desc: &[usize]) -> u128 {
-    debug_assert!(basic_sizes_desc.windows(2).all(|w| w[0] >= w[1]), "basic_sizes_desc must be descending");
-
-    let (mut work, mut worst) = (0u128, 0u128);
-    for &air in basic_sizes_desc {
-        work += air as u128;
-        // At least one: the large class covers every air.
-        let streams: u128 = basic.iter().filter(|c| air <= c.size).map(|c| c.count as u128).sum();
-        worst = worst.max((work << 20) / streams);
-    }
-    worst
-}
-
 /// How many streams of `size` fit in `room`, at most `cap`. A size of 0 means no such class.
 fn n_fit(room: usize, size: usize, cap: usize) -> usize {
     room.checked_div(size).map_or(0, |n| cap.min(n))
 }
 
+/// Buy streams of the two sizes out of `room`: at most `cap` in total, `cap_regular` regular ones.
+///
+/// One of each first so neither class starves, then the leftover buys the best thing it still
+/// affords. The caller guarantees `large + regular` fits, so a large stream is always bought.
+fn buy_streams(room: usize, large: usize, regular: usize, cap: usize, cap_regular: usize) -> (usize, usize) {
+    debug_assert!(0 < regular && regular < large, "classes must be distinct sizes: {regular} vs {large}");
+    let pairs = (room / (large + regular)).min(cap / 2).min(cap_regular);
+    let (mut n_large, mut n_regular) = (pairs, pairs);
+    let mut left = room - pairs * (large + regular);
+
+    loop {
+        let slot = n_large + n_regular < cap;
+        // Best buy first (it hosts every air), then the cheaper half-measure — except that emptying
+        // the class while a regular is affordable would strand its price.
+        if slot && left >= large {
+            left -= large;
+            n_large += 1;
+        } else if slot && n_regular < cap_regular && left >= regular && (2 * regular <= large || n_regular == 1) {
+            left -= regular;
+            n_regular += 1;
+        } else if n_regular > 0 && left >= large - regular {
+            left -= large - regular;
+            n_regular -= 1;
+            n_large += 1;
+        } else {
+            return (n_large, n_regular);
+        }
+    }
+}
+
 /// Cut `budget` (in field elements, per GPU) into a large and a regular stream class.
 ///
-/// `basic_sizes` is the per-air basic requirement in any order — sorted here, since the floor reads
-/// it largest first; duplicates weigh twice. `class_floor` is the smallest a basic class may be: it
-/// must hold anything besides a basic proof that can land on one of these streams — today the
-/// compressor/vadcop_final launches that share them. `recursive_size` sizes the recursive1/recursive2
-/// class.
+/// `basic_sizes` is the per-air basic requirement in any order; duplicates weigh twice.
+/// `class_floor` is the smallest a basic class may be — it must hold anything besides a basic proof
+/// that can land on one of these streams, today the compressor/vadcop_final launches that share them.
+/// It is raised to `recursive_size` (which sizes the recursive1/recursive2 class), since those fall
+/// back to these streams too.
 ///
-/// The large size is fixed by the biggest air; the regular size and the split of streams between the
-/// two are searched by [`makespan_floor`], the most large-heavy carve winning ties (see
-/// [`LARGE_HEAVY_SLACK`]).
+/// The large class is sized by the biggest air. The regular class prefers the biggest air no larger
+/// than half of it that earns its streams: shrinking from `large` to `s` frees `large - s`, which
+/// only pays for itself if it buys another `s` stream. Failing that it takes the biggest air that
+/// fits beside a large stream, which [`buy_streams`] trades back up when that is the better buy.
 ///
-/// Basic streams are funded first — they are the only home for basics *and* compressors — and
-/// aggregation takes the remainder, subject only to [`RECURSIVE_STREAM_FLOOR`].
+/// Aggregation gets streams of its own only while `recursive_size` is under half of `class_floor`,
+/// where those bytes buy more than one restricted stream per basic stream's price; above it the
+/// budget buys basic streams and `max_recursive_streams` bounds aggregation *workers* instead.
+/// Basic streams are funded first either way, subject only to [`RECURSIVE_STREAM_FLOOR`].
 ///
 /// Returns `None` when the budget cannot even hold one stream for the largest air.
 pub fn plan_stream_layout(
@@ -109,13 +115,11 @@ pub fn plan_stream_layout(
     if max_basic_streams == 0 {
         return None;
     }
-    // [`makespan_floor`] reads the airs largest first; normalize once rather than trust the caller.
-    let mut basic_sizes_desc: Vec<usize> = basic_sizes.to_vec();
-    basic_sizes_desc.sort_unstable_by(|a, b| b.cmp(a));
-
-    // The candidate sizes are the distinct air requirements, each raised to the floor so either class
-    // can also take a compressor and any contributions commit. Largest first.
-    let mut sizes: Vec<usize> = basic_sizes_desc.iter().map(|&s| s.max(class_floor)).collect();
+    // A recursive launch falls back to a basic stream whenever the pool is busy or gone, so the floor
+    // must cover it — enforced here rather than assumed of the caller.
+    let class_floor = class_floor.max(recursive_size);
+    let mut sizes: Vec<usize> = basic_sizes.iter().map(|&s| s.max(class_floor)).collect();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
     sizes.dedup();
 
     // The large class must hold anything that can land on a non-recursive stream.
@@ -124,54 +128,69 @@ pub fn plan_stream_layout(
         return None;
     }
 
+    // Under 2x an aggregation-only stream costs about what a basic one does and runs far less; every
+    // basic stream holds the launch anyway, so the bytes buy those and priority moves to the workers.
+    let pool_is_redundant = class_floor < 2 * recursive_size;
+    let pool_size = if pool_is_redundant { 0 } else { recursive_size };
+
     // The first large stream ignores the recursive floor — without it nothing can run at all.
-    let for_extra_streams = budget.saturating_sub(recursive_size * RECURSIVE_STREAM_FLOOR.min(max_recursive_streams));
+    let room = budget.saturating_sub(pool_size * RECURSIVE_STREAM_FLOOR.min(max_recursive_streams));
 
-    // Every air requirement a second class could be funded at, plus 0 for the uniform carve. Searched,
-    // not picked up front: streams afforded and airs stranded are exactly what the floor measures.
-    let regulars = sizes.iter().skip(1).copied().filter(|&s| large + s <= for_extra_streams).chain([0]);
+    // A class must serve a strict majority of the airs, which is exactly "reaches the median air".
+    // Strict, so a key growing precompiles to an exact split does not buy a fleet.
+    let bulk_floor = {
+        let mut asc = basic_sizes.to_vec();
+        asc.sort_unstable();
+        asc[asc.len() / 2]
+    };
+    // Sizes that still leave room for the large stream they run beside, largest first.
+    let candidates = || sizes.iter().skip(1).copied().filter(|&s| s > 0 && large + s <= room);
 
-    // The slack compares splits of the same two classes, so it stays inside one candidate size.
-    let best_for = |regular: usize| -> Option<(u128, StreamLayout)> {
-        let carves: Vec<(u128, StreamLayout)> = (1..=max_basic_streams)
-            .filter_map(|n_large| {
-                let spent = n_large * large;
-                if spent > budget || (n_large > 1 && spent > for_extra_streams) {
-                    return None;
-                }
-                let n_regular = n_fit(for_extra_streams.saturating_sub(spent), regular, max_basic_streams - n_large);
-
-                let mut basic = vec![StreamClass { size: large, count: n_large }];
-                if n_regular > 0 {
-                    basic.push(StreamClass { size: regular, count: n_regular });
-                }
-                let remaining = budget - spent - n_regular * regular;
-                let n_recursive = n_fit(remaining, recursive_size, max_recursive_streams);
-                Some((
-                    makespan_floor(&basic, &basic_sizes_desc),
-                    StreamLayout {
-                        basic,
-                        recursive: StreamClass { size: recursive_size, count: n_recursive },
-                        unused: remaining - n_recursive * recursive_size,
-                    },
-                ))
-            })
-            .collect();
-        let best = carves.iter().map(|(floor, _)| *floor).min()?;
-        carves
-            .into_iter()
-            .filter(|(floor, _)| *floor as f64 <= best as f64 * LARGE_HEAVY_SLACK)
-            .max_by_key(|(_, layout)| (layout.basic[0].count, layout.recursive.count))
+    // Dust is never preferred: it falls through to the biggest class that fits instead.
+    let earns_a_fleet = |s: usize| s >= bulk_floor && s * FLEET_FLOOR >= large;
+    let candidate = candidates().find(|&s| 2 * s <= large && earns_a_fleet(s)).or_else(|| candidates().next());
+    let (n_large, regular, n_regular) = match candidate {
+        Some(regular) => {
+            let cap_regular = if earns_a_fleet(regular) { max_basic_streams } else { 1 };
+            let (n_large, n_regular) = buy_streams(room, large, regular, max_basic_streams, cap_regular);
+            (n_large, regular, n_regular)
+        }
+        // Nothing fits beside a large stream, so the floor of one is that stream: the recursive floor
+        // may have taken the room for it.
+        None => (n_fit(room, large, max_basic_streams).max(1), 0, 0),
     };
 
-    // Ties go large-heavy, then to more streams, then (iteration order) to the larger size —
-    // shrinking a class the floor is indifferent to only exiles an air.
-    regulars
-        .filter_map(best_for)
-        .min_by_key(|(floor, layout)| {
-            (*floor, std::cmp::Reverse(layout.basic[0].count), std::cmp::Reverse(layout.n_basic_streams()))
-        })
-        .map(|(_, layout)| layout)
+    // The candidate is picked before the trade-ups run, so a carve left all large looks once more:
+    // its change may still fund a smaller air.
+    let (regular, n_regular) = if n_regular == 0 && n_large < max_basic_streams {
+        let left = room.saturating_sub(n_large * large);
+        candidates().find(|&s| s <= left).map_or((regular, 0), |spare| (spare, 1))
+    } else {
+        (regular, n_regular)
+    };
+
+    let mut basic = vec![StreamClass { size: large, count: n_large }];
+    if n_regular > 0 {
+        basic.push(StreamClass { size: regular, count: n_regular });
+    }
+
+    let spent = n_large * large + n_regular * regular;
+    debug_assert!(spent <= budget, "carved {spent} out of a {budget} budget");
+    let remaining = budget - spent;
+    let n_pool = n_fit(remaining, pool_size, max_recursive_streams);
+    // Dedicated streams get one worker each. Without any — the pool was dropped, or the budget could
+    // not fund one — aggregation shares the basic streams, which costs a thread and not memory; but
+    // never every stream at once, or the basic queue stalls behind them.
+    let shared_workers = max_recursive_streams.min((n_large + n_regular).saturating_sub(1).max(1));
+    Some(StreamLayout {
+        basic,
+        recursive: StreamClass { size: pool_size, count: n_pool },
+        aggregation_workers: match n_pool {
+            0 if recursive_size > 0 => shared_workers,
+            n => n,
+        },
+        unused: remaining - n_pool * pool_size,
+    })
 }
 
 #[cfg(test)]
@@ -202,7 +221,7 @@ mod tests {
     }
 
     /// The air requirements arrive in whatever order the caller holds them; the carve must not
-    /// depend on it, since the floor reads them largest first.
+    /// depend on it, since the classes are picked from them largest first.
     #[test]
     fn the_input_order_of_the_airs_does_not_matter() {
         let sorted: Vec<usize> = ZISK_BASIC_GB.iter().copied().map(gb).collect();
@@ -235,29 +254,47 @@ mod tests {
         }
     }
 
-    /// The split only beats scarcity: where the cap binds before memory, every stream should be large
-    /// so every air can use all of them.
+    /// Where the cap binds before memory every stream should be large: the pairs trade back up.
     #[test]
     fn a_roomy_budget_goes_uniform() {
         let layout = zisk_layout(120.0, 4, 10);
         assert_eq!(layout.basic, vec![StreamClass { size: gb(14.57), count: 4 }], "{:?}", layout.basic);
     }
 
-    /// Equilibrium wants a large stream next, but the remainder cannot fund one: the carve keeps
-    /// buying regulars rather than stopping there.
+    /// A budget that funds three of each gets three of each: the outlier is never flattened away.
     #[test]
-    fn a_class_that_no_longer_fits_yields_to_the_other() {
+    fn the_classes_grow_together() {
         let layout = zisk_layout(70.0, 16, 10);
         assert_eq!(
             layout.basic,
-            vec![StreamClass { size: gb(14.57), count: 2 }, StreamClass { size: gb(6.45), count: 6 }]
+            vec![StreamClass { size: gb(14.57), count: 3 }, StreamClass { size: gb(6.45), count: 3 }]
         );
     }
 
-    /// 6.26 GB regulars would fit just as many streams as 6.45 GB ones, and picking them would
-    /// exile the 6.45 air to the large streams for nothing. Ties go to the larger size.
+    /// What the pairs leave goes to whichever class still fits, largest first.
     #[test]
-    fn a_smaller_regular_is_only_taken_when_it_buys_a_stream() {
+    fn the_remainder_buys_the_largest_stream_that_still_fits() {
+        let layout = zisk_layout(40.0, 16, 10);
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 2 }, StreamClass { size: gb(6.45), count: 1 }],
+            "a large stream fitted in the remainder: {:?}",
+            layout.basic
+        );
+
+        let layout = zisk_layout(33.0, 16, 10);
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 1 }, StreamClass { size: gb(6.45), count: 2 }],
+            "only a regular one fitted: {:?}",
+            layout.basic
+        );
+    }
+
+    /// The regular size is a property of the key, not the budget: 6.26 GB fits as many streams as
+    /// 6.45 and exiles the 6.45 air for nothing. The old carve drifted with the budget; this must not.
+    #[test]
+    fn the_regular_size_does_not_drift_with_the_budget() {
         for budget in [ZISK_BUDGET_GB, 33.0, 40.0, 60.0, 80.0] {
             let layout = zisk_layout(budget, 16, 10);
             assert_eq!(layout.basic[1].size, gb(6.45), "budget {budget}: {:?}", layout.basic);
@@ -276,8 +313,8 @@ mod tests {
         assert!(layout.recursive.count >= 3, "aggregation still gets the remainder: {:?}", layout.recursive);
     }
 
-    /// Preloaded const trees push every non-outlier air below the compressor floor, so the floor
-    /// sizes the second class. Matches zisk1: 14.57 + 6.24, four recursive.
+    /// Preloaded const trees push every non-outlier air below the floor, so the floor sizes the second
+    /// class. Matches zisk1, whose measured gain rests on that class surviving the recursive floor.
     #[test]
     fn preloaded_sizes_put_the_second_class_at_the_compressor_floor() {
         let sizes = [gb(14.57), gb(5.9), gb(3.8), gb(2.6), gb(0.75)];
@@ -288,17 +325,6 @@ mod tests {
             vec![StreamClass { size: gb(14.57), count: 1 }, StreamClass { size: gb(ZISK_COMPRESSOR_GB), count: 1 }]
         );
         assert_eq!(layout.recursive.count, 4);
-    }
-
-    /// The floor must never cost this card its second basic class — that undoes the whole measured
-    /// gain (26.7s -> 21.5s) and the margin is thin, so pin it.
-    #[test]
-    fn the_recursive_floor_does_not_cost_the_second_class() {
-        let sizes = [gb(14.57), gb(5.9), gb(3.8), gb(2.6), gb(0.75)];
-        let layout =
-            plan_stream_layout(gb(26.15), &sizes, gb(ZISK_COMPRESSOR_GB), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
-        assert_eq!(layout.n_basic_streams(), 2, "second class lost to the floor: {:?}", layout.basic);
-        assert_eq!(layout.recursive.count, 4, "floor is a minimum, not a cap: {:?}", layout.recursive);
     }
 
     /// The floor is what stops a large budget from spending everything on classes.
@@ -346,25 +372,18 @@ mod tests {
         }
     }
 
-    /// Aggregation off: `class_floor` is 0 (no compressor shares these streams), so only the
-    /// non-outlier floor stops the carve from buying the smallest air on the list. Without it the
-    /// card got 1 x 14.57 + 18 x 0.75 GB — a class hosting 6 of 42 airs — and every real proof
-    /// serialized on the single large stream.
+    /// Aggregation off, so only the bulk rule keeps the class off the smallest air: a carve free to
+    /// take it bought 1 x 14.57 + 18 x 0.75 GB, hosting 6 of 42 airs.
     #[test]
     fn a_no_aggregation_carve_still_hosts_the_airs() {
         let sizes: Vec<usize> = ZISK_BASIC_GB.iter().copied().map(gb).collect();
         let layout = plan_stream_layout(gb(29.05), &sizes, 0, 0, 20, 0).expect("budget holds the largest air");
         assert!(layout.n_basic_streams() >= 2, "no second stream to overlap with: {:?}", layout.basic);
         assert_eq!(layout.basic[1].size, gb(6.45), "second class cannot host the bulk airs: {:?}", layout.basic);
-        assert!(
-            layout.basic.iter().all(|c| c.size >= gb(6.45)),
-            "a class below the non-outlier floor survived: {:?}",
-            layout.basic
-        );
     }
 
     /// Coverage is worth a lot, but never the second basic stream: where the budget cannot pair the
-    /// largest air with a class that hosts most airs, a smaller class still beats having only one.
+    /// largest air with the class just behind it, the small airs still define one the bulk can use.
     #[test]
     fn coverage_never_costs_the_second_class() {
         // 14.5 + 12.0 does not fit, so the only classes left are the ones the small airs define.
@@ -408,26 +427,23 @@ mod tests {
         }
     }
 
-    /// A near-outlier the budget cannot give a regular class to falls back to the large streams.
-    /// The candidate search must keep looking past it instead of settling for one class.
+    /// 14.5 + 12.0 overruns the budget, so what is left funds a class hosting 1 of 3 airs: one spare.
     #[test]
     fn an_air_too_big_for_the_regular_class_falls_back_to_the_large_one() {
         let sizes = [gb(14.5), gb(12.0), gb(6.23)];
         let layout = plan_stream_layout(gb(26.15), &sizes, gb(6.24), gb(ZISK_RECURSIVE_GB), 16, 10).unwrap();
 
-        // 14.5 + 12 overruns the budget, so the 12 GB air keeps the large class as its only home.
         assert_eq!(
             layout.basic,
             vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(6.24), count: 1 }]
         );
-        // The 6.23 GB air is below the floor, so its class is the floor -- never smaller.
+        // The 6.23 GB air is below `class_floor`, so its class is the floor -- never smaller.
         assert!(layout.basic[1].size >= gb(6.23));
         assert!(layout.recursive.count >= 3);
     }
 
-    /// The measured ZisK key: 7.42 GB largest air against a 6.24 GB compressor floor. The split
-    /// `1x7.42 + 2x6.24` and uniform `3x7.42` buy the same three streams, so the split bought nothing
-    /// while confining the 7.42 air to one stream for the whole run — it must lose on parallelism.
+    /// 7.42 GB largest air against a 6.24 GB floor: the 6.24 class is bought and traded straight back
+    /// up for 1.18 GB a stream, since the split buys no more streams than uniform.
     #[test]
     fn a_split_that_buys_no_stream_loses_to_uniform() {
         let sizes: Vec<usize> =
@@ -440,13 +456,184 @@ mod tests {
         assert!(layout.recursive.count >= 1, "aggregation must keep at least the floor");
     }
 
-    /// A genuine outlier keeps its own class: on a budget this tight the split really does buy
-    /// streams (2L+6R against 4 uniform), so it must not be flattened into one size.
+    /// Below half of 14.57 there is only dust, so the class goes above half to the one that earns it.
     #[test]
-    fn a_real_outlier_still_gets_its_own_class() {
-        let layout = zisk_layout(70.0, 16, 10);
-        assert_eq!(layout.basic.len(), 2, "outlier must not be collapsed: {:?}", layout.basic);
-        assert_eq!(layout.basic[0].size, gb(14.57));
+    fn a_gap_below_half_puts_the_regular_class_above_it() {
+        let sizes: Vec<usize> = [14.57f64, 8.0, 0.75].iter().copied().map(gb).collect();
+        for (budget, want) in [(26.0, (1, 1)), (33.0, (1, 2)), (60.0, (3, 2)), (80.0, (4, 2))] {
+            let layout = plan_stream_layout(gb(budget), &sizes, 0, 0, 20, 0).expect("budget holds the largest air");
+            let (n_large, n_regular) = want;
+            assert_eq!(
+                layout.basic,
+                vec![StreamClass { size: gb(14.57), count: n_large }, StreamClass { size: gb(8.0), count: n_regular }],
+                "budget {budget}: {:?}",
+                layout.basic
+            );
+        }
+    }
+
+    /// Three of these five airs outrun anything the leftover funds: one spare is all it is worth.
+    #[test]
+    fn a_class_the_bulk_cannot_use_is_worth_one_spare_stream() {
+        let sizes: Vec<usize> = [14.5f64, 12.0, 12.0, 12.0, 1.0].iter().copied().map(gb).collect();
+        let layout = plan_stream_layout(gb(26.0), &sizes, 0, 0, 20, 0).expect("budget holds the largest air");
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(1.0), count: 1 }],
+            "{:?}",
+            layout.basic
+        );
+    }
+
+    /// Trading the last regular up ends at 2 x 14.5 with 11 GB dead; buying it is a 3rd stream.
+    #[test]
+    fn a_buyable_regular_is_bought_before_the_last_one_is_traded_up() {
+        let sizes: Vec<usize> = [14.5f64, 12.0, 12.0, 12.0, 1.0].iter().copied().map(gb).collect();
+        let layout = plan_stream_layout(gb(40.0), &sizes, 0, 0, 20, 0).expect("budget holds the largest air");
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(12.0), count: 2 }],
+            "{:?}",
+            layout.basic
+        );
+    }
+
+    /// Tiny airs reaching exactly half the count must not flip the carve into a fleet of 1 GB streams.
+    #[test]
+    fn added_precompiles_do_not_flip_the_carve_to_a_tiny_fleet() {
+        let sizes: Vec<usize> = [14.5f64, 12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0].iter().copied().map(gb).collect();
+        let layout = plan_stream_layout(gb(40.0), &sizes, 0, 0, 20, 0).expect("budget holds the largest air");
+        assert_eq!(layout.basic[1].size, gb(12.0), "a tiny fleet was bought: {:?}", layout.basic);
+    }
+
+    /// Cap-bound: 12.96 GB left over makes one regular large rather than sit unspent.
+    #[test]
+    fn a_cap_bound_carve_trades_its_regulars_up() {
+        let layout = zisk_layout(55.0, 4, 0);
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.57), count: 3 }, StreamClass { size: gb(6.45), count: 1 }],
+            "{:?}",
+            layout.basic
+        );
+        assert!(layout.unused < gb(14.57 - 6.45), "another trade-up was affordable: {layout:?}");
+    }
+
+    /// A measured zisk proving key, largest first, GB. Two thirds are precompiles a given proof never
+    /// instantiates — the reason no rule here may count a key's airs as work.
+    const ZISK_KEY_GB: &[f64] = &[
+        12.81, 5.99, 5.82, 5.69, 5.32, 4.52, 4.52, 4.43, 4.43, 4.32, 4.19, 4.07, 3.99, 3.89, 3.82, 3.65, 3.63, 3.63,
+        3.24, 3.09, 2.94, 2.91, 2.88, 2.60, 2.60, 2.47, 2.36, 2.35, 2.28, 2.13, 2.08, 1.94, 1.92, 1.79, 1.79, 1.65,
+        1.47, 1.43, 1.23, 1.17, 1.11, 0.74, 0.63,
+    ];
+
+    /// The regular class takes the top of the band it serves, whatever a smaller one would buy:
+    /// work-scoring bought `1 x 12.81 + 3 x 4.52`, confining the 5.32-5.99 GB airs to one stream.
+    #[test]
+    fn the_regular_class_is_not_shaved_below_the_band_it_serves() {
+        let sizes: Vec<usize> = ZISK_KEY_GB.iter().copied().map(gb).collect();
+        for (budget, want) in [(28.21, (1, 2)), (40.0, (2, 2)), (60.0, (3, 3))] {
+            let layout = plan_stream_layout(gb(budget), &sizes, 0, 0, 16, 0).expect("budget holds the largest air");
+            let (n_large, n_regular) = want;
+            assert_eq!(
+                layout.basic,
+                vec![StreamClass { size: gb(12.81), count: n_large }, StreamClass { size: gb(5.99), count: n_regular }],
+                "budget {budget}: {:?}",
+                layout.basic
+            );
+        }
+    }
+
+    /// Blake3: recursion at ~7.5 GB floors the basic classes too, so a dedicated stream costs what a
+    /// basic one does. At 40 GB dropping the pool buys 3 universal streams, not 2 + 1.
+    #[test]
+    fn blake3_sized_recursion_shares_the_basic_streams() {
+        let sizes: Vec<usize> = ZISK_BASIC_GB.iter().copied().map(gb).collect();
+        for (budget, want_basic) in [(25.23, 2), (33.0, 3), (40.0, 3), (60.0, 5)] {
+            let layout = plan_stream_layout(gb(budget), &sizes, gb(7.5), gb(7.5), 16, 10).unwrap();
+            assert_eq!(layout.recursive.count, 0, "budget {budget}: pool not dropped: {:?}", layout.recursive);
+            assert_eq!(layout.n_basic_streams(), want_basic, "budget {budget}: {:?}", layout.basic);
+            // Aggregation keeps workers of its own, but never all the streams they share.
+            assert_eq!(layout.aggregation_workers, want_basic - 1, "budget {budget}: {layout:?}");
+            assert!(layout.aggregation_workers < layout.n_basic_streams(), "basics can stall: {layout:?}");
+            // Every basic stream can host a recursive launch, so nothing is homeless.
+            assert!(layout.basic.iter().all(|c| c.size >= gb(7.5)), "{:?}", layout.basic);
+        }
+    }
+
+    /// Five 1 GB airs of nine make 1 GB the median, which on the count rule alone bought 16 streams
+    /// only the dust could use. Dust never decides the carve, so one more precompile changes nothing.
+    #[test]
+    fn one_more_dust_air_does_not_change_the_carve() {
+        let with_dust: Vec<usize> =
+            [14.5f64, 12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0, 1.0].iter().copied().map(gb).collect();
+        let without: Vec<usize> = [14.5f64, 12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0].iter().copied().map(gb).collect();
+        for budget in [40.0, 60.0] {
+            let a = plan_stream_layout(gb(budget), &with_dust, 0, 0, 20, 0).unwrap();
+            let b = plan_stream_layout(gb(budget), &without, 0, 0, 20, 0).unwrap();
+            assert_eq!(a.basic, b.basic, "budget {budget}: one dust air moved the carve: {:?}", a.basic);
+            // And the band that does earn streams gets them.
+            assert!(a.basic.iter().all(|c| c.count == 1 || c.size >= gb(12.0)), "{:?}", a.basic);
+        }
+
+        // 40 GB: the 12 GB band takes two homes rather than the budget dying or buying dust.
+        let layout = plan_stream_layout(gb(40.0), &with_dust, 0, 0, 20, 0).unwrap();
+        assert_eq!(
+            layout.basic,
+            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(12.0), count: 2 }],
+            "{:?}",
+            layout.basic
+        );
+        assert!(layout.unused < gb(2.0), "budget left for dead: {layout:?}");
+    }
+
+    /// No dedicated stream must still mean workers, or rec1/rec2 waits behind every queued basic.
+    #[test]
+    fn a_pool_the_budget_cannot_fund_still_gets_workers() {
+        let sizes = [gb(14.57), gb(6.45)];
+        let layout = plan_stream_layout(gb(15.0), &sizes, gb(6.24), gb(1.33), 16, 10).unwrap();
+        assert_eq!(layout.recursive.count, 0, "{layout:?}");
+        assert!(layout.aggregation_workers > 0, "aggregation left with nothing: {layout:?}");
+    }
+
+    /// At 1.33 GB against a 6.24 GB floor the pool buys four streams for one basic stream's price.
+    #[test]
+    fn a_cheap_recursive_class_keeps_its_own_streams() {
+        let layout = zisk_layout(ZISK_BUDGET_GB, 16, 10);
+        assert!(layout.recursive.count >= 3, "cheap pool must survive: {:?}", layout.recursive);
+        assert_eq!(layout.aggregation_workers, layout.recursive.count, "one worker per dedicated stream");
+    }
+
+    /// Raise the floor rather than rely on a pool: one the budget cannot fund leaves it homeless.
+    #[test]
+    fn an_oversized_recursive_launch_raises_the_floor() {
+        let sizes: Vec<usize> = ZISK_BASIC_GB.iter().copied().map(gb).collect();
+        let layout = plan_stream_layout(gb(60.0), &sizes, gb(6.24), gb(16.0), 16, 10).unwrap();
+        assert!(layout.basic.iter().all(|c| c.size >= gb(16.0)), "no home for the launch: {:?}", layout.basic);
+        assert!(layout.aggregation_workers > 0, "and it keeps its priority: {layout:?}");
+
+        // Too small for even one such stream is a configuration error, not a carve that hangs later.
+        assert!(plan_stream_layout(gb(15.0), &sizes, gb(6.24), gb(16.0), 16, 10).is_none());
+    }
+
+    /// At 36 the 12 GB class is bought and traded up; its 8 GB of change would otherwise die.
+    #[test]
+    fn an_all_large_carve_spends_its_change_on_a_spare() {
+        let sizes: Vec<usize> = [14.0f64, 12.0, 8.0].iter().copied().map(gb).collect();
+        for (budget, want) in [(36.0, Some(2)), (50.0, Some(3)), (30.0, None), (44.0, None)] {
+            let layout = plan_stream_layout(gb(budget), &sizes, 0, 0, 16, 0).unwrap();
+            match want {
+                // The change covers an 8 GB stream: take it rather than let it die.
+                Some(n_large) => assert_eq!(
+                    layout.basic,
+                    vec![StreamClass { size: gb(14.0), count: n_large }, StreamClass { size: gb(8.0), count: 1 }],
+                    "budget {budget}: {:?}",
+                    layout.basic
+                ),
+                // Under 8 GB of change: nothing to buy, and uniform hosts every air.
+                None => assert_eq!(layout.basic.len(), 1, "budget {budget}: {:?}", layout.basic),
+            }
+        }
     }
 
     /// A budget under the largest air is a configuration error, not a silently truncated carve.
@@ -472,6 +659,7 @@ mod tests {
         let layout = StreamLayout {
             basic: vec![StreamClass { size: 9, count: 1 }, StreamClass { size: 4, count: 2 }],
             recursive: StreamClass { size: 1, count: 3 },
+            aggregation_workers: 3,
             unused: 0,
         };
         assert_eq!(layout.basic_stream_sizes(), vec![9, 4, 4]);
@@ -483,11 +671,10 @@ mod tests {
         sizes.iter().filter(|&&s| s <= class.size).count()
     }
 
-    /// One big air, one close behind, the rest the bulk. The regular class is sized for the bulk
-    /// (6.23), but the near-outlier rides the large class — and 14.5 + 12.0 is half the work, so a
-    /// second large stream is worth more than a fourth regular one.
+    /// A class at 12.0 costs nearly what a second large stream does and hosts one air fewer, so the
+    /// regular class skips past it and the near-outlier rides the large streams.
     #[test]
-    fn the_classes_are_balanced_by_the_work_each_must_run() {
+    fn a_near_outlier_rides_the_large_class_rather_than_taking_one() {
         let sizes = [gb(14.5), gb(12.0), gb(6.23), gb(5.9), gb(5.4), gb(3.8), gb(2.6), gb(1.5)];
         let layout = plan_stream_layout(gb(40.0), &sizes, 0, 0, 20, 0).unwrap();
         assert_eq!(
@@ -496,24 +683,29 @@ mod tests {
         );
     }
 
-    /// Same with aggregation: the compressor floor only bounds a class from below.
+    /// Same with aggregation: the compressor floor only bounds a class from below, and the skip is
+    /// the size rule's, not the budget's — 14.5 + 12.0 would have fitted here.
     #[test]
-    fn aggregation_sizes_the_regular_class_so_no_air_is_stranded() {
+    fn aggregation_does_not_change_which_size_the_regular_class_takes() {
         let sizes = [gb(14.5), gb(12.0), gb(6.23), gb(5.9), gb(5.4), gb(3.8), gb(2.6), gb(1.5)];
         let layout = plan_stream_layout(gb(29.05), &sizes, gb(6.24), gb(1.33), 20, 10).unwrap();
-        // A 6.24 regular affords one more stream but strands the 12 GB air: 2.1% worse floor.
         assert_eq!(
             layout.basic,
-            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(12.0), count: 1 }]
+            vec![StreamClass { size: gb(14.5), count: 1 }, StreamClass { size: gb(6.24), count: 2 }]
         );
     }
 
-    /// No *fleet* of streams may host less than half the airs — the old carve bought 7 x 1.50 GB ones
-    /// hosting 1 of 8. A single top-up stream is the opposite shape and can be optimal.
+    /// No *fleet* may host less than half the airs — the old carve bought 7 x 1.50 GB ones hosting 1
+    /// of 8. A single spare is the opposite shape, so only `count > 1` is held to it.
     #[test]
     fn no_carve_buys_a_fleet_below_half_the_airs() {
-        let shapes: [&[f64]; 3] =
-            [&[14.5, 12.0, 6.23, 5.9, 5.4, 3.8, 2.6, 1.5], ZISK_BASIC_GB, &[14.57, 5.9, 3.8, 2.6, 0.75]];
+        let shapes: [&[f64]; 5] = [
+            &[14.5, 12.0, 6.23, 5.9, 5.4, 3.8, 2.6, 1.5],
+            ZISK_BASIC_GB,
+            &[14.57, 5.9, 3.8, 2.6, 0.75],
+            &[14.57, 8.0, 0.75],
+            &[14.5, 12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0],
+        ];
         for shape in shapes {
             let sizes: Vec<usize> = shape.iter().copied().map(gb).collect();
             for budget in [26.0, 26.15, 29.05, 33.0, 40.0, 60.0, 80.0] {
@@ -525,6 +717,56 @@ mod tests {
                             "budget {budget} floor {floor}: class {class:?} hosts {} of {}: {:?}",
                             hosted(class, &sizes),
                             sizes.len(),
+                            layout.basic
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Overspending is a failed `cudaMalloc` at startup, so sweep every knob against every shape.
+    #[test]
+    fn no_carve_ever_overspends_its_budget() {
+        let shapes: [&[f64]; 6] = [
+            ZISK_KEY_GB,
+            ZISK_BASIC_GB,
+            &[14.5, 12.0, 6.23, 5.9, 5.4, 3.8, 2.6, 1.5],
+            &[7.42, 5.99, 5.82, 5.57, 5.31, 4.52, 0.75],
+            &[14.57, 8.0, 0.75],
+            &[14.5, 12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0],
+        ];
+        for shape in shapes {
+            let sizes: Vec<usize> = shape.iter().copied().map(gb).collect();
+            for budget in [14.6, 20.0, 26.15, 28.21, 33.0, 40.0, 60.0, 80.0, 200.0] {
+                for (floor, rec) in [(0.0, 0.0), (ZISK_COMPRESSOR_GB, ZISK_RECURSIVE_GB), (9.0, 0.5)] {
+                    for (max_basic, max_rec) in [(1, 0), (2, 1), (4, 8), (16, 10), (20, 0)] {
+                        let Some(layout) =
+                            plan_stream_layout(gb(budget), &sizes, gb(floor), gb(rec), max_basic, max_rec)
+                        else {
+                            continue;
+                        };
+                        let where_ =
+                            format!("shape {shape:?} budget {budget} floor {floor} caps {max_basic}/{max_rec}");
+
+                        let spent: usize = layout.basic.iter().map(|c| c.size * c.count).sum::<usize>()
+                            + layout.recursive.size * layout.recursive.count;
+                        assert_eq!(spent + layout.unused, gb(budget), "{where_}: {layout:?}");
+
+                        assert!(!layout.basic.is_empty(), "{where_}: no basic class");
+                        assert_eq!(layout.basic[0].size, sizes[0].max(gb(floor)), "{where_}: {:?}", layout.basic);
+                        assert!(layout.n_basic_streams() <= max_basic, "{where_}: {:?}", layout.basic);
+                        assert!(layout.recursive.count <= max_rec, "{where_}: {:?}", layout.recursive);
+                        assert!(layout.aggregation_workers <= max_rec, "{where_}: {layout:?}");
+                        // Aggregation must always have somewhere to run first: dedicated streams, or
+                        // workers on the shared ones. Neither is starvation behind the basic queue.
+                        assert!(
+                            rec == 0.0 || max_rec == 0 || layout.recursive.count > 0 || layout.aggregation_workers > 0,
+                            "{where_}: aggregation has neither streams nor workers: {layout:?}"
+                        );
+                        assert!(
+                            layout.basic.iter().all(|c| c.size >= gb(floor) && c.count > 0),
+                            "{where_}: {:?}",
                             layout.basic
                         );
                     }

--- a/common/src/gpu_stream_layout.rs
+++ b/common/src/gpu_stream_layout.rs
@@ -181,6 +181,12 @@ pub fn plan_stream_layout(
     // Dedicated streams get one worker each. Without any — the pool was dropped, or the budget could
     // not fund one — aggregation shares the basic streams, which costs a thread and not memory; but
     // never every stream at once, or the basic queue stalls behind them.
+    //
+    // The `max(1)` is the deliberate exception at a single basic stream, where that rule would leave
+    // aggregation with no worker at all. Holding it back there buys nothing: one stream serialises
+    // basic and recursive work regardless, so there is no overlap to protect, and the tail of the
+    // aggregation tree is on the critical path. Better to interleave than to make it wait for the
+    // whole basic queue to drain. From two streams up the rule applies and one is always left free.
     let shared_workers = max_recursive_streams.min((n_large + n_regular).saturating_sub(1).max(1));
     Some(StreamLayout {
         basic,

--- a/common/src/memory_handler.rs
+++ b/common/src/memory_handler.rs
@@ -1,9 +1,9 @@
 use crossbeam_channel::{bounded, Sender, Receiver};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 use crossbeam_queue::SegQueue;
 use crate::ProofCtx;
 use proofman_fields::PrimeField64;
@@ -13,6 +13,33 @@ use proofman_starks_lib_c::{register_host_memory_c, unregister_host_memory_c};
 /// Ceiling on the re-check interval of a thread waiting for a pooled buffer. A released buffer
 /// wakes it immediately, so this bounds cancel responsiveness, not pickup latency.
 const MAX_POOL_WAIT_BACKOFF: Duration = Duration::from_millis(1);
+
+/// Wait charged to the buffer it was incurred for, keyed by that buffer's data pointer.
+///
+/// Keyed by buffer rather than by thread because the block can happen on any worker the witness
+/// components spin up, while the buffer it waited for always ends up in one known instance's trace.
+static PENDING_WAITS: LazyLock<Mutex<HashMap<usize, Duration>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn charge_wait_to_buffer<F>(buffer: &[F], waited: Duration) {
+    let key = buffer.as_ptr() as usize;
+    let mut map = PENDING_WAITS.lock().unwrap_or_else(|e| e.into_inner());
+    *map.entry(key).or_insert(Duration::ZERO) += waited;
+}
+
+/// Drop a buffer's unread wait. Called on release so the ledger only ever holds in-flight
+/// buffers: an entry nobody reads back (a table instance, an untimed path) would otherwise
+/// accumulate for the life of the process.
+fn forget_buffer_wait<F>(buffer: &[F]) {
+    let key = buffer.as_ptr() as usize;
+    PENDING_WAITS.lock().unwrap_or_else(|e| e.into_inner()).remove(&key);
+}
+
+/// How long the buffer now backing `ptr` waited to be acquired, clearing the entry. `ZERO` when it
+/// never blocked (or the pointer is not a pooled buffer).
+pub fn take_buffer_wait(ptr: *const u8) -> Duration {
+    let mut map = PENDING_WAITS.lock().unwrap_or_else(|e| e.into_inner());
+    map.remove(&(ptr as usize)).unwrap_or(Duration::ZERO)
+}
 
 /// Round a host range out to page boundaries — `cudaHostRegister` requires the
 /// region to cover whole pages.
@@ -100,6 +127,8 @@ fn register_pool<F: PrimeField64>(buffers: &[Vec<F>]) -> Vec<usize> {
 /// Single fixed-size buffer pool over a bounded channel (internal to `MemoryHandlerRecursive`).
 /// `take()` waits on the channel with a backoff timeout so the abort path (`cancelled`) can wake it.
 struct Pool<F: PrimeField64 + Send + Sync + 'static> {
+    /// Names this pool in the wait diagnostics, so a blocked acquisition can be matched to it.
+    name: &'static str,
     sender: Sender<Vec<F>>,
     receiver: Receiver<Vec<F>>,
     n_buffers: usize,
@@ -113,13 +142,17 @@ struct Pool<F: PrimeField64 + Send + Sync + 'static> {
     /// Data pointers of the pool's OWN buffers — only these are re-pooled on release (a cancel-escape
     /// buffer is freed instead), so the pool stays at exactly N pinned buffers and `release` never blocks.
     original_ptrs: HashSet<usize>,
+    /// Time callers have spent blocked here, and how many acquisitions blocked. Without this the
+    /// wait is invisible: it is charged to whichever timer wraps the caller.
+    wait_ns: AtomicU64,
+    wait_count: AtomicUsize,
     /// Buffers the last `reset` found missing. While non-zero a waiter gets a fresh buffer instead of
     /// parking on one that is never coming back; a later clean `reset` clears it.
     deficit: AtomicUsize,
 }
 
 impl<F: PrimeField64 + Send + Sync + 'static> Pool<F> {
-    fn new(n_buffers: usize, buffer_size: usize, pin: bool, cancelled: Arc<AtomicBool>) -> Self {
+    fn new(name: &'static str, n_buffers: usize, buffer_size: usize, pin: bool, cancelled: Arc<AtomicBool>) -> Self {
         let (sender, receiver) = bounded(n_buffers);
         let buffers: Vec<Vec<F>> = (0..n_buffers).map(|_| vec![F::ZERO; buffer_size]).collect();
         let registered_buffers: Vec<usize> = if pin { register_pool(&buffers) } else { Vec::new() };
@@ -129,6 +162,7 @@ impl<F: PrimeField64 + Send + Sync + 'static> Pool<F> {
             sender.send(buffer).unwrap();
         }
         Self {
+            name,
             sender,
             receiver,
             n_buffers,
@@ -137,24 +171,67 @@ impl<F: PrimeField64 + Send + Sync + 'static> Pool<F> {
             cancelled,
             original_ptrs,
             deficit: AtomicUsize::new(0),
+            wait_ns: AtomicU64::new(0),
+            wait_count: AtomicUsize::new(0),
         }
+    }
+
+    /// Total blocked time and how many acquisitions blocked.
+    fn wait_stats(&self) -> (Duration, usize) {
+        (Duration::from_nanos(self.wait_ns.load(Ordering::Relaxed)), self.wait_count.load(Ordering::Relaxed))
+    }
+
+    /// Report total blocked time. The sum of the callers' reported waits must equal this; if it
+    /// falls short, some blocking is not reaching a span and the per-span numbers are understated.
+    fn log_wait(&self) {
+        let (waited, blocked) = self.wait_stats();
+        if blocked > 0 {
+            tracing::debug!(
+                "Pool '{}' ({} buffers): {} acquisitions blocked, {:.3}s total",
+                self.name,
+                self.n_buffers,
+                blocked,
+                waited.as_secs_f64()
+            );
+        }
+    }
+
+    /// Charge a blocked acquisition to this pool's total and to the buffer it was waiting for, so
+    /// the caller that ends up with that buffer can subtract the wait from its own span.
+    fn charge_wait<T>(&self, buffer: &[T], waited: Duration) {
+        self.wait_ns.fetch_add(waited.as_nanos() as u64, Ordering::Relaxed);
+        self.wait_count.fetch_add(1, Ordering::Relaxed);
+        charge_wait_to_buffer(buffer, waited);
     }
 
     fn take(&self) -> Vec<F> {
         // The timeout only paces the abort-flag re-check, so it escalates: a fixed 100us cost
         // 10k wakeups/s per waiter, exactly while the pool was exhausted.
         let mut backoff = Duration::from_micros(100);
+        // Fast path first, so an uncontended acquisition costs no clock read.
+        if let Ok(buffer) = self.receiver.try_recv() {
+            return buffer;
+        }
+        let started = Instant::now();
         loop {
             match self.receiver.recv_timeout(backoff) {
-                Ok(buffer) => return buffer,
+                Ok(buffer) => {
+                    let waited = started.elapsed();
+                    self.charge_wait(&buffer, waited);
+                    return buffer;
+                }
                 Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
                     // on cancel, hand back a fresh buffer so teardown doesn't hang
                     if self.cancelled.load(Ordering::SeqCst) {
-                        return vec![F::ZERO; self.buffer_size];
+                        let (waited, buffer) = (started.elapsed(), vec![F::ZERO; self.buffer_size]);
+                        self.charge_wait(&buffer, waited);
+                        return buffer;
                     }
                     if let Some(short_by) = self.short_by() {
-                        tracing::error!("Pool::take: pool short by {short_by}; using an unpooled buffer");
-                        return vec![F::ZERO; self.buffer_size];
+                        let (waited, buffer) = (started.elapsed(), vec![F::ZERO; self.buffer_size]);
+                        self.charge_wait(&buffer, waited);
+                        tracing::error!("Pool '{}': short by {short_by}; using an unpooled buffer", self.name);
+                        return buffer;
                     }
                     backoff = (backoff * 2).min(MAX_POOL_WAIT_BACKOFF);
                 }
@@ -196,6 +273,8 @@ impl<F: PrimeField64 + Send + Sync + 'static> Pool<F> {
     }
 
     fn release(&self, buffer: Vec<F>) -> ProofmanResult<()> {
+        // Every take charges this buffer's wait; whoever wanted it has read it by now.
+        forget_buffer_wait(&buffer);
         if buffer.len() != self.buffer_size {
             return Err(ProofmanError::ProofmanError(format!(
                 "Pool::release: wrong size {} (expected {})",
@@ -309,7 +388,7 @@ impl<F: PrimeField64 + Send + Sync + 'static> MemoryHandler<F> {
         // Page-lock the basic-trace pool for direct H2D (trace is an H2D source; pairs with the
         // direct-copy fast path in goldilocks_tooling.cu). Relies on buffers never permanently
         // escaping the pool, which `reset` enforces.
-        let pool = Pool::new(n_buffers, buffer_size, true, cancelled.clone());
+        let pool = Pool::new("basic-trace", n_buffers, buffer_size, true, cancelled.clone());
 
         let total_memory = n_buffers * buffer_size * std::mem::size_of::<F>();
         tracing::info!("MemoryHandler::Total memory for basic traces: {}", crate::format_bytes(total_memory as f64));
@@ -350,14 +429,23 @@ impl<F: PrimeField64 + Send + Sync + 'static> MemoryHandler<F> {
     /// CALCULATING_WITNESS, each iteration touching state shared with the releasing threads.
     pub fn take_buffer(&self) -> Vec<F> {
         let mut backoff = std::time::Duration::from_micros(50);
+        let mut started: Option<Instant> = None;
         loop {
             if let Some(buffer) = self.pool.try_take() {
+                if let Some(t) = started {
+                    let waited = t.elapsed();
+                    self.pool.charge_wait(&buffer, waited);
+                }
                 return buffer;
             }
+            // Only now is this a wait; the first poll above is the uncontended path.
+            let started = *started.get_or_insert_with(Instant::now);
             // Abort path: the awaited buffer may never be released (proof errored first), so return
             // a fresh buffer to unblock the worker and let the process tear down instead of spinning.
             if self.pool.is_cancelled() {
-                return self.pool.fresh_buffer();
+                let (waited, buffer) = (started.elapsed(), self.pool.fresh_buffer());
+                self.pool.charge_wait(&buffer, waited);
+                return buffer;
             }
             if let Some((iid, remove_from_calculated)) = self.instance_ids_to_be_released.pop() {
                 if remove_from_calculated {
@@ -365,19 +453,31 @@ impl<F: PrimeField64 + Send + Sync + 'static> MemoryHandler<F> {
                 }
                 let (is_shared, buf) = self.pctx.free_instance_traces(iid);
                 if is_shared {
+                    let waited = started.elapsed();
+                    self.pool.charge_wait(&buf, waited);
                     return buf;
                 }
                 continue;
             }
             if let Some(buffer) = self.pool.take_timeout(backoff) {
+                let waited = started.elapsed();
+                self.pool.charge_wait(&buffer, waited);
                 return buffer;
             }
             if let Some(short_by) = self.pool.short_by() {
+                let buffer = self.pool.fresh_buffer();
+                self.pool.charge_wait(&buffer, started.elapsed());
                 tracing::error!("MemoryHandler::take_buffer: pool short by {short_by}; using an unpooled buffer");
-                return self.pool.fresh_buffer();
+                return buffer;
             }
             backoff = (backoff * 2).min(MAX_POOL_WAIT_BACKOFF);
         }
+    }
+
+    /// Log how long callers spent blocked on this pool. Their own timers include that wait, so
+    /// without this line a queueing delay reads as witness compute.
+    pub fn log_wait_summary(&self) {
+        self.pool.log_wait();
     }
 
     pub fn release_buffer(&self, buffer: Vec<F>) -> ProofmanResult<()> {
@@ -430,11 +530,17 @@ impl<F: PrimeField64 + Send + Sync + 'static> MemoryHandlerRecursive<F> {
         buffer_size_trace_compressor: usize,
     ) -> Self {
         let cancelled = Arc::new(AtomicBool::new(false));
-        let witness = Pool::new(n_buffers, buffer_size_witness, false, cancelled.clone());
-        let witness_compressor =
-            Pool::new(n_buffers_compressor, buffer_size_witness_compressor, false, cancelled.clone());
-        let trace = Pool::new(n_buffers, buffer_size_trace, true, cancelled.clone());
-        let trace_compressor = Pool::new(n_buffers_compressor, buffer_size_trace_compressor, true, cancelled.clone());
+        let witness = Pool::new("recursive-witness", n_buffers, buffer_size_witness, false, cancelled.clone());
+        let witness_compressor = Pool::new(
+            "compressor-witness",
+            n_buffers_compressor,
+            buffer_size_witness_compressor,
+            false,
+            cancelled.clone(),
+        );
+        let trace = Pool::new("recursive-trace", n_buffers, buffer_size_trace, true, cancelled.clone());
+        let trace_compressor =
+            Pool::new("compressor-trace", n_buffers_compressor, buffer_size_trace_compressor, true, cancelled.clone());
 
         let total = witness.total_bytes()
             + witness_compressor.total_bytes()
@@ -481,6 +587,14 @@ impl<F: PrimeField64 + Send + Sync + 'static> MemoryHandlerRecursive<F> {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    /// Same as [`MemoryHandler::log_wait_summary`], across all four recursive pools.
+    pub fn log_wait_summary(&self) {
+        self.witness.log_wait();
+        self.witness_compressor.log_wait();
+        self.trace.log_wait();
+        self.trace_compressor.log_wait();
     }
 
     pub fn take_buffer_witness(&self) -> Vec<F> {
@@ -737,5 +851,33 @@ mod tests {
         let fresh = h.take_buffer_witness(); // would hang pre-cancel on an empty pool
         assert_eq!(fresh.len(), 8);
         h.reset().unwrap(); // cancelled path skips integrity checks
+    }
+
+    /// A blocked acquisition must be attributed to the pool, not left inside whichever timer wraps
+    /// the caller -- that is what made a 6.4s buffer wait read as 6.4s of witness compute.
+    #[test]
+    fn a_blocked_acquisition_is_charged_to_the_pool() {
+        use proofman_fields::Goldilocks;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let pool: Arc<Pool<Goldilocks>> = Arc::new(Pool::new("test", 1, 8, false, cancelled));
+
+        // The only buffer, so the next take must block.
+        let held = pool.take();
+        assert_eq!(pool.wait_stats(), (Duration::ZERO, 0), "an uncontended take must not be charged");
+
+        let returner = {
+            let pool = pool.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(150));
+                pool.release(held).unwrap();
+            })
+        };
+        let _second = pool.take();
+        returner.join().unwrap();
+
+        let (waited, blocked) = pool.wait_stats();
+        assert_eq!(blocked, 1, "exactly one acquisition blocked");
+        assert!(waited >= Duration::from_millis(100), "wait of {waited:?} should reflect the 150ms hold");
+        assert!(waited < Duration::from_secs(5), "wait of {waited:?} is implausible");
     }
 }

--- a/common/src/proof_ctx.rs
+++ b/common/src/proof_ctx.rs
@@ -993,7 +993,8 @@ impl<F: PrimeField64> ProofCtx<F> {
         max_number_streams_gpu: usize,
         max_number_recursive_streams_gpu: usize,
         final_snark: bool,
-    ) -> ProofmanResult<(u64, u64, u64)> {
+        // -> (basic streams/GPU, recursive streams/GPU, aggregation workers/GPU, GPUs)
+    ) -> ProofmanResult<(u64, u64, u64, u64)> {
         let d_buffers = Arc::new(DeviceBuffer(gen_device_buffers_c(
             self.mpi_ctx.node_rank as u32,
             self.mpi_ctx.node_n_processes as u32,
@@ -1086,6 +1087,7 @@ impl<F: PrimeField64> ProofCtx<F> {
             false => StreamLayout {
                 basic: vec![StreamClass { size: sctx.max_prover_buffer_size.max(recursive_capable_size), count: 1 }],
                 recursive: StreamClass { size: max_prover_recursive2_buffer_size, count: 0 },
+                aggregation_workers: 0,
                 unused: 0,
             },
         };
@@ -1103,12 +1105,16 @@ impl<F: PrimeField64> ProofCtx<F> {
                 .map(|c| format!("{} x {}", c.count, format_bytes(c.size as f64 * 8.0)))
                 .collect::<Vec<_>>()
                 .join(" + ");
+            let aggregation_desc = match n_recursive_streams_per_gpu {
+                0 => format!("{} aggregation workers sharing the basic streams", layout.aggregation_workers),
+                n => format!("{n} dedicated streams per GPU for recursive proofs"),
+            };
             tracing::info!(
-                "Using {} streams per GPU for basic proofs ({}) and {} streams per GPU for recursive proofs. \
+                "Using {} streams per GPU for basic proofs ({}) and {}. \
                  Using {} for fixed pols, {} unused",
                 n_streams_per_gpu,
                 classes,
-                n_recursive_streams_per_gpu,
+                aggregation_desc,
                 format_bytes((total_const_area + total_const_area_aggregation) as f64 * 8.0),
                 format_bytes(layout.unused as f64 * 8.0),
             );
@@ -1166,7 +1172,7 @@ impl<F: PrimeField64> ProofCtx<F> {
 
         self.d_buffers = d_buffers;
 
-        Ok((n_streams_per_gpu as u64, n_recursive_streams_per_gpu as u64, n_gpus))
+        Ok((n_streams_per_gpu as u64, n_recursive_streams_per_gpu as u64, layout.aggregation_workers as u64, n_gpus))
     }
 
     pub fn get_device_buffers_ptr(&self) -> *mut c_void {

--- a/pil2-stark/src/api/starks_api.cu
+++ b/pil2-stark/src/api/starks_api.cu
@@ -2438,6 +2438,12 @@ static const AirInstanceInfo *requestedAirInstance(DeviceCommitBuffers* d_buffer
     return byType->second[0];
 }
 
+// A forced request may only be held to a pool that exists: the Rust carve drops it when an
+// aggregation-only stream costs what a basic one does.
+static bool hasRecursivePool(DeviceCommitBuffers* d_buffers){
+    return d_buffers->n_recursive_streams > 0;
+}
+
 static uint64_t largestBasicCapacity(DeviceCommitBuffers* d_buffers){
     uint64_t largest = 0;
     for (uint32_t j = 0; j < d_buffers->n_streams; ++j) {
@@ -2494,30 +2500,19 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
         return wantSlot != UINT64_MAX && sd.constPolsOffset == wantSlot && sd.constAuxOffset == wantAux
                && sd.constAggBuffer == wantAgg && sd.constRecurserId.empty();
     };
-    uint32_t countFreeStreamsGPU[d_buffers->n_gpus];
-    uint32_t countUnusedStreams[d_buffers->n_gpus];
-    int streamIdxGPU[d_buffers->n_gpus];
-    bool warmFoundGPU[d_buffers->n_gpus];
-    bool unusedFoundGPU[d_buffers->n_gpus];
-
-    for( uint32_t i = 0; i < d_buffers->n_gpus; i++){
-        countUnusedStreams[i] = 0;
-        countFreeStreamsGPU[i] = 0;
-        streamIdxGPU[i] = -1;
-        warmFoundGPU[i] = false;
-        unusedFoundGPU[i] = false;
-    }
+    // The best free stream on one GPU, and how much it has free (which picks between GPUs).
+    struct GpuPick { int stream = -1; uint32_t free = 0, unused = 0; bool warm = false, wasUnused = false; };
+    std::vector<GpuPick> picks(d_buffers->n_gpus);
 
     // Tightest fit first, so larger classes stay free for the airs with nowhere else to go. Only free
     // streams are compared, so a busy tight class never idles the big one. Within a class: warm, then unused.
-    auto betterCandidate = [&](uint32_t cand, int best, bool candWarm, bool candUnused,
-                               bool bestWarm, bool bestUnused) {
-        if (best < 0) return true;
+    auto betterCandidate = [&](uint32_t cand, const GpuPick &best, bool candWarm, bool candUnused) {
+        if (best.stream < 0) return true;
         const uint64_t candCap = d_buffers->streamsData[cand].auxTraceCapacity;
-        const uint64_t bestCap = d_buffers->streamsData[best].auxTraceCapacity;
+        const uint64_t bestCap = d_buffers->streamsData[best.stream].auxTraceCapacity;
         if (candCap != bestCap) return candCap < bestCap;
-        if (candWarm != bestWarm) return candWarm;
-        return candUnused && !bestUnused;
+        if (candWarm != best.warm) return candWarm;
+        return candUnused && !best.wasUnused;
     };
 
     bool someFree = false;
@@ -2534,87 +2529,51 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
         // try_lock, so this never blocks on harvest/reserve.
         std::lock_guard<std::mutex> gsel(d_buffers->stream_selection_mutex);
         const bool firstGpuBorrowed = d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire);
-        if (recursive) {
+        // One pool pass; the best candidate per GPU is left locked.
+        auto scanPool = [&](auto pool) {
             for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
-                if (firstGpuBorrowed && d_buffers->streamsData[i].gpuId == firstGpuId) continue;
-                if (d_buffers->streamsData[i].recursive && d_buffers->streamsData[i].mutex_stream_selection.try_lock()) {
-                    // Re-check the borrow flag under the lock.
-                    if (d_buffers->streamsData[i].gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
-                        d_buffers->streamsData[i].mutex_stream_selection.unlock();
-                        continue;
-                    }
-                    // Ran to completion but not yet harvested: free to take, and its
-                    // const-tree is still loaded. Queried once and reused by the warm test.
-                    const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
-                    if ((d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained)
-                        && fitsCapacity(d_buffers->streamsData[i])) {
-                        uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
-
-                        countFreeStreamsGPU[gpuLocalId]++;
-                        if(d_buffers->streamsData[i].status==0){
-                            countUnusedStreams[gpuLocalId]++;
-                        }
-                        // status==0 is deliberately absent from isWarm: the only path to it
-                        // (reset_device_streams_gpu) calls invalidateContext() first, so the
-                        // key comparison there can never match an unused stream anyway.
-                        bool warm = isWarm(d_buffers->streamsData[i], drained);
-                        bool unused = d_buffers->streamsData[i].status==0;
-                        if (betterCandidate(i, streamIdxGPU[gpuLocalId], warm, unused,
-                                            warmFoundGPU[gpuLocalId], unusedFoundGPU[gpuLocalId])) {
-                            streamIdxGPU[gpuLocalId] = i;
-                            warmFoundGPU[gpuLocalId] = warm;
-                            unusedFoundGPU[gpuLocalId] = unused;
-                        }
-                        someFree = true;
-                        streams_locked[i] = true;
-                    } else {
-                        d_buffers->streamsData[i].mutex_stream_selection.unlock();
-                    }
+                StreamData &sd = d_buffers->streamsData[i];
+                if (firstGpuBorrowed && sd.gpuId == firstGpuId) continue;
+                if (!pool(sd) || !sd.mutex_stream_selection.try_lock()) continue;
+                // Re-check the borrow flag under the lock.
+                if (sd.gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
+                    sd.mutex_stream_selection.unlock();
+                    continue;
                 }
+                // Ran to completion but not yet harvested: free to take, and its const-tree is still
+                // loaded. Queried once and reused by the warm test.
+                const bool drained = sd.status==2 && cudaEventQuery(sd.end_event) == cudaSuccess;
+                if (!(sd.status==0 || sd.status==3 || drained) || !fitsCapacity(sd)) {
+                    sd.mutex_stream_selection.unlock();
+                    continue;
+                }
+                GpuPick &pick = picks[d_buffers->gpus_g2l[sd.gpuId]];
+                const bool unused = sd.status==0;
+                pick.free++;
+                pick.unused += unused;
+                // status==0 is deliberately absent from isWarm: the only path to it
+                // (reset_device_streams_gpu) calls invalidateContext() first, so the key comparison
+                // there can never match an unused stream anyway.
+                const bool warm = isWarm(sd, drained);
+                if (betterCandidate(i, pick, warm, unused)) {
+                    pick.stream = i;
+                    pick.warm = warm;
+                    pick.wasUnused = unused;
+                }
+                someFree = true;
+                streams_locked[i] = true;
             }
+        };
+
+        if (recursive) {
+            scanPool([](const StreamData &sd) { return sd.recursive; });
         }
 
-        // Recursive requests that found a recursive stream skip this (someFree set);
-        // a non-forced recursive request with no free recursive stream falls back to
-        // non-recursive streams, exactly as the old while-loop did.
-        if (!someFree && (!recursive || !force_recursive)) {
-            for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
-                if (firstGpuBorrowed && d_buffers->streamsData[i].gpuId == firstGpuId) continue;
-                if (!d_buffers->streamsData[i].recursive && d_buffers->streamsData[i].mutex_stream_selection.try_lock()) {
-                    // Re-check the borrow flag under the lock (see the recursive loop above).
-                    if (d_buffers->streamsData[i].gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
-                        d_buffers->streamsData[i].mutex_stream_selection.unlock();
-                        continue;
-                    }
-                    // Ran to completion but not yet harvested: free to take, and its
-                    // const-tree is still loaded. Queried once and reused by the warm test.
-                    const bool drained = d_buffers->streamsData[i].status==2 && cudaEventQuery(d_buffers->streamsData[i].end_event) == cudaSuccess;
-                    if ((d_buffers->streamsData[i].status==0 || d_buffers->streamsData[i].status==3 || drained)
-                        && fitsCapacity(d_buffers->streamsData[i])) {
-                        uint32_t gpuLocalId = d_buffers->gpus_g2l[d_buffers->streamsData[i].gpuId];
-
-                        countFreeStreamsGPU[gpuLocalId]++;
-                        if(d_buffers->streamsData[i].status==0){
-                            countUnusedStreams[gpuLocalId]++;
-                        }
-                        // status==0 is deliberately absent from isWarm: the only path to it
-                        // (reset_device_streams_gpu) calls invalidateContext() first, so the
-                        // key comparison there can never match an unused stream anyway.
-                        bool warm = isWarm(d_buffers->streamsData[i], drained);
-                        bool unused = d_buffers->streamsData[i].status==0;
-                        if (betterCandidate(i, streamIdxGPU[gpuLocalId], warm, unused,
-                                            warmFoundGPU[gpuLocalId], unusedFoundGPU[gpuLocalId])) {
-                            streamIdxGPU[gpuLocalId] = i;
-                            warmFoundGPU[gpuLocalId] = warm;
-                            unusedFoundGPU[gpuLocalId] = unused;
-                        }
-                        someFree = true;
-                        streams_locked[i] = true;
-                    } else {
-                        d_buffers->streamsData[i].mutex_stream_selection.unlock();
-                    }
-                }
-            }
+        // A recursive request with no free recursive stream falls back here. The reverse is NOT
+        // allowed: only gen_recursive_proof_gpu resolves its aux trace by `sd.recursive`, so a basic
+        // launch on a recursive stream would index the basic pool with a recursive localStreamId.
+        if (!someFree && (!recursive || !(force_recursive && hasRecursivePool(d_buffers)))) {
+            scanPool([](const StreamData &sd) { return !sd.recursive; });
         }
     }
 
@@ -2623,13 +2582,13 @@ uint32_t reserve_best_stream_scan(DeviceCommitBuffers* d_buffers, uint64_t airgr
     // Most free streams wins; ties break on unused count. someFree guarantees a candidate.
     int bestGpu = -1;
     for (uint32_t i = 0; i < d_buffers->n_gpus; i++) {
-        if (streamIdxGPU[i] == -1) continue;
-        if (bestGpu == -1 || countFreeStreamsGPU[i] > countFreeStreamsGPU[bestGpu] ||
-            (countFreeStreamsGPU[i] == countFreeStreamsGPU[bestGpu] && countUnusedStreams[i] > countUnusedStreams[bestGpu])) {
+        if (picks[i].stream < 0) continue;
+        if (bestGpu == -1 || picks[i].free > picks[bestGpu].free ||
+            (picks[i].free == picks[bestGpu].free && picks[i].unused > picks[bestGpu].unused)) {
             bestGpu = i;
         }
     }
-    uint32_t selectedStreamId = streamIdxGPU[bestGpu];
+    uint32_t selectedStreamId = picks[bestGpu].stream;
     for (uint32_t i = 0; i < d_buffers->n_total_streams; i++) {
         if (streams_locked[i] && i != selectedStreamId) {
             d_buffers->streamsData[i].mutex_stream_selection.unlock();
@@ -2657,7 +2616,7 @@ uint32_t selectStream(DeviceCommitBuffers* d_buffers, uint64_t airgroupId, uint6
             uint64_t largest = 0;
             for (uint32_t i = 0; i < d_buffers->n_total_streams; ++i) {
                 const StreamData &sd = d_buffers->streamsData[i];
-                if (force_recursive && !sd.recursive) continue;
+                if (force_recursive && hasRecursivePool(d_buffers) && !sd.recursive) continue;
                 largest = std::max(largest, sd.auxTraceCapacity);
                 if (sd.auxTraceCapacity >= requirementFor(d_buffers, sd, need)) eligible++;
             }
@@ -2704,9 +2663,9 @@ uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, uint64_
     DeviceCommitBuffers* d_buffers = (DeviceCommitBuffers*)d_buffers_;
     if (streamId >= d_buffers->n_total_streams) return 0;
     StreamData& sd = d_buffers->streamsData[streamId];
-    // A forced recursive launch must stay on a recursive stream; refuse otherwise so
-    // the caller falls back to the cold scan.
-    if (force_recursive && !sd.recursive) return 0;
+    // A forced recursive launch must stay on a recursive stream while a pool exists; refuse
+    // otherwise so the caller falls back to the cold scan.
+    if (force_recursive && hasRecursivePool(d_buffers) && !sd.recursive) return 0;
     // Warm is worthless if the launch does not fit; the cold scan will find a class that does.
     const uint64_t known = requiredAuxTrace(d_buffers, airgroupId, airId, std::string(proofType));
     const uint64_t need = requirementFor(d_buffers, sd, known);
@@ -2714,21 +2673,25 @@ uint32_t reserve_stream_if_free_gpu(void* d_buffers_, uint32_t streamId, uint64_
     const uint32_t firstGpuId = d_buffers->my_gpu_ids[0];
     if (d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire) && sd.gpuId == firstGpuId) return 0;
 
-    std::lock_guard<std::mutex> gsel(d_buffers->stream_selection_mutex);
-    if (!sd.mutex_stream_selection.try_lock()) return 0;
-    if (sd.gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
-        sd.mutex_stream_selection.unlock();
-        return 0;
-    }
-    bool free = sd.status==0 || sd.status==3 || (sd.status==2 && cudaEventQuery(sd.end_event) == cudaSuccess);
-    if (!free) { sd.mutex_stream_selection.unlock(); return 0; }
-    // Warm but too roomy: taking it would park this launch on a stream some larger air may be the
-    // only user of. Refuse, and let the scan apply its tightest-fit rule. Sized pool only -- the
-    // recursive streams are one class, and comparing them against basic ones just loses affinity.
-    if (!sd.recursive && sd.auxTraceCapacity > need
-        && tighterFreeStreamExists(d_buffers, need, sd.auxTraceCapacity, streamId, sd.gpuId)) {
-        sd.mutex_stream_selection.unlock();
-        return 0;
+    {
+        // Scoped like the cold scan's: reserving harvests a proof, and the global lock must never be
+        // held across that. The per-stream lock, which guards the state, stays held.
+        std::lock_guard<std::mutex> gsel(d_buffers->stream_selection_mutex);
+        if (!sd.mutex_stream_selection.try_lock()) return 0;
+        if (sd.gpuId == firstGpuId && d_buffers->firstGpuBufferBorrowed.load(std::memory_order_acquire)) {
+            sd.mutex_stream_selection.unlock();
+            return 0;
+        }
+        bool free = sd.status==0 || sd.status==3 || (sd.status==2 && cudaEventQuery(sd.end_event) == cudaSuccess);
+        if (!free) { sd.mutex_stream_selection.unlock(); return 0; }
+        // Warm but too roomy: taking it would park this launch on a stream some larger air may be the
+        // only user of. Refuse, and let the scan apply its tightest-fit rule. Sized pool only -- the
+        // recursive streams are one class, and comparing them against basic ones just loses affinity.
+        if (!sd.recursive && sd.auxTraceCapacity > need
+            && tighterFreeStreamExists(d_buffers, need, sd.auxTraceCapacity, streamId, sd.gpuId)) {
+            sd.mutex_stream_selection.unlock();
+            return 0;
+        }
     }
     reserveStreamLocked(d_buffers, streamId);
     sd.mutex_stream_selection.unlock();

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -80,8 +80,10 @@ void calculateWitnessSTD_gpu(SetupCtx& setupCtx, StepsParams& h_params, StepsPar
 }
 
 void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols, gl64_t *d_const_tree, char *constTreePath, uint32_t stream_id, uint64_t instance_id, DeviceCommitBuffers *d_buffers, AirInstanceInfo *air_instance_info, bool skipRecalculation, TimerGPU &timer, cudaStream_t stream, bool recursive = false, bool reuse_constants = false) {
-    // Per-stream timer is reused: drop categories a prior aborted job left open.
+    // Per-stream timer is reused: drop categories left open by an aborted job, and the load
+    // phase's, so KERNELS CONTRIBUTIONS covers the proof window only.
     TimerResetCategoriesGPU(timer);
+    TimerClearCategoriesGPU(timer);
     TimerStartGPU(timer, STARK_GPU_PROOF);
     TimerStartGPU(timer, STARK_STEP_0);
 
@@ -105,12 +107,14 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     // (air, stream, region) gets its own graph:
     //   0x57455850 "WEXP"  witness expressions
     //   0x434d5431 "CM1"   commit stage 1 (+ recursive, skipRecalculation in key)
-    //   0x53544432 "STD2"  stage-2 getFields + gsum/gprod + im hints + im pols
+    //   0x53544432 "STD2"  stage-2 getFields + gsum/gprod + im hints
+    //   0x494d504c "IMPL"  im pols
     //   0x434d5432 "CM2"   commit stage 2 + airValues transcript puts
     //   0x51455850 "QEXP"  Q expression
     //   0x434d5451 "CMQ"   commit stage Q
     //   0x4556414c "EVAL"  evals memset + LEv/evmap + evals transcript + FRI challenges
-    //   0x46524950 "FRIP"  calculateXis + computeX + FRI expression
+    //   0x46524950 "FRIP"  calculateXis + computeX
+    //   0x46524558 "FREX"  FRI expression
     //   0x465249   "FRI"   FRI fold+merkelize step (+ step in key)
     //   0x4752494e "GRIN"  grinding (+ powBits in key)
     //   0x515559   "QUY"   query proofs (+ d_const_tree in key: preloaded trees repoint it)
@@ -255,12 +259,16 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, true, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, false, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
 
+    });
     TimerStopGPU(timer, STARK_CALCULATE_WITNESS_STD);
 
+    // Own capture region so the section timers stay outside every region body: a replay returns
+    // before the body, so a start/stop pair split across it loses the stop event.
     TimerStartGPU(timer, CALCULATE_IM_POLS);
-    calculateImPolsExpressions(setupCtx, air_instance_info->expressions_gpu, h_params, d_params, 2, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
-    TimerStopGPU(timer, CALCULATE_IM_POLS);
+    cudagraph::run(cudagraph::key(0x494d504cULL ^ graphCtxId), countId, stream, [&] {
+        calculateImPolsExpressions(setupCtx, air_instance_info->expressions_gpu, h_params, d_params, 2, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     });
+    TimerStopGPU(timer, CALCULATE_IM_POLS);
     
     TimerStartGPU(timer, STARK_COMMIT_STAGE_2);
     cudagraph::run(cudagraph::key(0x434d5432ULL ^ graphCtxId), countId, stream, [&] {
@@ -288,7 +296,10 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     }
     TimerStopCategoryGPU(timer, TRANSCRIPT);
     uint64_t zi_offset = setupCtx.starkInfo.mapOffsets[std::make_pair("zi", true)];
+    // The zerofier is what the Q expression divides by, and it spans the extended domain.
+    TimerStartCategoryGPU(timer, EXPRESSIONS);
     computeZerofier(h_params.aux_trace + zi_offset, setupCtx.starkInfo.starkStruct.nBits, setupCtx.starkInfo.starkStruct.nBitsExt, stream);
+    TimerStopCategoryGPU(timer, EXPRESSIONS);
 
     if (setupCtx.starkInfo.calculateFixedExtended && !reuse_constants) {
         TimerStartGPU(timer, FIXED_POLS_TREE);
@@ -323,7 +334,9 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     gl64_t * d_LEv = (gl64_t *) h_params.aux_trace +setupCtx.starkInfo.mapOffsets[std::make_pair("lev", false)];
 
     cudagraph::run(cudagraph::key(0x4556414cULL ^ graphCtxId), countId, stream, [&] {
+    TimerStartCategoryGPU(timer, EVALS);
     CHECKCUDAERR(cudaMemsetAsync(h_params.evals, 0, setupCtx.starkInfo.evMap.size() * FIELD_EXTENSION * sizeof(Goldilocks::Element), stream));
+    TimerStopCategoryGPU(timer, EVALS);
     uint64_t count = 0;
     for(uint64_t i = 0; i < setupCtx.starkInfo.openingPoints.size(); i += EVALS_OPENING_BATCH) {
         std::vector<int64_t> openingPoints;
@@ -360,17 +373,22 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     //--------------------------------
     TimerStartGPU(timer, STARK_STEP_FRI);
     cudagraph::run(cudagraph::key(0x46524950ULL ^ graphCtxId), countId, stream, [&] {
+    TimerStartCategoryGPU(timer, FRI);
     calculateXis_inplace(setupCtx, h_params, air_instance_info->opening_points, d_xiChallenge, stream);
     uint64_t x_offset = setupCtx.starkInfo.mapOffsets[std::make_pair("x", true)];
     dim3 threads(256);
     dim3 blocks((NExtended + threads.x - 1) / threads.x);
     computeX_kernel<<<blocks, threads, 0, stream>>>((gl64_t *)h_params.aux_trace + x_offset, NExtended, Goldilocks::shift(), Goldilocks::w(setupCtx.starkInfo.starkStruct.nBitsExt));
+    TimerStopCategoryGPU(timer, FRI);
+    });
+    // Own capture region, as CALCULATE_IM_POLS: inside the FRIP body these two lost every replay.
     TimerStartGPU(timer, STARK_FRI_POLYNOMIAL);
     TimerStartCategoryGPU(timer, EXPRESSIONS);
-    calculateFRIExpression(setupCtx, h_params, air_instance_info, stream);
+    cudagraph::run(cudagraph::key(0x46524558ULL ^ graphCtxId), countId, stream, [&] {
+        calculateFRIExpression(setupCtx, h_params, air_instance_info, stream);
+    });
     TimerStopCategoryGPU(timer, EXPRESSIONS);
     TimerStopGPU(timer, STARK_FRI_POLYNOMIAL);
-    });
     for(uint64_t step = 0; step < setupCtx.starkInfo.starkStruct.steps.size() - 1; ++step) { 
         Goldilocks::Element *src = h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("fri_" + to_string(step + 1), true)];
         starks.treesFRI[step]->setSource(src);
@@ -401,14 +419,18 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             }
             else
             {
+                TimerStartCategoryGPU(timer, TRANSCRIPT);
                 if(!setupCtx.starkInfo.starkStruct.hashCommits) {
                     d_transcript->put((Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
                 } else {
                     calculateHash(d_transcript_helper, d_challenge, setupCtx, (Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
                     d_transcript->put(d_challenge, HASH_SIZE, stream);
                 }
+                TimerStopCategoryGPU(timer, TRANSCRIPT);
             }
+            TimerStartCategoryGPU(timer, TRANSCRIPT);
             d_transcript->getField((uint64_t *)d_challenge, stream);
+            TimerStopCategoryGPU(timer, TRANSCRIPT);
         });
     }
 
@@ -438,7 +460,9 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     TimerStopCategoryGPU(timer, FRI);
     TimerStopGPU(timer, STARK_STEP_FRI);
 
+    TimerStartCategoryGPU(timer, SET_PROOF);
     setProof(setupCtx, (Goldilocks::Element *)d_aux_trace, (Goldilocks::Element *)d_const_tree, proof_buffer_pinned, stream);
+    TimerStopCategoryGPU(timer, SET_PROOF);
 
     TimerStopGPU(timer, STARK_GPU_PROOF);
 }

--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -334,9 +334,7 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     gl64_t * d_LEv = (gl64_t *) h_params.aux_trace +setupCtx.starkInfo.mapOffsets[std::make_pair("lev", false)];
 
     cudagraph::run(cudagraph::key(0x4556414cULL ^ graphCtxId), countId, stream, [&] {
-    TimerStartCategoryGPU(timer, EVALS);
     CHECKCUDAERR(cudaMemsetAsync(h_params.evals, 0, setupCtx.starkInfo.evMap.size() * FIELD_EXTENSION * sizeof(Goldilocks::Element), stream));
-    TimerStopCategoryGPU(timer, EVALS);
     uint64_t count = 0;
     for(uint64_t i = 0; i < setupCtx.starkInfo.openingPoints.size(); i += EVALS_OPENING_BATCH) {
         std::vector<int64_t> openingPoints;
@@ -372,15 +370,17 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
     // 6. Compute FRI
     //--------------------------------
     TimerStartGPU(timer, STARK_STEP_FRI);
-    cudagraph::run(cudagraph::key(0x46524950ULL ^ graphCtxId), countId, stream, [&] {
+    // Outside the region, not in it: a replay skips the body, so a category timed inside one
+    // stops being sampled. This category happens to cover the whole body, so it can just wrap it.
     TimerStartCategoryGPU(timer, FRI);
+    cudagraph::run(cudagraph::key(0x46524950ULL ^ graphCtxId), countId, stream, [&] {
     calculateXis_inplace(setupCtx, h_params, air_instance_info->opening_points, d_xiChallenge, stream);
     uint64_t x_offset = setupCtx.starkInfo.mapOffsets[std::make_pair("x", true)];
     dim3 threads(256);
     dim3 blocks((NExtended + threads.x - 1) / threads.x);
     computeX_kernel<<<blocks, threads, 0, stream>>>((gl64_t *)h_params.aux_trace + x_offset, NExtended, Goldilocks::shift(), Goldilocks::w(setupCtx.starkInfo.starkStruct.nBitsExt));
-    TimerStopCategoryGPU(timer, FRI);
     });
+    TimerStopCategoryGPU(timer, FRI);
     // Own capture region, as CALCULATE_IM_POLS: inside the FRIP body these two lost every replay.
     TimerStartGPU(timer, STARK_FRI_POLYNOMIAL);
     TimerStartCategoryGPU(timer, EXPRESSIONS);
@@ -419,18 +419,14 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
             }
             else
             {
-                TimerStartCategoryGPU(timer, TRANSCRIPT);
                 if(!setupCtx.starkInfo.starkStruct.hashCommits) {
                     d_transcript->put((Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
                 } else {
                     calculateHash(d_transcript_helper, d_challenge, setupCtx, (Goldilocks::Element *)d_friPol, (1 << setupCtx.starkInfo.starkStruct.steps[step].nBits) * FIELD_EXTENSION, stream);
                     d_transcript->put(d_challenge, HASH_SIZE, stream);
                 }
-                TimerStopCategoryGPU(timer, TRANSCRIPT);
             }
-            TimerStartCategoryGPU(timer, TRANSCRIPT);
             d_transcript->getField((uint64_t *)d_challenge, stream);
-            TimerStopCategoryGPU(timer, TRANSCRIPT);
         });
     }
 

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -1067,8 +1067,7 @@ void merkelizeFRI_inplace(SetupCtx& setupCtx, StepsParams &h_params, uint64_t st
     uint64_t height = pol2N / width;
     dim3 nThreads(32, 32);
     dim3 nBlocks((width + nThreads.x - 1) / nThreads.x, (height + nThreads.y - 1) / nThreads.y);
-    // The transpose lays the polynomial out for the tree, so it belongs to the same category --
-    // outside it, it was the largest single contributor to the report's OTHER line.
+    // The transpose lays the polynomial out for the tree, so it belongs to the same category.
     TimerStartCategoryGPU(timer, MERKLE_TREE);
     transposeFRI<<<nBlocks, nThreads, 0, stream>>>((gl64_t *)treeFRI->source, (gl64_t *)pol, pol2N, width);
 

--- a/pil2-stark/src/starkpil/starks_gpu.cu
+++ b/pil2-stark/src/starkpil/starks_gpu.cu
@@ -1067,15 +1067,19 @@ void merkelizeFRI_inplace(SetupCtx& setupCtx, StepsParams &h_params, uint64_t st
     uint64_t height = pol2N / width;
     dim3 nThreads(32, 32);
     dim3 nBlocks((width + nThreads.x - 1) / nThreads.x, (height + nThreads.y - 1) / nThreads.y);
-    transposeFRI<<<nBlocks, nThreads, 0, stream>>>((gl64_t *)treeFRI->source, (gl64_t *)pol, pol2N, width);
-    
+    // The transpose lays the polynomial out for the tree, so it belongs to the same category --
+    // outside it, it was the largest single contributor to the report's OTHER line.
     TimerStartCategoryGPU(timer, MERKLE_TREE);
+    transposeFRI<<<nBlocks, nThreads, 0, stream>>>((gl64_t *)treeFRI->source, (gl64_t *)pol, pol2N, width);
+
     buildMerkleTreeGPU(setupCtx.starkInfo.starkStruct.merkleTreeArity, (uint64_t*)treeFRI->nodes, (uint64_t *)treeFRI->source, treeFRI->width, treeFRI->height, Layout::RowMajor, stream);
     TimerStopCategoryGPU(timer, MERKLE_TREE);
 
     uint64_t tree_size = treeFRI->numNodes;
     if(d_transcript != nullptr) {
+        TimerStartCategoryGPU(timer, TRANSCRIPT);
         d_transcript->put(&treeFRI->nodes[tree_size - HASH_SIZE], HASH_SIZE, stream);
+        TimerStopCategoryGPU(timer, TRANSCRIPT);
     }
 }
 

--- a/pil2-stark/src/starkpil/starks_gpu_bn128.cu
+++ b/pil2-stark/src/starkpil/starks_gpu_bn128.cu
@@ -347,9 +347,9 @@ void merkelizeFRI_bn128_gpu(SetupCtx& setupCtx, StepsParams &h_params, uint64_t 
 
     Goldilocks::Element *src = h_params.aux_trace + setupCtx.starkInfo.mapOffsets[std::make_pair("fri_" + to_string(step + 1), true)];
     treeFRI->setSource(src); 
-    transposeFRI<<<nBlocks, nThreads, 0, stream>>>((gl64_t *)treeFRI->source, (gl64_t *)pol, pol2N, width);
-    
     TimerStartCategoryGPU(timer, MERKLE_TREE);
+    transposeFRI<<<nBlocks, nThreads, 0, stream>>>((gl64_t *)treeFRI->source, (gl64_t *)pol, pol2N, width);
+
     PoseidonBN128GPU::FrElement * pNodes;
     int64_t tree_size = treeFRI->getNumNodes(treeFRI->height);
     cudaMalloc((void**)&pNodes, tree_size * sizeof(PoseidonBN128GPU::FrElement));

--- a/pil2-stark/src/utils/gpu_timer.cuh
+++ b/pil2-stark/src/utils/gpu_timer.cuh
@@ -16,6 +16,9 @@ struct TimerEntry {
     cudaEvent_t start = nullptr;
     cudaEvent_t stop = nullptr;
     float timeMs = -1.0f;
+    // Nesting level at the first start(): sections wrap each other, and a flat log of them
+    // reads as double counting.
+    uint32_t depth = 0;
 };
 
 class TimerGPU {
@@ -24,6 +27,8 @@ public:
     std::unordered_map<std::string, std::vector<TimerEntry>> multiTimers;
     std::unordered_map<std::string, size_t> activeCategoryTimers;
     std::vector<std::string> order;
+    // Open sections, innermost last; only its size is used, as the next section's depth.
+    std::vector<std::string> openSections;
     cudaStream_t stream = nullptr;
 
     TimerGPU() = default;
@@ -42,17 +47,28 @@ public:
         return true;
     }
 
+    // A cudaEventRecord issued inside a cudagraph body becomes a graph node bound to this handle,
+    // which clear()/clearCategories() then destroys while the cached graph still replays it.
+    bool capturing() const {
+        if (stream == nullptr) return false;
+        cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+        return cudaStreamIsCapturing(stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone;
+    }
+
     void start(const std::string& name) {
+        if (capturing()) return;
         if (timers.find(name) == timers.end()) {
             cudaEvent_t start, stop;
             if (!createEvent(start) || !createEvent(stop)) return;
-            timers[name] = {start, stop, -1.0f};
+            timers[name] = {start, stop, -1.0f, (uint32_t)openSections.size()};
             order.push_back(name);
         }
+        openSections.push_back(name);
         cudaEventRecord(timers[name].start, stream);
     }
 
     void stop(const std::string& name) {
+        if (capturing()) return;
         auto it = timers.find(name);
         if (it == timers.end()) {
 #ifndef __GOLDILOCKS_ENV__
@@ -61,9 +77,13 @@ public:
             return;
         }
         cudaEventRecord(it->second.stop, stream);
+        for (size_t i = openSections.size(); i-- > 0;) {
+            if (openSections[i] == name) { openSections.erase(openSections.begin() + i); break; }
+        }
     }
 
     void startCategory(const std::string& name) {
+        if (capturing()) return;
         if (activeCategoryTimers.find(name) != activeCategoryTimers.end()) {
 #ifndef __GOLDILOCKS_ENV__
             zklog.error("TimerGPU::startCategory called without stop for previous timer: " + name);
@@ -81,6 +101,7 @@ public:
     }
 
     void stopCategory(const std::string& name) {
+        if (capturing()) return;
         auto it = activeCategoryTimers.find(name);
         if (it == activeCategoryTimers.end()) {
 #ifndef __GOLDILOCKS_ENV__
@@ -138,7 +159,7 @@ public:
         for (const auto& name : order) {
             auto& entry = timers[name];
             if (entry.timeMs < 0.0f) syncAndCompute(name);
-            zklog.trace("<-- " + name + " : " + std::to_string(entry.timeMs / 1000.0f) + " s");
+            zklog.trace("<-- " + std::string(2 * entry.depth, ' ') + name + " : " + std::to_string(entry.timeMs / 1000.0f) + " s");
         }
         if (order.empty()) {
             for (auto& [category, entries] : multiTimers) {
@@ -175,8 +196,22 @@ public:
         }
     }
 
-    // Clear stale open categories so an aborted job can't leak state into the next.
+    // Clear stale open categories/sections so an aborted job can't leak state into the next.
     void resetCategories() {
+        activeCategoryTimers.clear();
+        openSections.clear();
+    }
+
+    // Drop recorded categories so the next window's report covers only that window: the prove
+    // path records some before the proof opens (the load phase).
+    void clearCategories() {
+        for (auto& [_, entries] : multiTimers) {
+            for (auto& entry : entries) {
+                cudaEventDestroy(entry.start);
+                cudaEventDestroy(entry.stop);
+            }
+        }
+        multiTimers.clear();
         activeCategoryTimers.clear();
     }
 
@@ -187,6 +222,7 @@ public:
         }
         timers.clear();
         order.clear();
+        openSections.clear();
 
         for (auto& [_, entries] : multiTimers) {
             for (auto& entry : entries) {
@@ -202,6 +238,8 @@ public:
 #ifndef __GOLDILOCKS_ENV__
         if (timers.find(total_name) == timers.end()) return;
 
+        // clearCategories() at the proof window's start means everything left belongs to
+        // total_name; mixing in the load phase used to push the total over 100%.
         double time_total = getTimeSec(total_name);
         if (multiTimers.empty()) return;
         zklog.trace("     KERNELS CONTRIBUTIONS:");
@@ -225,9 +263,11 @@ public:
             oss.clear();
         }
 
+        // Every kernel the proof launches is inside a category, so what is left is the stream idle
+        // between them: launch latency, and no category can cover it -- a gap is inside none.
         double other_time = std::max(0.0, time_total - accounted_time);
         oss << std::fixed << std::setprecision(4) << other_time << "s (" << std::setprecision(2)<< (other_time / time_total) * 100.0 << "%)";
-        zklog.trace("        OTHER" + std::string(15 - 5, ' ') + ":  " + oss.str());
+        zklog.trace("        STREAM_GAPS" + std::string(15 - 11, ' ') + ":  " + oss.str());
 #endif
     }
 
@@ -270,6 +310,8 @@ inline std::string makeTimerName(const std::string& base, int id) {
 
 #define TimerResetCategoriesGPU(timer) (timer.resetCategories())
 
+#define TimerClearCategoriesGPU(timer) (timer.clearCategories())
+
 #define TimerGetElapsedCategoryGPU(timer, category) \
     (timer.getCategoryTotalTimeSec(#category))
 
@@ -289,6 +331,7 @@ inline std::string makeTimerName(const std::string& base, int id) {
 #define TimerSyncCategoriesGPU(timer)
 #define TimerResetGPU(timer)
 #define TimerResetCategoriesGPU(timer)
+#define TimerClearCategoriesGPU(timer)
 #define TimerGetElapsedCategoryGPU(timer, category) 0.0
 #define TimerLogCategoryContributionsGPU(timer, total_name)
 #define TimerSyncCategoriesGPU(timer)

--- a/pil2-stark/src/utils/gpu_timer.cuh
+++ b/pil2-stark/src/utils/gpu_timer.cuh
@@ -239,18 +239,15 @@ public:
         if (timers.find(total_name) == timers.end()) return;
 
         // clearCategories() at the proof window's start means everything left belongs to
-        // total_name; mixing in the load phase used to push the total over 100%.
+        // total_name, so the percentages below are against the right denominator: categories
+        // recorded during the load phase used to be divided by the proof's own span.
         double time_total = getTimeSec(total_name);
         if (multiTimers.empty()) return;
         zklog.trace("     KERNELS CONTRIBUTIONS:");
 
         std::vector<std::pair<std::string, double>> category_times;
-        double accounted_time = 0.0;
-
         for (const auto& [category, entries] : multiTimers) {
-            double total_sec = getCategoryTotalTimeSec(category);
-            accounted_time += total_sec;
-            category_times.emplace_back(category, total_sec);
+            category_times.emplace_back(category, getCategoryTotalTimeSec(category));
         }
 
         std::sort(category_times.begin(), category_times.end(),
@@ -263,11 +260,10 @@ public:
             oss.clear();
         }
 
-        // Every kernel the proof launches is inside a category, so what is left is the stream idle
-        // between them: launch latency, and no category can cover it -- a gap is inside none.
-        double other_time = std::max(0.0, time_total - accounted_time);
-        oss << std::fixed << std::setprecision(4) << other_time << "s (" << std::setprecision(2)<< (other_time / time_total) * 100.0 << "%)";
-        zklog.trace("        STREAM_GAPS" + std::string(15 - 11, ' ') + ":  " + oss.str());
+        // Deliberately no leftover/OTHER line. window-minus-categories is a coverage residual, not
+        // a measurement: other streams run in this stream's gaps, overlapping categories are summed
+        // rather than unioned, and a replayed capture region skips its body so its categories never
+        // fire at all. Naming it invited reading it as idle GPU, which it never was.
 #endif
     }
 

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -93,7 +93,8 @@ use crate::aggregate_worker_proofs;
 use std::ffi::c_void;
 
 use proofman_util::{
-    timer_start_info, timer_stop_and_log_info, timer_start_debug, timer_stop_and_log_debug, create_buffer_fast,
+    timer_start_info, timer_stop_and_log_info, timer_start_debug, timer_stop_and_log_debug,
+    timer_stop_and_log_debug_net, create_buffer_fast,
 };
 
 use serde::Serialize;
@@ -3680,6 +3681,9 @@ where
         self.check_cancel(true)?;
 
         timer_stop_and_log_info!(GENERATING_INNER_PROOFS);
+        // The per-instance witness timers include any wait for a buffer; report it separately.
+        self.memory_handler.log_wait_summary();
+        self.memory_handler_recursive_witness.log_wait_summary();
 
         let mut proof_id = None;
         let mut vadcop_final_proof = None;
@@ -4836,8 +4840,13 @@ where
                         Self::try_send_threads(&tx_threads_clone, n_threads_witness, &cancellation_info_clone);
                         // Free the slot before the counter so admission can refill immediately.
                         drop(slot);
-                        timer_stop_and_log_debug!(
+                        // The buffer this instance ended up with carries however long its
+                        // acquisition blocked, whichever worker did the blocking.
+                        let waited =
+                            proofman_common::take_buffer_wait(pctx_clone.get_air_instance_trace_ptr(instance_id));
+                        timer_stop_and_log_debug_net!(
                             GENERATING_WC,
+                            waited,
                             "GENERATING_WC_{} [{}:{}]",
                             instance_id,
                             airgroup_id,
@@ -4942,8 +4951,13 @@ where
                         cancellation_info_clone.write_recover().cancel(Some(e));
                         return;
                     }
-                    timer_stop_and_log_debug!(
+                    // Whichever span took the buffer owns its wait; the lookup clears it, so the
+                    // second span below sees zero rather than double-counting.
+                    let preparing_waited =
+                        proofman_common::take_buffer_wait(pctx_clone.get_air_instance_trace_ptr(instance_id));
+                    timer_stop_and_log_debug_net!(
                         PREPARING_WC,
+                        preparing_waited,
                         "PREPARING_WC_{} [{}:{}]",
                         instance_id,
                         airgroup_id,
@@ -4961,16 +4975,20 @@ where
                         cancellation_info_clone.write_recover().cancel(Some(e));
                         return;
                     }
-                    timer_stop_and_log_debug!(
+                    let computing_waited =
+                        proofman_common::take_buffer_wait(pctx_clone.get_air_instance_trace_ptr(instance_id));
+                    timer_stop_and_log_debug_net!(
                         COMPUTING_WC,
+                        computing_waited,
                         "COMPUTING_WC_{} [{}:{}]",
                         instance_id,
                         airgroup_id,
                         air_id
                     );
                     Self::try_send_threads(&tx_threads_clone, threads_to_use_witness, &cancellation_info_clone);
-                    timer_stop_and_log_debug!(
+                    timer_stop_and_log_debug_net!(
                         GENERATING_WC,
+                        preparing_waited + computing_waited,
                         "GENERATING_WC_{} [{}:{}]",
                         instance_id,
                         airgroup_id,

--- a/proofman/src/proofman.rs
+++ b/proofman/src/proofman.rs
@@ -498,6 +498,8 @@ pub struct ProofMan<F: PrimeField64> {
     wcm: Arc<WitnessManager<F>>,
     n_streams: usize,
     n_streams_non_recursive: usize,
+    /// Device streams per node — what the C side indexes. Not `n_streams`, which counts workers.
+    n_device_streams: usize,
     memory_handler: Arc<MemoryHandler<F>>,
     memory_handler_recursive_witness: Arc<MemoryHandlerRecursive<F>>,
     proofs: Arc<Vec<RwLock<Option<Proof<F>>>>>,
@@ -2323,8 +2325,16 @@ where
             RankInfo { world_rank: mpi_ctx.rank, local_rank: mpi_ctx.node_rank, n_processes: mpi_ctx.n_processes };
         initialize_logger(options.verbose_mode, Some(&rank_info));
 
-        let (pctx, sctx, setups_vadcop, n_streams_per_gpu, n_recursive_streams_per_gpu, n_gpus, recurser_const_offset) =
-            Self::initialize_proofman(mpi_ctx.clone(), proving_key_path, &options)?;
+        let (
+            pctx,
+            sctx,
+            setups_vadcop,
+            n_streams_per_gpu,
+            n_recursive_streams_per_gpu,
+            n_aggregation_workers_per_gpu,
+            n_gpus,
+            recurser_const_offset,
+        ) = Self::initialize_proofman(mpi_ctx.clone(), proving_key_path, &options)?;
 
         timer_start_info!(INIT_PROOFMAN);
 
@@ -2355,8 +2365,11 @@ where
             false => 1,
         };
 
-        let n_streams = ((n_streams_per_gpu + n_recursive_streams_per_gpu) * n_proof_threads) as usize;
+        // Workers are not device streams: without a pool they share the basic ones. Anything the C
+        // side indexes by stream needs `n_device_streams`.
+        let n_streams = ((n_streams_per_gpu + n_aggregation_workers_per_gpu) * n_proof_threads) as usize;
         let n_streams_non_recursive = (n_streams_per_gpu * n_proof_threads) as usize;
+        let n_device_streams = ((n_streams_per_gpu + n_recursive_streams_per_gpu) * n_proof_threads) as usize;
 
         let memory_handler = Arc::new(MemoryHandler::new(pctx.clone(), max_witness_stored, max_buffer_size));
         let memory_handler_recursive_witness = Arc::new(MemoryHandlerRecursive::new(
@@ -2455,6 +2468,7 @@ where
             recurser_fold_lock: Mutex::new(()),
             n_streams,
             n_streams_non_recursive,
+            n_device_streams,
             max_num_threads,
             num_threads_per_witness,
             memory_handler,
@@ -3176,7 +3190,7 @@ where
             self.handle_recursives.lock().unwrap().push(handle_recursive);
         }
 
-        let instance_ids_in_streams: Vec<i64> = vec![-1; self.n_streams];
+        let instance_ids_in_streams: Vec<i64> = vec![-1; self.n_device_streams];
         get_instances_ready_c(self.pctx.get_device_buffers_ptr(), instance_ids_in_streams.as_ptr() as *mut i64);
 
         instance_ids_in_streams.par_iter().enumerate().for_each(|(stream_id, instance_id)| {
@@ -5159,7 +5173,7 @@ where
         mpi_ctx: Arc<MpiCtx>,
         proving_key_path: PathBuf,
         options: &ProofmanOptions,
-    ) -> ProofmanResult<(Arc<ProofCtx<F>>, Arc<SetupCtx<F>>, Arc<SetupsVadcop<F>>, u64, u64, u64, u64)> {
+    ) -> ProofmanResult<(Arc<ProofCtx<F>>, Arc<SetupCtx<F>>, Arc<SetupsVadcop<F>>, u64, u64, u64, u64, u64)> {
         if !set_gpu_mode_c(options.gpu) {
             return Err(ProofmanError::InvalidConfiguration(
                 "GPU mode requested but library was built without CUDA support".into(),
@@ -5241,15 +5255,16 @@ where
 
         pctx.set_weights(&sctx, &setups_vadcop)?;
 
-        let (n_streams_per_gpu, n_recursive_streams_per_gpu, n_gpus) = pctx.set_device_buffers(
-            &sctx,
-            &setups_vadcop,
-            options.aggregation,
-            options.gpu,
-            options.max_number_streams,
-            options.max_number_recursive_streams,
-            options.final_snark,
-        )?;
+        let (n_streams_per_gpu, n_recursive_streams_per_gpu, n_aggregation_workers_per_gpu, n_gpus) = pctx
+            .set_device_buffers(
+                &sctx,
+                &setups_vadcop,
+                options.aggregation,
+                options.gpu,
+                options.max_number_streams,
+                options.max_number_recursive_streams,
+                options.final_snark,
+            )?;
 
         use_packed_trace_c(pctx.get_device_buffers_ptr(), options.packed);
 
@@ -5347,7 +5362,16 @@ where
 
         timer_stop_and_log_info!(INITIALIZING_PROOFMAN);
 
-        Ok((pctx, sctx, setups_vadcop, n_streams_per_gpu, n_recursive_streams_per_gpu, n_gpus, aggregation_const_end))
+        Ok((
+            pctx,
+            sctx,
+            setups_vadcop,
+            n_streams_per_gpu,
+            n_recursive_streams_per_gpu,
+            n_aggregation_workers_per_gpu,
+            n_gpus,
+            aggregation_const_end,
+        ))
     }
 
     #[allow(dead_code)]

--- a/proofman/src/recursion.rs
+++ b/proofman/src/recursion.rs
@@ -16,7 +16,8 @@ use proofman_common::{
 use std::os::raw::{c_void, c_char};
 
 use proofman_util::{
-    timer_start_info, timer_stop_and_log_info, timer_start_debug, timer_stop_and_log_debug, create_buffer_fast,
+    timer_start_info, timer_stop_and_log_info, timer_start_debug, timer_stop_and_log_debug,
+    timer_stop_and_log_debug_net, create_buffer_fast,
 };
 
 use crate::{add_publics_circom, add_publics_aggregation};
@@ -126,8 +127,9 @@ pub fn gen_witness_recursive<F: PrimeField64>(
         add_publics_circom(&mut updated_proof, 0, pctx, None);
         let circom_witness =
             generate_witness::<F>(setup, memory_handler_recursive_witness, proof.global_idx.unwrap(), &updated_proof)?;
-        timer_stop_and_log_debug!(
+        timer_stop_and_log_debug_net!(
             GENERATE_COMPRESSOR_WITNESS,
+            proofman_common::take_buffer_wait(circom_witness.as_ptr() as *const u8),
             "GENERATING_COMPRESSOR_WITNESS_{} [{}:{}]",
             proof.global_idx.unwrap(),
             proof.airgroup_id,
@@ -172,8 +174,9 @@ pub fn gen_witness_recursive<F: PrimeField64>(
 
         let circom_witness =
             generate_witness::<F>(setup, memory_handler_recursive_witness, proof.global_idx.unwrap(), &updated_proof)?;
-        timer_stop_and_log_debug!(
+        timer_stop_and_log_debug_net!(
             GENERATE_RECURSIVE1_WITNESS,
+            proofman_common::take_buffer_wait(circom_witness.as_ptr() as *const u8),
             "GENERATING_RECURSIVE1_WITNESS_{} [{}:{}]",
             proof.global_idx.unwrap(),
             proof.airgroup_id,
@@ -235,7 +238,11 @@ pub fn gen_witness_aggregation<F: PrimeField64>(
     let circom_witness =
         generate_witness::<F>(setup_recursive2, memory_handler_recursive_witness, 0, &updated_proof_recursive2)?;
 
-    timer_stop_and_log_debug!(GENERATE_WITNESS_AGGREGATION);
+    timer_stop_and_log_debug_net!(
+        GENERATE_WITNESS_AGGREGATION,
+        proofman_common::take_buffer_wait(circom_witness.as_ptr() as *const u8),
+        "GENERATE_WITNESS_AGGREGATION"
+    );
     Ok(Proof::new_witness(
         ProofType::Recursive2,
         airgroup_id,

--- a/util/src/timer_macro.rs
+++ b/util/src/timer_macro.rs
@@ -189,3 +189,32 @@ macro_rules! timer_stop_and_log_trace {
         tracing::trace!("{}<<< {} ({}ms){}", escape_in, format!($($arg)+), $name.as_millis(), escape_out);
     };
 }
+
+/// Like [`timer_stop_and_log_debug`] but subtracts a known blocked interval, so the logged span is
+/// the work itself. `$waited` is a `Duration`; it is reported alongside rather than dropped.
+#[macro_export]
+macro_rules! timer_stop_and_log_debug_net {
+    ($name:ident, $waited:expr, $($arg:tt)+) => {
+        #[allow(non_snake_case)]
+        let $name = std::time::Instant::now() - $name;
+        let waited: std::time::Duration = $waited;
+        let net = $name.saturating_sub(waited);
+        let is_terminal = std::io::IsTerminal::is_terminal(&std::io::stdout()) && std::env::var("NO_COLOR").is_err();
+        let escape_in = match is_terminal {
+            true => "\x1b[2m",
+            false => "",
+        };
+        let escape_out = match is_terminal {
+            true => "\x1b[37;0m",
+            false => "",
+        };
+        tracing::debug!(
+            "{}<<< {} ({}ms) [waited {}ms]{}",
+            escape_in,
+            format!($($arg)+),
+            net.as_millis(),
+            waited.as_millis(),
+            escape_out
+        );
+    };
+}


### PR DESCRIPTION
Three related pieces of work on how the per-GPU aux-trace budget is cut into streams, and on making the timing that guides that work honest.

## 1. Stream carve: make the aggregation pool optional

`plan_stream_layout` used a makespan-floor search. It is replaced by a rule the budget alone decides, and aggregation stops being given memory once an aggregation-only stream costs what a basic one does.

**Carve.** The regular class is the biggest air under half of `large` that earns its streams — it must reach the median air and not be dust beside a large one. Failing that it takes the biggest air that fits beside a large stream, which `buy_streams` trades back up when that is the better buy. `buy_streams` buys one of each class first so neither starves, then spends the leftover on the best thing it still affords, in a single loop. A class the bulk cannot use earns one spare stream and never a fleet, so adding a dust air to a proving key no longer moves the carve.

**Aggregation.** The dedicated pool is funded only while a recursive stream costs under half a basic one. Above that, every basic stream can host a recursive launch anyway, so the bytes buy basic streams instead and priority moves to `StreamLayout::aggregation_workers` — which cost a thread, not memory. `class_floor` is raised to `recursive_size` on entry, so a launch larger than every air can never be left homeless by a pool the budget could not fund.

**Stream selection.** `force_recursive` degrades when no pool exists, rather than spinning forever against an empty one. The two pool scans share one lambda and per-GPU bookkeeping became one struct instead of five parallel arrays. `reserve_stream_if_free` no longer holds the global selection lock across a proof harvest, matching what the cold scan already did. `n_streams` (workers) and `n_device_streams` are now distinct types of count — the `get_instances_ready` out-buffer is sized by the latter.

The nine measured zisk1 configurations carve exactly as before.

## 2. Witness timers: charge pool waits to the pool

A witness thread that blocks in `take_buffer` waiting for a pooled buffer is blocked *inside* `COMPUTING_WC`/`GENERATING_WC`, so a queueing delay was reported as witness compute. A 6.4s buffer wait showed up as 6.4s of witness work — which is what made the witness side look expensive when it was really waiting for the prover to release a trace.

Each blocked acquisition is now charged to the buffer it was waiting for, keyed by that buffer's data pointer. Keying by buffer rather than by thread is what makes this work: the block can happen on any worker a witness component spins up, but the buffer always ends up in one known instance's trace, so the span that receives it can subtract the wait. `timer_stop_and_log_debug_net!` reports it alongside the net span (`(Nms) [waited Mms]`) rather than dropping it, and each pool logs its own total so the sum can be checked against the per-span numbers — if it falls short, some blocking is not reaching a span.

The uncontended path is unchanged: it takes no clock read and is not charged.

Applies to `GENERATING_WC`, `PREPARING_WC`, `COMPUTING_WC`, and the recursive compressor / recursive1 / aggregation witness spans.

## 3. GPU timer: report the proof window, and only what was measured

The `KERNELS CONTRIBUTIONS` breakdown could exceed 100%, and its `OTHER` line was dominated by work that simply had no category, so it was not usable for attributing GPU time.

- Categories recorded before the proof opened (the load phase) were still in the map when the report divided by `STARK_GPU_PROOF`. `genProof_gpu` now clears them at the window's start, so the percentages are against the right denominator.
- A `cudaEventRecord` issued inside a cudagraph body becomes a graph node bound to that event handle, which a later `clear()` destroys while the cached graph still replays it. Timer calls are now no-ops while the stream is capturing.
- Sections whose start and stop straddled a capture-region boundary lost the stop on every replay and reported a stale span. The im-pols and FRI-expression bodies get their own regions (`IMPL`, `FREX`) with the timers outside them.
- Kernels that were in no category at all are now in one: the FRI transpose, the zerofier, the evals memset, the FRI transcript puts, `setProof`, and `calculateXis`/`computeX`.
- Nested sections carry their depth, so the flat log no longer reads as double counting.

**The leftover line is gone.** `window - sum(categories)` was reported as `OTHER`, then briefly as `STREAM_GAPS`, on the reading that whatever is not inside a category is stream idle between launches. It never measured that:

- this is a multi-stream prover, so a gap in one stream is normally another stream's kernels holding the GPU, not idle silicon;
- categories are summed rather than unioned, so any overlap silently eats into the remainder (which is then clamped at zero);
- a replayed capture region skips its body, so every category timer inside one stops firing and all of that work lands in the leftover.

Under graphs the third alone drives the line toward 100%, which reads as an idle GPU on a prover that measures ~98.7% fed. It is a coverage residual, not a measurement, and naming it invited the wrong conclusion — so the per-category breakdown stays and the line goes.

## Verification

- `cargo check --workspace --lib` clean; `proofman-common` + `proofman-util` 75/75 (including a new test pinning that a blocked acquisition is charged to the pool and an uncontended one is not); `gpu_stream_layout` 38/38, among them a 300k-case randomized fuzz over the carve asserting no overspend, `spent + unused == budget`, caps respected, no class below the floor, and aggregation never homeless.
- `pil2-stark` and the goldilocks GPU suite rebuild clean; `testsgpu` 45/45 on an RTX 5090.

## Reviewer notes

- `IMPL`/`FREX` change production cudagraph partitioning (two extra regions) purely so two section timers do not go stale under replay. That trade is deliberate but worth a second opinion.
- `shared_workers` deliberately keeps `.max(1)` at a single basic stream, where the "never every stream at once" rule would otherwise leave aggregation with no worker. One stream serialises basic and recursive work regardless, so there is no overlap to protect there, and the aggregation tail is on the critical path.
