### PR TITLE
perf(std): evaluate the im_col hints once, not once per accumulator

### DIFF
--- a/pil2-stark/src/starkpil/gen_proof.cuh
+++ b/pil2-stark/src/starkpil/gen_proof.cuh
@@ -36,38 +36,45 @@ void calculateWitnessExpr_gpu(SetupCtx& setupCtx, StepsParams& h_params, StepsPa
     }
 }
 
+// The im_col/im_airval hints do not depend on `prod`: they read cm1 + stage-2 challenges and write
+// the same "reference" destinations either way, so evaluating them inside calculateWitnessSTD_gpu ran
+// the whole set twice whenever an AIR has both a gprod and a gsum column.
+void calculateImHints_gpu(SetupCtx& setupCtx, StepsParams& h_params, StepsParams *d_params, ExpressionsGPU *expressionsCtxGPU, ExpsArguments *d_expsArgs, DestParamsGPU *d_destParams, Goldilocks::Element *pinned_exps_params, Goldilocks::Element *pinned_exps_args, uint64_t& countId, TimerGPU &timer, cudaStream_t stream) {
+    if(setupCtx.expressionsBin.getNumberHintIdsByName("gprod_col") == 0 && setupCtx.expressionsBin.getNumberHintIdsByName("gsum_col") == 0) return;
+
+    uint64_t nImHints = setupCtx.expressionsBin.getNumberHintIdsByName("im_col");
+    uint64_t nImHintsAirVals = setupCtx.expressionsBin.getNumberHintIdsByName("im_airval");
+    uint64_t nImTotalHints = nImHints + nImHintsAirVals;
+    if(nImTotalHints == 0) return;
+
+    uint64_t imHints[nImTotalHints];
+    setupCtx.expressionsBin.getHintIdsByName(imHints, "im_col");
+    setupCtx.expressionsBin.getHintIdsByName(&imHints[nImHints], "im_airval");
+    std::string hintFieldDest[nImTotalHints];
+    std::string hintField1[nImTotalHints];
+    std::string hintField2[nImTotalHints];
+    HintFieldOptions hintOptions1[nImTotalHints];
+    HintFieldOptions hintOptions2[nImTotalHints];
+    for(uint64_t i = 0; i < nImTotalHints; i++) {
+        hintFieldDest[i] = "reference";
+        hintField1[i] = "numerator";
+        hintField2[i] = "denominator";
+        HintFieldOptions options1;
+        HintFieldOptions options2;
+        options2.inverse = true;
+        hintOptions1[i] = options1;
+        hintOptions2[i] = options2;
+    }
+
+    multiplyHintFieldsGPU(setupCtx, h_params, d_params, nImTotalHints, imHints, hintFieldDest, hintField1, hintField2, hintOptions1, hintOptions2, expressionsCtxGPU, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
+}
+
 void calculateWitnessSTD_gpu(SetupCtx& setupCtx, StepsParams& h_params, StepsParams *d_params, bool prod, ExpressionsGPU *expressionsCtxGPU, ExpsArguments *d_expsArgs, DestParamsGPU *d_destParams, Goldilocks::Element *pinned_exps_params, Goldilocks::Element *pinned_exps_args, uint64_t& countId, TimerGPU &timer, cudaStream_t stream) {
 
     std::string name = prod ? "gprod_col" : "gsum_col";
     if(setupCtx.expressionsBin.getNumberHintIdsByName(name) == 0) return;
     uint64_t hint[1];
     setupCtx.expressionsBin.getHintIdsByName(hint, name);
-
-    uint64_t nImHints = setupCtx.expressionsBin.getNumberHintIdsByName("im_col");
-    uint64_t nImHintsAirVals = setupCtx.expressionsBin.getNumberHintIdsByName("im_airval");
-    uint64_t nImTotalHints = nImHints + nImHintsAirVals;
-    if(nImTotalHints > 0) {
-        uint64_t imHints[nImHints + nImHintsAirVals];
-        setupCtx.expressionsBin.getHintIdsByName(imHints, "im_col");
-        setupCtx.expressionsBin.getHintIdsByName(&imHints[nImHints], "im_airval");
-        std::string hintFieldDest[nImTotalHints];
-        std::string hintField1[nImTotalHints];
-        std::string hintField2[nImTotalHints];
-        HintFieldOptions hintOptions1[nImTotalHints];
-        HintFieldOptions hintOptions2[nImTotalHints];
-        for(uint64_t i = 0; i < nImTotalHints; i++) {
-            hintFieldDest[i] = "reference";
-            hintField1[i] = "numerator";
-            hintField2[i] = "denominator";
-            HintFieldOptions options1;
-            HintFieldOptions options2;
-            options2.inverse = true;
-            hintOptions1[i] = options1;
-            hintOptions2[i] = options2;
-        }
-
-        multiplyHintFieldsGPU(setupCtx, h_params, d_params, nImTotalHints, imHints, hintFieldDest, hintField1, hintField2, hintOptions1, hintOptions2, expressionsCtxGPU, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
-    }
 
     HintFieldOptions options1;
     HintFieldOptions options2;
@@ -256,6 +263,7 @@ void genProof_gpu(SetupCtx& setupCtx, gl64_t *d_aux_trace, gl64_t *d_const_pols,
         }
     }
     TimerStopCategoryGPU(timer, TRANSCRIPT);
+    calculateImHints_gpu(setupCtx, h_params, d_params, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, true, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, false, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
 

--- a/pil2-stark/src/starkpil/gen_proof.hpp
+++ b/pil2-stark/src/starkpil/gen_proof.hpp
@@ -21,38 +21,44 @@ void calculateWitnessExpr(SetupCtx& setupCtx, StepsParams& params, ExpressionsCt
 }
 
 
+// The im_col/im_airval hints do not depend on `prod`: they read cm1 + stage-2 challenges and write
+// the same "reference" destinations either way, so evaluating them inside calculateWitnessSTD ran the
+// whole set twice whenever an AIR has both a gprod and a gsum column (the recursion airs do).
+void calculateImHints(SetupCtx& setupCtx, StepsParams& params, ExpressionsCtx &expressionsCtx) {
+    if(setupCtx.expressionsBin.getNumberHintIdsByName("gprod_col") == 0 && setupCtx.expressionsBin.getNumberHintIdsByName("gsum_col") == 0) return;
+
+    uint64_t nImHints = setupCtx.expressionsBin.getNumberHintIdsByName("im_col");
+    uint64_t nImHintsAirVals = setupCtx.expressionsBin.getNumberHintIdsByName("im_airval");
+    uint64_t nImTotalHints = nImHints + nImHintsAirVals;
+    if(nImTotalHints == 0) return;
+
+    std::vector<uint64_t> imHints(nImTotalHints);
+    setupCtx.expressionsBin.getHintIdsByName(imHints.data(), "im_col");
+    setupCtx.expressionsBin.getHintIdsByName(&imHints[nImHints], "im_airval");
+    std::vector<std::string> hintFieldDest(nImTotalHints);
+    std::vector<std::string> hintField1(nImTotalHints);
+    std::vector<std::string> hintField2(nImTotalHints);
+    std::vector<HintFieldOptions> hintOptions1(nImTotalHints);
+    std::vector<HintFieldOptions> hintOptions2(nImTotalHints);
+    for(uint64_t i = 0; i < nImTotalHints; i++) {
+        hintFieldDest[i] = "reference";
+        hintField1[i] = "numerator";
+        hintField2[i] = "denominator";
+        HintFieldOptions options1;
+        HintFieldOptions options2;
+        options2.inverse = true;
+        hintOptions1[i] = options1;
+        hintOptions2[i] = options2;
+    }
+
+    multiplyHintFields(setupCtx, params, expressionsCtx, nImTotalHints, imHints.data(), hintFieldDest.data(), hintField1.data(), hintField2.data(), hintOptions1.data(), hintOptions2.data());
+}
+
 void calculateWitnessSTD(SetupCtx& setupCtx, StepsParams& params, ExpressionsCtx &expressionsCtx, bool prod) {
     std::string name = prod ? "gprod_col" : "gsum_col";
     if(setupCtx.expressionsBin.getNumberHintIdsByName(name) == 0) return;
     uint64_t hint[1];
     setupCtx.expressionsBin.getHintIdsByName(hint, name);
-
-    uint64_t nImHints = setupCtx.expressionsBin.getNumberHintIdsByName("im_col");
-    uint64_t nImHintsAirVals = setupCtx.expressionsBin.getNumberHintIdsByName("im_airval");
-    uint64_t nImTotalHints = nImHints + nImHintsAirVals;
-    if(nImTotalHints > 0) {
-        std::vector<uint64_t> imHints(nImHints + nImHintsAirVals);
-        setupCtx.expressionsBin.getHintIdsByName(imHints.data(), "im_col");
-        setupCtx.expressionsBin.getHintIdsByName(&imHints[nImHints], "im_airval");
-        std::vector<std::string> hintFieldDest(nImTotalHints);
-        std::vector<std::string> hintField1(nImTotalHints);
-        std::vector<std::string> hintField2(nImTotalHints);
-        std::vector<HintFieldOptions> hintOptions1(nImTotalHints);
-        std::vector<HintFieldOptions> hintOptions2(nImTotalHints);
-        for(uint64_t i = 0; i < nImTotalHints; i++) {
-            hintFieldDest[i] = "reference";
-            hintField1[i] = "numerator";
-            hintField2[i] = "denominator";
-            HintFieldOptions options1;
-            HintFieldOptions options2;
-            options2.inverse = true;
-            hintOptions1[i] = options1;
-            hintOptions2[i] = options2;
-        }
-
-        multiplyHintFields(setupCtx, params, expressionsCtx, nImTotalHints, imHints.data(), hintFieldDest.data(), hintField1.data(), hintField2.data(), hintOptions1.data(), hintOptions2.data());
-        
-    }
 
     HintFieldOptions options1;
     HintFieldOptions options2;
@@ -132,6 +138,7 @@ void genProof(SetupCtx& setupCtx, uint64_t airgroupId, uint64_t airId, uint64_t 
         }
     }
 
+    calculateImHints(setupCtx, params, expressionsCtx);
     calculateWitnessSTD(setupCtx, params, expressionsCtx, true);
     calculateWitnessSTD(setupCtx, params, expressionsCtx, false);
     TimerStopAndLog(STARK_CALCULATE_WITNESS_STD);

--- a/pil2-stark/src/starkpil/verify_constraints.cuh
+++ b/pil2-stark/src/starkpil/verify_constraints.cuh
@@ -219,6 +219,7 @@ void calculateTraceInstance(SetupCtx& setupCtx, gl64_t *d_aux_trace, uint32_t st
     TimerStartGPU(timer, STARK_CALCULATE_WITNESS_STD);
     calculateWitnessExpr_gpu(setupCtx, h_params, d_params, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
 
+    calculateImHints_gpu(setupCtx, h_params, d_params, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, true, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     calculateWitnessSTD_gpu(setupCtx, h_params, d_params, false, air_instance_info->expressions_gpu, d_expsArgs, d_destParams, pinned_exps_params, pinned_exps_args, countId, timer, stream);
     TimerStopGPU(timer, STARK_CALCULATE_WITNESS_STD);


### PR DESCRIPTION
`calculateWitnessSTD` runs twice per proof — once for the `gprod` column, once for the `gsum` column — and the `im_col`/`im_airval` block lived inside it. That block never reads `prod`. It fetches **every** im hint by name, `std_sum`'s and `std_prod`'s alike, and writes the same `"reference"` destinations either way.

```cpp
void calculateWitnessSTD(..., bool prod) {
    std::string name = prod ? "gprod_col" : "gsum_col";
    if (getNumberHintIdsByName(name) == 0) return;      // <-- the only thing that reads `prod`
    ...
    getHintIdsByName(imHints, "im_col");                 // ALL of them, sum's and prod's
    getHintIdsByName(&imHints[nImHints], "im_airval");
    multiplyHintFields(... nImTotalHints ...);           // evaluated in BOTH passes
    ...
}
```

An air with only a `gsum` column never noticed: the `prod` pass returns on that guard before reaching the block, so it ran exactly once. An air with **both** columns ran the entire set twice, identically.

## Who this affects

`gprod` only appears where a Plonk connection argument does, which means circuits generated from circom — so this is a recursion-path cost. Scanning all 46 airs in a zisk proving key:

| air | im hints duplicated |
| --- | --- |
| `Keccakf/compressor` | **62** |
| `recursive2` | 36 |
| `vadcop_final` | 36 |
| every basic air (`gprod=0`) | — none |

Note the duplicated set includes `std_sum`'s own hints, not just `std_prod`'s — `im_airval` is emitted *only* by `std_sum.pil`.

## The fix

Hoisted into `calculateImHints{,_gpu}`, called once before the two passes. The guard widens from *"does this pass's column exist"* to *"does either exist"*, so an air with neither still does no work.

`verify_constraints.cuh` needs the hoisted call too — without it the im pols are never computed on that path at all.

## Measurements

test-recursive blake3 Compressor (36 im hints), RTX 5090, warm (first proof in a process discarded — it pays a one-off lazy CUDA module load):

| section | before | after | |
| --- | ---: | ---: | ---: |
| `STARK_CALCULATE_WITNESS_STD` | 9.49 ms | 4.98 ms | **−47.5%** |
| `STARK_GPU_PROOF` | 93.20 ms | 88.62 ms | **−5.0%** |

Every other section moved by less than 0.2%.

## Validation

- **The saved proof is byte-identical before and after** (`--save-proof` + `cmp`). That is what makes the change safe: the removed work could only ever have reproduced what the first pass already wrote.
- `verify-constraints` passes — all air constraints and all global constraints.
- The im values depend only on `cm1` and the stage-2 challenges, and neither `accMulHintFields` nor `updateAirgroupValue` writes them.

Testing was done on `feat/blake3-recursion`, where these three files are byte-identical to their state on `pre-develop-1.3.0-alpha`; the fix does not depend on anything in that branch.
